### PR TITLE
Add metadata and pageNotFound to createExternalDomain service

### DIFF
--- a/api/utils/cfApiClient.js
+++ b/api/utils/cfApiClient.js
@@ -91,8 +91,9 @@ class CloudFoundryAPIClient {
    * @param {string} params.name The CF service name
    * @param {string} params.origin The target origin of the domains
    * @param {string} params.path The target path of the domains
+   * @param {string} [params.pageNotFound] The optional path for a custom 404 page for the domains
    * @param {string} params.cfCdnSpaceName The name of the cf space to put the domain
-   * @param {string} params.cfDomainWithCdnPlanGuid The guuid of the external domain service plan
+   * @param {string} params.cfDomainWithCdnPlanGuid The guid of the external domain service plan
    * @returns
    */
   async createExternalDomain(params) {
@@ -101,12 +102,15 @@ class CloudFoundryAPIClient {
       name,
       origin,
       path,
+      pageNotFound,
       cfCdnSpaceName,
       cfDomainWithCdnPlanGuid,
     } = params;
 
     const spaceGuid = await this.authRequest('GET', `/v3/spaces?names=${cfCdnSpaceName}`)
       .then(res => res.resources[0].guid);
+
+    const error_responses = pageNotFound ? `{ "404": "${pageNotFound}" }` : undefined;
 
     const body = {
       type: 'managed',
@@ -123,8 +127,17 @@ class CloudFoundryAPIClient {
           },
         },
       },
+      metadata: {
+        annotations: {
+          domains,
+          error_responses,
+          origin,
+          path,
+        },
+      },
       parameters: {
         domains,
+        error_responses,
         origin,
         path,
       },

--- a/api/utils/cfApiClient.js
+++ b/api/utils/cfApiClient.js
@@ -110,7 +110,7 @@ class CloudFoundryAPIClient {
     const spaceGuid = await this.authRequest('GET', `/v3/spaces?names=${cfCdnSpaceName}`)
       .then(res => res.resources[0].guid);
 
-    const error_responses = pageNotFound ? `{ "404": "${pageNotFound}" }` : undefined;
+    const errorResponses = pageNotFound ? { 404: pageNotFound } : {};
 
     const body = {
       type: 'managed',
@@ -130,14 +130,14 @@ class CloudFoundryAPIClient {
       metadata: {
         annotations: {
           domains,
-          error_responses,
+          error_responses: errorResponses,
           origin,
           path,
         },
       },
       parameters: {
         domains,
-        error_responses,
+        error_responses: errorResponses,
         origin,
         path,
       },

--- a/test/api/support/cfAPINocks.js
+++ b/test/api/support/cfAPINocks.js
@@ -144,12 +144,11 @@ const mockCreateService = (
     body.metadata.annotations.origin === origin &&
     body.metadata.annotations.path === path &&
     (pageNotFound
-      ? body.metadata.annotations.error_responses ===
-        `{ "404": "${pageNotFound}" }`
-      : true) &&
+      ? body.metadata.annotations.error_responses["404"] === pageNotFound
+      : Object.keys(body.metadata.annotations.error_responses).length === 0) &&
     (pageNotFound
-      ? body.parameters.error_responses === `{ "404": "${pageNotFound}" }`
-      : true);
+      ? body.parameters.error_responses["404"] === pageNotFound
+      : Object.keys(body.parameters.error_responses).length === 0);
 
   return nock(url, reqheaders)
     .post("/v3/service_instances", matcher)

--- a/test/api/support/cfAPINocks.js
+++ b/test/api/support/cfAPINocks.js
@@ -131,16 +131,28 @@ const mockCreateS3ServiceInstance = (body, resources) => {
   return n.reply(200, resources);
 };
 
-const mockCreateService = ({
-  domains, name, origin, path,
-}, resources) => {
-  const matcher = body => body.name === name
-      && body.parameters.domains === domains
-      && body.parameters.origin === origin
-      && body.parameters.path === path;
+const mockCreateService = (
+  { domains, name, origin, path, pageNotFound },
+  resources
+) => {
+  const matcher = (body) =>
+    body.name === name &&
+    body.parameters.domains === domains &&
+    body.parameters.origin === origin &&
+    body.parameters.path === path &&
+    body.metadata.annotations.domains === domains &&
+    body.metadata.annotations.origin === origin &&
+    body.metadata.annotations.path === path &&
+    (pageNotFound
+      ? body.metadata.annotations.error_responses ===
+        `{ "404": "${pageNotFound}" }`
+      : true) &&
+    (pageNotFound
+      ? body.parameters.error_responses === `{ "404": "${pageNotFound}" }`
+      : true);
 
   return nock(url, reqheaders)
-    .post('/v3/service_instances', matcher)
+    .post("/v3/service_instances", matcher)
     .reply(200, resources);
 };
 

--- a/test/api/unit/utils/cfApiClient.create.test.js
+++ b/test/api/unit/utils/cfApiClient.create.test.js
@@ -281,5 +281,30 @@ describe('CloudFoundryAPIClient', () => {
         cfDomainWithCdnPlanGuid: config.env.cfDomainWithCdnPlanGuid,
       });
     });
+
+    it('creates the service with custom 404 error page', async () => {
+      const domains = 'www.agency.gov';
+      const name = 'www.agency.gov-ext';
+      const origin = 'abc.sites.pages.cloud.gov';
+      const path = '/site/owner/repo/';
+      const pageNotFound = '/index.html';
+
+      mockTokenRequest();
+      apiNocks.mockFetchSpacesRequest(config.env.cfCdnSpaceName, { resources: [{ guid: 'guid' }] });
+      apiNocks.mockCreateService({
+        domains, name, origin, path, pageNotFound
+      }, {});
+
+      const apiClient = new CloudFoundryAPIClient();
+      await apiClient.createExternalDomain({
+        domains,
+        name,
+        origin,
+        path,
+        pageNotFound,
+        cfCdnSpaceName: config.env.cfCdnSpaceName,
+        cfDomainWithCdnPlanGuid: config.env.cfDomainWithCdnPlanGuid,
+      });
+    });
   });
 });


### PR DESCRIPTION
Related to #3722 

## Changes proposed in this pull request:
- [x] Add metadata annotations to the service for `createExternalDomain` method
  - The following annotations to be appended to the service_instance:
    - `domains`, `error_responses`,`origin`, `path` 
- [x] Add `pageNotFound` param to `createExternalDomain` method add a custom 404 page to the `error_response` parameter
- [ ] Add column to domain model to record `error_response` parameter
- [ ] Update existing external domain services with metadata annotations

## security considerations
None