### PR TITLE
ci: Switch build queue for federalist prod to bull

### DIFF
--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -21,7 +21,7 @@ applications:
       - federalist-((env))-s3
       - ((product))-((env))-env
       - federalist-((env))-sqs-creds
-      - ((product))-((env))-redis
+      - pages-((env))-redis
       - ((product))-((env))-proxy
       - ((product))-((env))-domain
       - federalist-((env))-uev-key

--- a/.cloudgov/vars/production.yml
+++ b/.cloudgov/vars/production.yml
@@ -8,7 +8,7 @@ env_postfix: ''
 log_level: info
 feature_auth_github: 'true'
 feature_auth_uaa: 'false'
-feature_bull_site_build_queue: 'false'
+feature_bull_site_build_queue: 'true'
 uaa_host: https://uaa.fr.cloud.gov
 uaa_login_host: https://login.fr.cloud.gov
 new_relic_app_name: web


### PR DESCRIPTION
This work is related to https://github.com/cloud-gov/product/issues/2091

## Changes proposed in this pull request:
- Switch the build queue to use the redis backed bull queue

## security considerations
Needed for SCR
