### PR TITLE
feat: Allow admins to add site to an org

### DIFF
--- a/admin-client/src/components/Alert.svelte
+++ b/admin-client/src/components/Alert.svelte
@@ -1,6 +1,5 @@
 <script>
   import { onMount } from 'svelte';
-  import { fly } from 'svelte/transition';
   import { notification } from '../stores';
 
   import GridContainer from './GridContainer.svelte';
@@ -14,7 +13,6 @@
 </script>
 
 <div
-  transition:fly={{ y: 100, duration: 750 }}
   class="position-fixed mobile-lg:margin-top-2 tablet:margin-top-4
   width-full z-top">
   <GridContainer>

--- a/admin-client/src/components/Form.svelte
+++ b/admin-client/src/components/Form.svelte
@@ -7,6 +7,7 @@
   export let title;
   export let action = 'Save';
   export let large = false;
+  export let disabled = false;
 
   let submitting = false;
   let errors = {};
@@ -19,6 +20,7 @@
 
     try {
       const result = await onSubmit();
+
       if (onSuccess) {
         onSuccess(result);
       }
@@ -45,12 +47,12 @@
       <legend class="usa-legend usa-legend--large">
         {title}
       </legend>
-      
+
       <p>
         Required fields are marked with an asterisk (<abbr title="required" class="usa-hint usa-hint--required">*</abbr>).
       </p>
     {/if}
-    
+
     {#if hasErrors}
       <div class="usa-alert usa-alert--error usa-alert--slim">
         <div class="usa-alert__body">
@@ -63,7 +65,7 @@
 
     <slot {errors}></slot>
 
-    <input class="usa-button" type="submit" value={action} disabled={submitting}>
+    <input class="usa-button" type="submit" value={action} disabled={submitting || disabled}>
   </fieldset>
 </form>
 

--- a/admin-client/src/components/SiteFormOrganization.svelte
+++ b/admin-client/src/components/SiteFormOrganization.svelte
@@ -1,0 +1,43 @@
+<script>
+  import Form from './Form.svelte';
+  import SelectInput from './SelectInput.svelte';
+
+  export let site;
+  export let orgs;
+  export let onSubmit;
+  export let onSuccess;
+  export let onFailure;
+
+  const siteOrg = orgs?.data?.find((org) => org.id === site.organizationId);
+  const orgOptions = orgs?.data?.map((org) => ({
+    value: org.id,
+    label: org.name,
+    id: org.id,
+  }));
+
+  $: value = siteOrg.id;
+</script>
+
+<div class="grid-row">
+  <div class="grid-col-8 grid-offset-4">
+    <Form
+      action="Update"
+      disabled={value === siteOrg.id || !value}
+      onSubmit={() => onSubmit(value, site.id)}
+      {onSuccess}
+      {onFailure}
+      let:errors
+    >
+      <fieldset class="usa-fieldset">
+        <legend class="usa-legend usa-legend">Site Organization</legend>
+        <SelectInput
+          error={errors.isActive}
+          name="Organization"
+          label='Organizations'
+          options={orgOptions}
+          bind:value={value}
+        />
+      </fieldset>
+    </Form>
+  </div>
+</div>

--- a/admin-client/src/components/SiteFormOrganization.svelte
+++ b/admin-client/src/components/SiteFormOrganization.svelte
@@ -15,14 +15,14 @@
     id: org.id,
   }));
 
-  $: value = siteOrg.id;
+  $: value = siteOrg?.id || '';
 </script>
 
 <div class="grid-row">
   <div class="grid-col-8 grid-offset-4">
     <Form
       action="Update"
-      disabled={value === siteOrg.id || !value}
+      disabled={value === siteOrg?.id || !value}
       onSubmit={() => onSubmit(value, site.id)}
       {onSuccess}
       {onFailure}

--- a/admin-client/src/components/index.js
+++ b/admin-client/src/components/index.js
@@ -26,6 +26,7 @@ export { default as SelectInput } from './SelectInput.svelte';
 export { default as SiteCard } from './SiteCard.svelte';
 export { default as SiteDeleteForm } from './SiteDeleteForm.svelte';
 export { default as SiteForm } from './SiteForm.svelte';
+export { default as SiteFormOrganization } from './SiteFormOrganization.svelte';
 export { default as SiteMetadata } from './SiteMetadata.svelte';
 export { default as TextInput } from './TextInput.svelte';
 export { default as UserTable } from './UserTable.svelte';

--- a/admin-client/src/lib/api.js
+++ b/admin-client/src/lib/api.js
@@ -201,7 +201,7 @@ async function fetchRawSites() {
 }
 
 async function updateSite(id, params) {
-  return put(`/sites/${id}`, params).catch(() => null);
+  return put(`/sites/${id}`, params);
 }
 
 async function fetchUserEnvironmentVariables(query = {}) {

--- a/admin-client/src/pages/Site.svelte
+++ b/admin-client/src/pages/Site.svelte
@@ -39,7 +39,7 @@
 
   async function handleOrgUpdateSuccess(site) {
     sitePromise = Promise.resolve(site);
-    notification.setSuccess('Site added to organizatoin successfully');
+    notification.setSuccess('Site added to organization successfully');
   }
 
   async function handleOrgUpdateFailure() {

--- a/api/admin/controllers/site.js
+++ b/api/admin/controllers/site.js
@@ -8,6 +8,7 @@ const EventCreator = require('../../services/EventCreator');
 const updateableAttrs = [
   'containerConfig',
   'isActive',
+  'organizationId',
 ];
 
 module.exports = wrapHandlers({

--- a/api/serializers/site.js
+++ b/api/serializers/site.js
@@ -18,6 +18,7 @@ const allowedAttributes = [
   's3ServiceName',
   'awsBucketName',
   'isActive',
+  'organizationId',
   'Organization',
   'Users',
 ];


### PR DESCRIPTION
Related to issue #3916 

## Changes proposed in this pull request:
- Allows admins to assign a site to an organization
- Remove `fly` transition for notification alerts in admin UI since the transition violates CSP policy.

## security considerations
Needed for SCR
