### PR TITLE
fix: uaa scope on user invite and Site.forUser filter

### DIFF
--- a/api/models/site.js
+++ b/api/models/site.js
@@ -84,15 +84,24 @@ const associate = ({
   }));
   Site.addScope('forUser', user => ({
     where: {
-      [Op.or]: [
-        Sequelize.where(Sequelize.col('Users.id'), Op.not, null),
-        { organizationId: { [Op.not]: null } },
+      [Op.and]: [
+        {
+          [Op.or]: [
+            Sequelize.where(Sequelize.col('Users.id'), Op.not, null),
+            { organizationId: { [Op.not]: null } },
+          ],
+        },
+        {
+          [Op.or]: [
+            { '$Users.id$': user.id },
+            { '$Organization.OrganizationRoles.userId$': user.id },
+          ],
+        },
       ],
     },
     include: [
       {
         model: User,
-        where: { id: user.id },
         required: false,
       },
       {
@@ -100,7 +109,6 @@ const associate = ({
         required: false,
         include: [{
           model: OrganizationRole,
-          where: { userId: user.id },
         }],
       },
     ],

--- a/test/api/support/cfUAANock.js
+++ b/test/api/support/cfUAANock.js
@@ -39,7 +39,7 @@ function mockAddUserToGroup(groupId, { origin, userId }, token, error) {
 /**
  * @param {string} returnAccessToken - the access token to return
  */
-function mockFetchClientToken(returnAccessToken) {
+function mockFetchClientToken(returnAccessToken, scope) {
   const url = new URL(uaaConfig.tokenURL);
 
   return nock(url.origin)
@@ -48,6 +48,7 @@ function mockFetchClientToken(returnAccessToken) {
       client_secret: uaaConfig.clientSecret,
       grant_type: 'client_credentials',
       response_type: 'token',
+      ...(scope && { scope }),
     })
     .reply(200, { access_token: returnAccessToken });
 }

--- a/test/api/unit/models/site.test.js
+++ b/test/api/unit/models/site.test.js
@@ -267,7 +267,6 @@ describe('Site model', () => {
         nonOrgSiteForUser,
         orgSiteForUser,
         orgSiteForOtherUserOrg,
-        orgSiteOnlyForUser,
       ].map(site => site.id);
 
       const expectedNonMemberIds = [

--- a/test/api/unit/utils/uaaClient.test.js
+++ b/test/api/unit/utils/uaaClient.test.js
@@ -242,7 +242,7 @@ describe('UAAClient', () => {
     const clientToken = 'client-token';
 
     beforeEach(async () => {
-      cfUAANock.mockFetchClientToken(clientToken);
+      cfUAANock.mockFetchClientToken(clientToken, 'scim.read,scim.invite,scim.write');
     });
 
     context('when the UAA user exists, but is not in the group', () => {

--- a/uaa/uaa.yml
+++ b/uaa/uaa.yml
@@ -38,7 +38,7 @@ oauth:
       override: true
       scope: openid,scim.invite
       authorized-grant-types: authorization_code,client_credentials
-      authorities: groups.update,scim.read,scim.invite
+      authorities: groups.update,scim.read,scim.invite,scim.write
       access-token-validity: 600
       refresh-token-validity: 259200
       autoapprove: true


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fixes uaa client to include `scim.write` and only grabs the token with the `scim.write` scope when adding a user to the 'pages.user' group.
- Fixes the scoped query for a user's sites on the `Site.forUsers` method to properly account for a user's sites in and outside of an org.

## security considerations
Update's uaa client authority to add `scim.write` scope but is only used on authenticated requests when adding a user to the `pages.user` uaa group. The token is not saved or available to the end user.
