### PR TITLE
Deploy 9/7/2022

### DIFF
--- a/api/models/site.js
+++ b/api/models/site.js
@@ -84,15 +84,24 @@ const associate = ({
   }));
   Site.addScope('forUser', user => ({
     where: {
-      [Op.or]: [
-        Sequelize.where(Sequelize.col('Users.id'), Op.not, null),
-        { organizationId: { [Op.not]: null } },
+      [Op.and]: [
+        {
+          [Op.or]: [
+            Sequelize.where(Sequelize.col('Users.id'), Op.not, null),
+            { organizationId: { [Op.not]: null } },
+          ],
+        },
+        {
+          [Op.or]: [
+            { '$Users.id$': user.id },
+            { '$Organization.OrganizationRoles.userId$': user.id },
+          ],
+        },
       ],
     },
     include: [
       {
         model: User,
-        where: { id: user.id },
         required: false,
       },
       {
@@ -100,7 +109,6 @@ const associate = ({
         required: false,
         include: [{
           model: OrganizationRole,
-          where: { userId: user.id },
         }],
       },
     ],

--- a/test/api/support/cfUAANock.js
+++ b/test/api/support/cfUAANock.js
@@ -39,7 +39,7 @@ function mockAddUserToGroup(groupId, { origin, userId }, token, error) {
 /**
  * @param {string} returnAccessToken - the access token to return
  */
-function mockFetchClientToken(returnAccessToken) {
+function mockFetchClientToken(returnAccessToken, scope) {
   const url = new URL(uaaConfig.tokenURL);
 
   return nock(url.origin)
@@ -48,6 +48,7 @@ function mockFetchClientToken(returnAccessToken) {
       client_secret: uaaConfig.clientSecret,
       grant_type: 'client_credentials',
       response_type: 'token',
+      ...(scope && { scope }),
     })
     .reply(200, { access_token: returnAccessToken });
 }

--- a/test/api/unit/models/site.test.js
+++ b/test/api/unit/models/site.test.js
@@ -267,7 +267,6 @@ describe('Site model', () => {
         nonOrgSiteForUser,
         orgSiteForUser,
         orgSiteForOtherUserOrg,
-        orgSiteOnlyForUser,
       ].map(site => site.id);
 
       const expectedNonMemberIds = [

--- a/test/api/unit/utils/uaaClient.test.js
+++ b/test/api/unit/utils/uaaClient.test.js
@@ -242,7 +242,7 @@ describe('UAAClient', () => {
     const clientToken = 'client-token';
 
     beforeEach(async () => {
-      cfUAANock.mockFetchClientToken(clientToken);
+      cfUAANock.mockFetchClientToken(clientToken, 'scim.read,scim.invite,scim.write');
     });
 
     context('when the UAA user exists, but is not in the group', () => {

--- a/uaa/uaa.yml
+++ b/uaa/uaa.yml
@@ -38,7 +38,7 @@ oauth:
       override: true
       scope: openid,scim.invite
       authorized-grant-types: authorization_code,client_credentials
-      authorities: groups.update,scim.read,scim.invite
+      authorities: groups.update,scim.read,scim.invite,scim.write
       access-token-validity: 600
       refresh-token-validity: 259200
       autoapprove: true

--- a/views/home.njk
+++ b/views/home.njk
@@ -11,24 +11,12 @@
         </div>
         <div class="usa-width-one-half">
           <p>This is a U.S. government service. Your use indicates your consent to monitoring, recording, and no expectation of privacy. Misuse is subject to criminal and civil penalties. <a href="/system-use">Read more details.</a><br></p>
-          {% if authUAA %}
-            <div class="well-gray-lightest text-center">
-              <a href="/login">
-                <button class="usa-button">
-                  Agree and continue with cloud.gov authentication
-                </button>
-              </a>
+          {% if appName === 'Pages' %}
+          <div class="usa-alert usa-alert-warning">
+            <div class="usa-alert-body">
+              <p class="usa-alert-text">If this is your first time logging in to {{ appName }}, please use Github authentication. You will be prompted to migrate to a cloud.gov account. Starting in the next few weeks, only cloud.gov authentication will be supported.</p>
             </div>
-          {% endif %}
-          {% if authGithub and authUAA %}
-            <div class="well">
-              <p class="hero-heading text-center">
-                Don't have cloud.gov account yet?
-              </p>
-            </div>
-            <p>
-              When you authenticate with Github, you will be prompted to create a cloud.gov account. You have until ___ to complete this process, after which only cloud.gov authentication will be supported.
-            </p>
+          </div>
           {% endif %}
           {% if authGithub %}
             <div class="well-gray-lightest text-center">
@@ -39,6 +27,15 @@
               </a>
             </div>
           {% endif%}
+          {% if authUAA %}
+            &nbsp;
+            <div class="text-center"> 
+              <p>If you have previously migrated to {{ appName }}</p>
+              <a href="/login">
+                  Continue with cloud.gov authentication
+              </a>
+            </div>
+          {% endif %}
           <p></p>
           {% if authUAA %}
             <p>If your office uses {{ appName }}, and you have any questions, please reach out to us at {{ supportEmail }}.</p>


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fixes uaa client to include `scim.write` and only grabs the token with the `scim.write` scope when adding a user to the 'pages.user' group.
- Fixes the scoped query for a user's sites on the `Site.forUsers` method to properly account for a user's sites in and outside of an org.

## security considerations
Update's uaa client authority to add `scim.write` scope but is only used on authenticated requests when adding a user to the `pages.user` uaa group. The token is not saved or available to the end user.
