### PR TITLE
Set origin to uaa for add member POST request to pages.user

### DIFF
--- a/api/utils/uaaClient.js
+++ b/api/utils/uaaClient.js
@@ -133,10 +133,10 @@ class UAAClient {
    *
    * Adds the UAA user to the specific UAA group, ignores an error if the user is a member.
    */
-  async addUserToGroup(groupId, { origin, userId }, clientToken) {
+  async addUserToGroup(groupId, { userId }, clientToken) {
     const path = `/Groups/${groupId}/members`;
     const options = {
-      body: { origin, type: 'USER', value: userId },
+      body: { origin: 'uaa', type: 'USER', value: userId },
       method: 'POST',
       token: clientToken,
     };

--- a/test/api/support/cfUAANock.js
+++ b/test/api/support/cfUAANock.js
@@ -21,13 +21,12 @@ function tokenAuth(token) {
 
 /**
  * @param {string} groupId
- * @param {{origin:string, userId: string}}
  * @param {string} token
  * @param {{error:string}=} error
  */
-function mockAddUserToGroup(groupId, { origin, userId }, token, error) {
+function mockAddUserToGroup(groupId, { userId }, token, error) {
   const n = nock(uaaHost, tokenAuth(token))
-    .post(`/Groups/${groupId}/members`, { origin, type: 'USER', value: userId });
+    .post(`/Groups/${groupId}/members`, { origin: 'uaa', type: 'USER', value: userId });
 
   if (error) {
     return n.reply(400, error);

--- a/test/api/unit/utils/uaaClient.test.js
+++ b/test/api/unit/utils/uaaClient.test.js
@@ -261,7 +261,7 @@ describe('UAAClient', () => {
 
         cfUAANock.mockFetchUserByEmail(email, clientToken, user);
         cfUAANock.mockFetchGroupId('pages.user', groupId, clientToken);
-        cfUAANock.mockAddUserToGroup(groupId, { origin, userId }, clientToken);
+        cfUAANock.mockAddUserToGroup(groupId, { userId }, clientToken);
         const inviteUserSpy = sinon.spy(uaaClient, 'inviteUser');
         const addUserToGroupSpy = sinon.spy(uaaClient, 'addUserToGroup');
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- To make sure the member is added to `pages.user` UAA group, use the `uaa` origin setting on the `POST` request by the UAA client

## security considerations
none
