### PR TITLE
fix: update admin client rollup config to properly output custom css

### DIFF
--- a/admin-client/rollup.config.js
+++ b/admin-client/rollup.config.js
@@ -74,7 +74,7 @@ export default {
       // we'll extract any component CSS out into
       // a separate file - better for performance
       css: (css) => {
-        css.write('public/build/bundle.css');
+        css.write('bundle.css');
       },
     }),
     // If you have external dependencies installed from


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update admin client's rollup config to out css to the correct directory
- Update to `rollup-plugin-svelte` in #3926 caused the incorrect output directory.

## security considerations
None
