### PR TITLE
feat: block already migrated users from using Federalist

### DIFF
--- a/api/services/passport.js
+++ b/api/services/passport.js
@@ -54,6 +54,10 @@ async function checkUpdateUser({
     return { flashMessage: 'You must login with your cloud.gov account. Please try again.' };
   }
 
+  if (config.app.product !== 'pages' && user.UAAIdentity) {
+    return { flashMessage: 'Now that you\'ve migrated, you must login to Pages with your cloud.gov account' };
+  }
+
   await user.update({
     username,
     email,

--- a/api/services/passport.js
+++ b/api/services/passport.js
@@ -54,7 +54,7 @@ async function checkUpdateUser({
     if (Features.enabled(Features.Flags.FEATURE_AUTH_UAA)) {
       return { flashMessage: 'You must login with your cloud.gov account. Please try again.' };
     }
-    return { flashMessage: 'Now that you\'ve migrated, you must login to Pages with your cloud.gov account' };
+    return { flashMessage: 'Now that you\'ve migrated, you must login to Pages with your cloud.gov account.' };
   }
 
   await user.update({

--- a/api/services/passport.js
+++ b/api/services/passport.js
@@ -50,11 +50,10 @@ async function checkUpdateUser({
     return { flashMessage };
   }
 
-  if (Features.enabled(Features.Flags.FEATURE_AUTH_UAA) && user.UAAIdentity) {
-    return { flashMessage: 'You must login with your cloud.gov account. Please try again.' };
-  }
-
-  if (config.app.product !== 'pages' && user.UAAIdentity) {
+  if (user.UAAIdentity) {
+    if (Features.enabled(Features.Flags.FEATURE_AUTH_UAA)) {
+      return { flashMessage: 'You must login with your cloud.gov account. Please try again.' };
+    }
     return { flashMessage: 'Now that you\'ve migrated, you must login to Pages with your cloud.gov account' };
   }
 

--- a/test/api/requests/auth.test.js
+++ b/test/api/requests/auth.test.js
@@ -235,8 +235,9 @@ describe('Authentication requests', () => {
             factory.user()
               .then((model) => {
                 user = model;
-                return githubAPINocks.githubAuth(user.username, [{ id: 123456 }]);
+                return factory.uaaIdentity({ userId: user.id });
               })
+              .then(() => githubAPINocks.githubAuth(user.username, [{ id: 123456 }]))
               .then(() => unauthenticatedSession({ oauthState }))
               .then((session) => {
                 cookie = session;

--- a/views/navigation.njk
+++ b/views/navigation.njk
@@ -41,7 +41,7 @@
               </a>
             </li>
             <li class="nav-action">
-              {% if hasUAAIdentity %}
+              {% if authUAA && hasUAAIdentity %}
                 <a class="usa-button usa-button-white" href="/logout">Log out</a>
               {% else %}
                 <a class="usa-button usa-button-white" href="/logout/github">Log out</a>

--- a/views/navigation.njk
+++ b/views/navigation.njk
@@ -41,7 +41,7 @@
               </a>
             </li>
             <li class="nav-action">
-              {% if authUAA && hasUAAIdentity %}
+              {% if authUAA and hasUAAIdentity %}
                 <a class="usa-button usa-button-white" href="/logout">Log out</a>
               {% else %}
                 <a class="usa-button usa-button-white" href="/logout/github">Log out</a>


### PR DESCRIPTION
## Changes proposed in this pull request:
- blocks users from Github authentication (the only option) on Federalist if they've already migrated (i.e. have a UAA identify)
- fixes the logout button for UAA identities in Federalists (though this should now be unreachable)

## security considerations
None 
