### PR TITLE
fix: add more rest-like route for removal of user from organization

### DIFF
--- a/admin-client/src/lib/api.js
+++ b/admin-client/src/lib/api.js
@@ -180,8 +180,8 @@ async function fetchRoles() {
   return get('/roles').catch(() => []);
 }
 
-async function removeUserOrgRole(params) {
-  return destroy('/organization-role', params);
+async function removeUserOrgRole({ userId, organizationId }) {
+  return destroy(`/organization/${organizationId}/user/${userId}`);
 }
 
 async function updateUserOrgRole(params) {

--- a/api/admin/controllers/organization-role.js
+++ b/api/admin/controllers/organization-role.js
@@ -7,22 +7,19 @@ const EventCreator = require('../../services/EventCreator');
 module.exports = wrapHandlers({
   async destroy(req, res) {
     const {
-      body: {
-        organizationId,
-        userId,
-      },
+      params: { org_id: orgId, user_id: userId },
     } = req;
 
-    const org = await fetchModelById(organizationId, Organization);
+    const org = await fetchModelById(orgId, Organization);
     if (!org) return res.notFound();
 
     await OrganizationRole.destroy({
       where: {
-        organizationId: toInt(organizationId),
+        organizationId: toInt(orgId),
         userId: toInt(userId),
       },
     });
-    EventCreator.audit(Event.labels.ADMIN_ACTION, req.user, 'OrganizationRole Removed', { organizationRole: { organizationId, userId } });
+    EventCreator.audit(Event.labels.ADMIN_ACTION, req.user, 'OrganizationRole Removed', { organizationRole: { orgId, userId } });
 
     return res.json({});
   },

--- a/api/admin/routers/api.js
+++ b/api/admin/routers/api.js
@@ -32,7 +32,7 @@ apiRouter.get('/organizations/:id', AdminControllers.Organization.findById);
 apiRouter.put('/organizations/:id', parseJson, AdminControllers.Organization.update);
 apiRouter.post('/organizations/:id/deactivate', AdminControllers.Organization.deactivate);
 apiRouter.post('/organizations/:id/activate', AdminControllers.Organization.activate);
-apiRouter.delete('/organization-role', parseJson, AdminControllers.OrganizationRole.destroy);
+apiRouter.delete('/organization/:org_id/user/:user_id', parseJson, AdminControllers.OrganizationRole.destroy);
 apiRouter.put('/organization-role', parseJson, AdminControllers.OrganizationRole.update);
 apiRouter.get('/roles', AdminControllers.Role.list);
 apiRouter.get('/sites', AdminControllers.Site.list);

--- a/api/controllers/organization-role.js
+++ b/api/controllers/organization-role.js
@@ -15,19 +15,16 @@ module.exports = wrapHandlers({
 
   async destroy(req, res) {
     const {
-      body: {
-        organizationId,
-        userId,
-      },
+      params: { org_id: orgId, user_id: userId },
       user,
     } = req;
 
-    const org = await fetchModelById(organizationId, Organization.forManagerRole(user));
+    const org = await fetchModelById(orgId, Organization.forManagerRole(user));
     if (!org) return res.notFound();
 
     await OrganizationRole.destroy({
       where: {
-        organizationId: toInt(organizationId),
+        organizationId: toInt(orgId),
         userId: toInt(userId),
       },
     });

--- a/api/routers/organization-role.js
+++ b/api/routers/organization-role.js
@@ -6,7 +6,10 @@ router.use(sessionAuth);
 router.use(csrfProtection);
 
 router.get('/organization-role', OrganizationRoleController.findAllForUser);
-router.delete('/organization-role', OrganizationRoleController.destroy);
+// for reasons that aren't totally clear, this method doesn't receive a request
+// body when running normally but the test requests do pass the body properly
+// router.delete('/organization-role', OrganizationRoleController.destroy);
+router.delete('/organization/:org_id/user/:user_id', OrganizationRoleController.destroy);
 router.put('/organization-role', OrganizationRoleController.update);
 
 module.exports = router;

--- a/api/routers/organization-role.js
+++ b/api/routers/organization-role.js
@@ -9,7 +9,7 @@ router.get('/organization-role', OrganizationRoleController.findAllForUser);
 // for reasons that aren't totally clear, this method doesn't receive a request
 // body when running normally but the test requests do pass the body properly
 // router.delete('/organization-role', OrganizationRoleController.destroy);
-router.delete('/organization/:org_id/user/:user_id', OrganizationRoleController.destroy);
+// in response, we moved this to a more REST-ful, path-based DELETE in /organization
 router.put('/organization-role', OrganizationRoleController.update);
 
 module.exports = router;

--- a/api/routers/organization.js
+++ b/api/routers/organization.js
@@ -1,5 +1,6 @@
 const router = require('express').Router();
 const OrganizationController = require('../controllers/organization');
+const OrganizationRoleController = require('../controllers/organization-role');
 const { csrfProtection, sessionAuth } = require('../middlewares');
 
 router.use(sessionAuth);
@@ -9,5 +10,7 @@ router.get('/organization', OrganizationController.findAllForUser);
 router.get('/organization/:id', OrganizationController.findOneForUser);
 router.post('/organization/:id/invite', OrganizationController.invite);
 router.get('/organization/:id/members', OrganizationController.members);
+// roles
+router.delete('/organization/:org_id/user/:user_id', OrganizationRoleController.destroy);
 
 module.exports = router;

--- a/frontend/util/federalistApi.js
+++ b/frontend/util/federalistApi.js
@@ -70,12 +70,8 @@ export default {
   },
 
   removeOrganizationRole(organizationId, userId) {
-    return request('organization-role', {
+    return request(`organization/${organizationId}/user/${userId}`, {
       method: 'DELETE',
-      data: {
-        organizationId,
-        userId,
-      },
     });
   },
 

--- a/public/swagger/index.yml
+++ b/public/swagger/index.yml
@@ -256,6 +256,37 @@ paths:
           description: Not found
           schema:
             $ref: "Error.json"
+  /organization/{org_id}/user/{user_id}:
+    parameters:
+      - name: org_id
+        in: path
+        type: integer
+        description: The id of the organization
+        required: true
+      - name: user_id
+        in: path
+        type: integer
+        description: The id of the target user
+        required: true
+    delete:
+      summary: Delete the organization role if the current user has permissions
+      responses:
+        200:
+          description: An empty object
+          schema:
+            type: object
+        400:
+          description: Bad request
+          schema:
+            $ref: "Error.json"
+        403:
+          description: Not authorized
+          schema:
+            $ref: "Error.json"
+        404:
+          description: Not found
+          schema:
+            $ref: "Error.json"
   /organization/{id}/invite:
     parameters:
     - name: id
@@ -268,7 +299,7 @@ paths:
       parameters:
         - name: roleId
           in: body
-          type: number
+          type: integer
           description: The id of the role type
           required: true
         - name: uaaEmail
@@ -358,17 +389,17 @@ paths:
       parameters:
         - name: organizationId
           in: body
-          type: number
+          type: integer
           description: The id of the organization
           required: true
         - name: roleId
           in: body
-          type: number
+          type: integer
           description: The id of the role type
           required: true
         - name: userId
           in: body
-          type: number
+          type: integer
           description: The id of the target user
           required: true
       responses:
@@ -376,36 +407,6 @@ paths:
           description: The updated organization role object
           schema:
             $ref: "OrganizationRole.json"
-        400:
-          description: Bad request
-          schema:
-            $ref: "Error.json"
-        403:
-          description: Not authorized
-          schema:
-            $ref: "Error.json"
-        404:
-          description: Not found
-          schema:
-            $ref: "Error.json"
-    delete:
-      summary: Delete the organization role if the current user has permissions
-      parameters:
-        - name: organizationId
-          in: body
-          type: number
-          description: The id of the organization
-          required: true
-        - name: userId
-          in: body
-          type: number
-          description: The id of the target user
-          required: true
-      responses:
-        200:
-          description: The updated organization role object
-          schema:
-            type: object
         400:
           description: Bad request
           schema:

--- a/test/api/admin/requests/organization-role.test.js
+++ b/test/api/admin/requests/organization-role.test.js
@@ -26,7 +26,7 @@ const itShouldRequireAdminAuthentication = (path, schema, method = 'get') => {
     const response = await request(app)[method](path)
       .expect(401);
 
-    validateAgainstJSONSchema('GET', schema, 403, response.body);
+    validateAgainstJSONSchema(method, schema, 403, response.body);
     expect(response.body.message).to.equal('Unauthorized');
   });
 };
@@ -53,8 +53,8 @@ describe('Organization Role Admin API', () => {
 
   afterEach(clean);
 
-  describe('DELETE /admin/organization-role', () => {
-    itShouldRequireAdminAuthentication('/organization-role', '/organization-role', 'delete');
+  describe('DELETE /admin/organization/:org_id/user/:user_id', () => {
+    itShouldRequireAdminAuthentication('/organization/1/user/1', '/organization/{org_id}/user/{user_id}', 'delete');
 
     it('deletes the organization role and returns an empty object', async () => {
       const [user, org] = await Promise.all([
@@ -74,15 +74,11 @@ describe('Organization Role Admin API', () => {
         },
       })).to.eq(1);
 
-      const response = await authenticatedRequest.delete('/organization-role')
+      const response = await authenticatedRequest.delete(`/organization/${org.id}/user/${user.id}`)
         .set('Origin', config.app.adminHostname)
-        .set('x-csrf-token', csrfToken.getToken())
-        .send({
-          organizationId: org.id,
-          userId: user.id,
-        });
+        .set('x-csrf-token', csrfToken.getToken());
 
-      validateAgainstJSONSchema('DELETE', '/organization-role', 200, response.body);
+      validateAgainstJSONSchema('DELETE', '/organization/{org_id}/user/{user_id}', 200, response.body);
 
       expect(await OrganizationRole.count({
         where: {

--- a/test/api/requests/organization-role.test.js
+++ b/test/api/requests/organization-role.test.js
@@ -67,8 +67,8 @@ describe('Organization Role API', () => {
     });
   });
 
-  describe('DELETE /v0/organization-role', () => {
-    requiresAuthentication('DELETE', '/organization-role');
+  describe('DELETE /v0/organization/:org_id/user/:user_id', () => {
+    requiresAuthentication('DELETE', '/organization/1/user/1', '/organization/{org_id}/user/{user_id}');
 
     it('returns a 404 if the user is not a manager of the organization', async () => {
       const [user, org] = await Promise.all([
@@ -81,14 +81,10 @@ describe('Organization Role API', () => {
         org.addUser(user, { through: { roleId: userRole.id } }),
       ]);
 
-      const response = await authenticatedRequest.delete('/v0/organization-role')
-        .set('x-csrf-token', csrfToken.getToken())
-        .send({
-          organizationId: org.id,
-          userId: user.id,
-        });
+      const response = await authenticatedRequest.delete(`/v0/organization/${org.id}/user/${user.id}`)
+        .set('x-csrf-token', csrfToken.getToken());
 
-      validateAgainstJSONSchema('DELETE', '/organization-role', 404, response.body);
+      validateAgainstJSONSchema('DELETE', '/organization/{org_id}/user/{user_id}', 404, response.body);
     });
 
     it('deletes the organization role and returns an empty object', async () => {
@@ -109,14 +105,10 @@ describe('Organization Role API', () => {
         },
       })).to.eq(1);
 
-      const response = await authenticatedRequest.delete('/v0/organization-role')
-        .set('x-csrf-token', csrfToken.getToken())
-        .send({
-          organizationId: org.id,
-          userId: user.id,
-        });
+      const response = await authenticatedRequest.delete(`/v0/organization/${org.id}/user/${user.id}`)
+        .set('x-csrf-token', csrfToken.getToken());
 
-      validateAgainstJSONSchema('DELETE', '/organization-role', 200, response.body);
+      validateAgainstJSONSchema('DELETE', '/organization/{org_id}/user/{user_id}', 200, response.body);
 
       expect(await OrganizationRole.count({
         where: {
@@ -137,14 +129,10 @@ describe('Organization Role API', () => {
         org.addUser(user, { through: { roleId: userRole.id } }),
       ]);
 
-      const response = await authenticatedRequest.delete('/v0/organization-role')
-        .set('x-csrf-token', csrfToken.getToken())
-        .send({
-          organizationId: org.id,
-          userId: user.id,
-        });
+      const response = await authenticatedRequest.delete(`/v0/organization/${org.id}/user/${user.id}`)
+        .set('x-csrf-token', csrfToken.getToken());
 
-      validateAgainstJSONSchema('DELETE', '/organization-role', 404, response.body);
+      validateAgainstJSONSchema('DELETE', '/organization/{org_id}/user/{user_id}', 404, response.body);
 
       expect(await OrganizationRole.count({
         where: {

--- a/test/api/support/validateAgainstJSONSchema.js
+++ b/test/api/support/validateAgainstJSONSchema.js
@@ -12,7 +12,6 @@ const validateAgainstJSONSchema = (action, path, statusCode, response) => {
   const actionLower = action.toLowerCase();
   const pathLower = path.toLowerCase();
   const statusCodeInt = parseInt(statusCode, 10);
-  console.log(schema.paths[pathLower], actionLower)
   const responseSchema = schema.paths[pathLower][actionLower].responses[statusCodeInt].schema;
 
   const result = validate(response, responseSchema);

--- a/test/api/support/validateAgainstJSONSchema.js
+++ b/test/api/support/validateAgainstJSONSchema.js
@@ -12,6 +12,7 @@ const validateAgainstJSONSchema = (action, path, statusCode, response) => {
   const actionLower = action.toLowerCase();
   const pathLower = path.toLowerCase();
   const statusCodeInt = parseInt(statusCode, 10);
+  console.log(schema.paths[pathLower], actionLower)
   const responseSchema = schema.paths[pathLower][actionLower].responses[statusCodeInt].schema;
 
   const result = validate(response, responseSchema);


### PR DESCRIPTION
## Changes proposed in this pull request:
- fix: add more rest-like route for removal of user from organization
- Close #3936

## security considerations
None 

## Notes
there is some non-ideal organization of routes now because this new route is `/organizations/...` while the others are `/organization-role` but I'm okay doing this little by little
