### PR TITLE
Don't show "Remove" button for sites in site list when an organization is present

### DIFF
--- a/frontend/components/siteList/siteListItem.jsx
+++ b/frontend/components/siteList/siteListItem.jsx
@@ -71,7 +71,10 @@ const SiteListItem = ({ organization, site, user }) => (
     <div className="sites-list-item-actions">
       <GitHubLink text="View repo" owner={site.owner} repository={site.repository} />
       { getViewLink(site.viewLink, site.repository) }
-      <ButtonLink clickHandler={handleRemoveSite(site, user)}>Remove</ButtonLink>
+      {
+        !organization
+        && <ButtonLink clickHandler={handleRemoveSite(site, user)}>Remove</ButtonLink>
+      }
     </div>
   </li>
 );

--- a/test/frontend/components/siteList/siteListItem.test.js
+++ b/test/frontend/components/siteList/siteListItem.test.js
@@ -4,7 +4,6 @@ import { shallow } from 'enzyme';
 import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 import siteActions from '../../../../frontend/actions/siteActions';
-import organization from '../../../../frontend/selectors/organization';
 
 proxyquire.noCallThru();
 
@@ -125,7 +124,7 @@ describe('<SiteListItem />', () => {
       <Fixture
         site={updatedSite}
         user={testUser}
-        organization={{...testOrganization, isSandbox: true, daysUntilSandboxCleaning: 5 }}
+        organization={{ ...testOrganization, isSandbox: true, daysUntilSandboxCleaning: 5 }}
       />
     );
     expect(wrapper.find('p')).to.have.length(1); // is sandbox
@@ -179,5 +178,11 @@ describe('<SiteListItem />', () => {
     expect(removeSiteLink.contains('Remove')).to.be.true;
     removeSiteLink.simulate('click', { preventDefault: () => ({}) });
     expect(clickSpy.called).to.be.true;
+  });
+
+  it('should not have a `Remove` button when it has an organization', () => {
+    wrapper = shallow(<Fixture site={testSite} user={testUser} organization={testOrganization} />);
+    const removeSiteLink = wrapper.find('ButtonLink');
+    expect(removeSiteLink.exists()).to.be.false;
   });
 });


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removes the "Remove" button on the site list when the site is in an organization. For non-organization sites, it can still be used, and is useful for removing old sites during migration.
- Close #3948 

## security considerations
None
