### PR TITLE
Feat: add github auth reset button to user settings

### DIFF
--- a/frontend/components/GithubAuthButton.jsx
+++ b/frontend/components/GithubAuthButton.jsx
@@ -42,9 +42,9 @@ function authorize() {
   });
 }
 
-const GithubAuthButton = ({ onFailure, onSuccess }) => (
+const GithubAuthButton = ({ onFailure, onSuccess, text }) => (
   <div className="well-gray-lightest">
-    <p>Sign in to your Github account to add sites to the platform.</p>
+    <p>{text}</p>
     <button
       type="button"
       className="usa-button github-auth-button"
@@ -64,6 +64,7 @@ const GithubAuthButton = ({ onFailure, onSuccess }) => (
 GithubAuthButton.propTypes = {
   onFailure: PropTypes.func,
   onSuccess: PropTypes.func,
+  text: PropTypes.func.isRequired,
 };
 
 GithubAuthButton.defaultProps = {

--- a/frontend/components/siteList/siteList.jsx
+++ b/frontend/components/siteList/siteList.jsx
@@ -97,6 +97,7 @@ export const SiteList = ({
         <GithubAuthButton
           onSuccess={onGithubAuthSuccess}
           onFailure={onGithubAuthFailure}
+          text="Sign in to your Github account to add sites to the platform."
         />
       );
     }

--- a/frontend/components/user/Settings.jsx
+++ b/frontend/components/user/Settings.jsx
@@ -9,6 +9,9 @@ import { userSettingsUpdated } from '../../actions/actionCreators/userActions';
 import federalistApi from '../../util/federalistApi';
 import LoadingIndicator from '../LoadingIndicator';
 import SettingsForm from './SettingsForm';
+import GithubAuthButton from '../GithubAuthButton';
+import userActions from '../../reducers/userActions';
+import alertActions from '../../actions/alertActions';
 
 function buildInitialValues(sites, user) {
   return {
@@ -21,6 +24,15 @@ function buildInitialValues(sites, user) {
     ),
   };
 }
+
+const onGithubAuthSuccess = () => {
+  userActions.fetchUser();
+  alertActions.alertSuccess('Github authorization successful');
+};
+
+const onGithubAuthFailure = (_error) => {
+  alertActions.alertError(_error.message);
+};
 
 function Settings({
   actions, organizations, sites, user,
@@ -71,6 +83,12 @@ function Settings({
           onSubmit={onSubmit}
           onSubmitFail={onSubmitFail}
           onSubmitSuccess={onSubmitSuccess}
+        />
+        <h3>Github Token</h3>
+        <GithubAuthButton
+          onSuccess={onGithubAuthSuccess}
+          onFailure={onGithubAuthFailure}
+          text="Reset your Github Access Token."
         />
       </div>
     </div>

--- a/test/frontend/components/user/Settings.test.js
+++ b/test/frontend/components/user/Settings.test.js
@@ -74,5 +74,6 @@ describe('<Settings />', () => {
 
     expect(wrapper.contains(<h1>User Settings</h1>)).to.be.true;
     expect(wrapper.contains(<h3>Build Notifications</h3>)).to.be.true;
+    expect(wrapper.contains(<h3>Github Token</h3>)).to.be.true;
   });
 });


### PR DESCRIPTION
## Changes proposed in this pull request:
- add Github auth reset button to user settings
- Towards #3953
- Note that this does not require removing the `githubAccessToken` from the database (because the token itself doesn't change) but trying to authorize again will prompt accepting the OAuth app again

## security considerations
None
