### PR TITLE
Github OAuth App Token Revocation

### DIFF
--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -1,5 +1,6 @@
 const Ajv = require('ajv');
 const userSerializer = require('../serializers/user');
+const { revokeApplicationGrant } = require('../services/GitHub');
 
 const ajv = new Ajv();
 
@@ -37,5 +38,12 @@ module.exports = {
     await user.update({ buildNotificationSettings });
 
     return res.json(userSerializer.serialize(user));
+  },
+
+  async revokeApplicationGrant(req, res) {
+    const { user } = req;
+    await revokeApplicationGrant(user);
+    // even if the token revoke fails, we return a 200 because we still want to prompt a reauth flow
+    return res.json({});
   },
 };

--- a/api/routers/user.js
+++ b/api/routers/user.js
@@ -5,5 +5,6 @@ const { csrfProtection, sessionAuth } = require('../middlewares');
 
 router.get('/me', sessionAuth, UserController.me);
 router.put('/me/settings', sessionAuth, csrfProtection, UserController.updateSettings);
+router.delete('/me/githubtoken', sessionAuth, UserController.revokeApplicationGrant);
 
 module.exports = router;

--- a/frontend/components/GithubAuthButton.jsx
+++ b/frontend/components/GithubAuthButton.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import globals from '../globals';
-
+import api from '../util/federalistApi';
 import { IconGitHub } from './icons';
 
 const apiUrl = globals.APP_HOSTNAME;
@@ -16,8 +16,8 @@ const calcWindow = () => ({
   top: window.screen.height / 2 - 800 / 2,
 });
 
-function authorize() {
-  return new Promise((resolve, reject) => {
+function authorize(revokeFirst) {
+  const authPromise = () => new Promise((resolve, reject) => {
     const url = `${apiUrl}${path}`;
 
     const {
@@ -40,16 +40,23 @@ function authorize() {
 
     authWindow.focus();
   });
+
+  if (revokeFirst) {
+    return api.revokeApplicationGrant().then(authPromise);
+  }
+  return authPromise();
 }
 
-const GithubAuthButton = ({ onFailure, onSuccess, text }) => (
+const GithubAuthButton = ({
+  onFailure, onSuccess, text, revokeFirst,
+}) => (
   <div className="well-gray-lightest">
     <p>{text}</p>
     <button
       type="button"
       className="usa-button github-auth-button"
       onClick={
-        () => authorize()
+        () => authorize(revokeFirst)
           .then(onSuccess)
           .catch(onFailure)
       }
@@ -64,12 +71,14 @@ const GithubAuthButton = ({ onFailure, onSuccess, text }) => (
 GithubAuthButton.propTypes = {
   onFailure: PropTypes.func,
   onSuccess: PropTypes.func,
-  text: PropTypes.func.isRequired,
+  text: PropTypes.string.isRequired,
+  revokeFirst: PropTypes.bool,
 };
 
 GithubAuthButton.defaultProps = {
   onFailure: () => {},
   onSuccess: () => {},
+  revokeFirst: false,
 };
 
 export default GithubAuthButton;

--- a/frontend/components/user/Settings.jsx
+++ b/frontend/components/user/Settings.jsx
@@ -75,6 +75,13 @@ function Settings({
         </div>
       </div>
       <div className="well">
+        <h3>Github Token</h3>
+        <GithubAuthButton
+          onSuccess={onGithubAuthSuccess}
+          onFailure={onGithubAuthFailure}
+          text="Reset your Github Access Token."
+          revokeFirst
+        />
         <h3>Build Notifications</h3>
         <SettingsForm
           initialValues={initialValues}
@@ -83,13 +90,6 @@ function Settings({
           onSubmit={onSubmit}
           onSubmitFail={onSubmitFail}
           onSubmitSuccess={onSubmitSuccess}
-        />
-        <h3>Github Token</h3>
-        <GithubAuthButton
-          onSuccess={onGithubAuthSuccess}
-          onFailure={onGithubAuthFailure}
-          text="Reset your Github Access Token."
-          revokeFirst
         />
       </div>
     </div>

--- a/frontend/components/user/Settings.jsx
+++ b/frontend/components/user/Settings.jsx
@@ -89,6 +89,7 @@ function Settings({
           onSuccess={onGithubAuthSuccess}
           onFailure={onGithubAuthFailure}
           text="Reset your Github Access Token."
+          revokeFirst
         />
       </div>
     </div>

--- a/frontend/util/federalistApi.js
+++ b/frontend/util/federalistApi.js
@@ -226,4 +226,12 @@ export default {
       handleHttpError: false,
     });
   },
+
+  revokeApplicationGrant() {
+    return request('me/githubtoken', {
+      method: 'DELETE',
+    }, {
+      handleHttpError: false,
+    });
+  },
 };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "keywords": [],
   "dependencies": {
     "@bull-board/express": "^3.2.4",
+    "@octokit/request": "^6.2.2",
     "@octokit/rest": "^18.5.2",
     "@socket.io/redis-adapter": "^7.0.0",
     "@supercharge/promise-pool": "^1.5.0",

--- a/public/swagger/index.yml
+++ b/public/swagger/index.yml
@@ -947,3 +947,11 @@ paths:
           description: Not authorized
           schema:
             $ref: "Error.json"
+  /me/githubtoken:
+    delete:
+      summary: Revoke OAuth token access for this user
+      responses:
+        200:
+          description: Always an empty object
+          schema:
+            type: object

--- a/test/api/requests/user.test.js
+++ b/test/api/requests/user.test.js
@@ -6,6 +6,8 @@ const factory = require('../support/factory');
 const { authenticatedSession } = require('../support/session');
 const validateAgainstJSONSchema = require('../support/validateAgainstJSONSchema');
 const csrfToken = require('../support/csrfToken');
+const githubAPINocks = require('../support/githubAPINocks');
+const config = require('../../../config');
 
 describe('User API', () => {
   const userResponseExpectations = (response, user) => {
@@ -107,11 +109,15 @@ describe('User API', () => {
 
   describe('DELETE /v0/me/githubtoken', () => {
     it('should return the same response no matter what', async () => {
+      githubAPINocks.revokeApplicationGrant({
+        clientID: config.passport.github.options.clientID,
+        responseCode: 200,
+      });
       const user = await factory.user();
       const cookie = await authenticatedSession(user);
 
       const response = await request(app)
-        .delete('/v0/me/token')
+        .delete('/v0/me/githubtoken')
         .set('Cookie', cookie)
         .set('x-csrf-token', csrfToken.getToken())
         .send()

--- a/test/api/requests/user.test.js
+++ b/test/api/requests/user.test.js
@@ -104,4 +104,20 @@ describe('User API', () => {
       expect(response.body.buildNotificationSettings[1]).to.eq('builds');
     });
   });
+
+  describe('DELETE /v0/me/githubtoken', () => {
+    it('should return the same response no matter what', async () => {
+      const user = await factory.user();
+      const cookie = await authenticatedSession(user);
+
+      const response = await request(app)
+        .delete('/v0/me/token')
+        .set('Cookie', cookie)
+        .set('x-csrf-token', csrfToken.getToken())
+        .send()
+        .expect(200);
+
+      validateAgainstJSONSchema('DELETE', '/me/githubtoken', 200, response.body);
+    });
+  });
 });

--- a/test/api/support/githubAPINocks.js
+++ b/test/api/support/githubAPINocks.js
@@ -495,6 +495,11 @@ const getContent = ({
   return nok;
 };
 
+const revokeApplicationGrant = ({ clientID, responseCode }) => {
+  const nok = nock('https://api.github.com').delete(`/applications/${clientID}/grant`);
+  nok.reply(responseCode, null);
+};
+
 module.exports = {
   getAccessToken,
   createRepoForOrg,
@@ -515,4 +520,5 @@ module.exports = {
   getCollaborators,
   getMembershipForUserInOrg,
   getContent,
+  revokeApplicationGrant,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7389,11 +7389,6 @@ nan@^2.14.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
-nan@^2.14.1:
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
-  integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
-
 nan@^2.15.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.16.0.tgz#664f43e45460fb98faf00edca0bb0d7b8dce7916"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1386,6 +1386,15 @@
     is-plain-object "^5.0.0"
     universal-user-agent "^6.0.0"
 
+"@octokit/endpoint@^7.0.0":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-7.0.3.tgz#0b96035673a9e3bedf8bab8f7335de424a2147ed"
+  integrity sha512-57gRlb28bwTsdNXq+O3JTQ7ERmBTuik9+LelgcLIVfYwf235VHbN9QNo4kXExtp/h8T423cR5iJThKtFYxC7Lw==
+  dependencies:
+    "@octokit/types" "^8.0.0"
+    is-plain-object "^5.0.0"
+    universal-user-agent "^6.0.0"
+
 "@octokit/graphql@^4.5.8":
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.6.2.tgz#ec44abdfa87f2b9233282136ae33e4ba446a04e7"
@@ -1394,6 +1403,11 @@
     "@octokit/request" "^5.3.0"
     "@octokit/types" "^6.0.3"
     universal-user-agent "^6.0.0"
+
+"@octokit/openapi-types@^14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-14.0.0.tgz#949c5019028c93f189abbc2fb42f333290f7134a"
+  integrity sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw==
 
 "@octokit/openapi-types@^7.2.3":
   version "7.3.0"
@@ -1429,6 +1443,15 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
+"@octokit/request-error@^3.0.0":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-3.0.2.tgz#f74c0f163d19463b87528efe877216c41d6deb0a"
+  integrity sha512-WMNOFYrSaX8zXWoJg9u/pKgWPo94JXilMLb2VManNOby9EZxrQaBe/QSC4a1TzpAlpxofg2X/jMnCyZgL6y7eg==
+  dependencies:
+    "@octokit/types" "^8.0.0"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
 "@octokit/request@^5.3.0", "@octokit/request@^5.4.12":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.5.0.tgz#6588c532255b8e71886cefa0d2b64b4ad73bf18c"
@@ -1439,6 +1462,18 @@
     "@octokit/types" "^6.16.1"
     is-plain-object "^5.0.0"
     node-fetch "^2.6.1"
+    universal-user-agent "^6.0.0"
+
+"@octokit/request@^6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-6.2.2.tgz#a2ba5ac22bddd5dcb3f539b618faa05115c5a255"
+  integrity sha512-6VDqgj0HMc2FUX2awIs+sM6OwLgwHvAi4KCK3mT2H2IKRt6oH9d0fej5LluF5mck1lRR/rFWN0YIDSYXYSylbw==
+  dependencies:
+    "@octokit/endpoint" "^7.0.0"
+    "@octokit/request-error" "^3.0.0"
+    "@octokit/types" "^8.0.0"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.7"
     universal-user-agent "^6.0.0"
 
 "@octokit/rest@^18.5.2":
@@ -1457,6 +1492,13 @@
   integrity sha512-wWPSynU4oLy3i4KGyk+J1BLwRKyoeW2TwRHgwbDz17WtVFzSK2GOErGliruIx8c+MaYtHSYTx36DSmLNoNbtgA==
   dependencies:
     "@octokit/openapi-types" "^7.2.3"
+
+"@octokit/types@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-8.0.0.tgz#93f0b865786c4153f0f6924da067fe0bb7426a9f"
+  integrity sha512-65/TPpOJP1i3K4lBJMnWqPUJ6zuOtzhtagDvydAWbEXpbFYA0oMKKyLb95NFZZP0lSh/4b6K+DQlzvYQJQQePg==
+  dependencies:
+    "@octokit/openapi-types" "^14.0.0"
 
 "@polka/url@^1.0.0-next.20":
   version "1.0.0-next.21"
@@ -7444,7 +7486,7 @@ nock@^13.0.5:
     lodash.set "^4.3.2"
     propagate "^2.0.0"
 
-node-fetch@^2.6.1:
+node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds a new route/service for revoking a user token grant from our Github OAuth app
- Uses this new route from the frontend `/settings` page for token resets

## Background
The token reset implemented in #3955 will only prompt re-authorizing the "Pages {env}" Github OAuth application for all organizations if the old token is first revoked. This implements the revocation flow prior to re-auth.

## security considerations
None.
