### PR TITLE
Feat disable user check 3957

### DIFF
--- a/api/external-auth/index.js
+++ b/api/external-auth/index.js
@@ -25,7 +25,7 @@ app.disable('x-powered-by');
 app.use(passport.initialize());
 app.get('/auth/github', async (req, res) => {
   const sites = await Site.findAll({ attributes: ['domain'] });
-  const domains = sites.map(site => site.domain);
+  const domains = sites.map(site => site.domain).filter(Boolean);
   const { referer } = req.headers;
   const domainMatch = extractDomain(new URL(referer).hostname);
   if ('cloud.gov'.includes(domainMatch) || domains.some(domain => domain.includes(domainMatch))) {

--- a/api/external-auth/index.js
+++ b/api/external-auth/index.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const extractDomain = require('extract-domain');
 const passport = require('./passport');
 const { Site, Event } = require('../models');
 const EventCreator = require('../services/EventCreator');
@@ -26,7 +27,8 @@ app.get('/auth/github', async (req, res) => {
   const sites = await Site.findAll({ attributes: ['domain'] });
   const domains = sites.map(site => site.domain);
   const { referer } = req.headers;
-  if (referer.includes('cloud.gov') || domains.some(domain => domain.includes(referer))) {
+  const domainMatch = extractDomain(new URL(referer).hostname);
+  if ('cloud.gov'.includes(domainMatch) || domains.some(domain => domain.includes(domainMatch))) {
     // TODO: match domain? currently using site[0] as temporary instance for logging
     EventCreator.audit(Event.labels.AUTHENTICATION, sites[0], 'External auth', { referer });
     return passport.authenticate('github', { session: false })(req, res);

--- a/api/external-auth/index.js
+++ b/api/external-auth/index.js
@@ -23,7 +23,7 @@ const app = express();
 app.disable('x-powered-by');
 app.use(passport.initialize());
 app.get('/auth/github', async (req, res) => {
-  const sites = await Site.findAll();
+  const sites = await Site.findAll({ attributes: ['domain'] });
   const domains = sites.map(site => site.domain);
   const { referer } = req.headers;
   if (referer.includes('cloud.gov') || domains.some(domain => domain.includes(referer))) {

--- a/api/external-auth/passport.js
+++ b/api/external-auth/passport.js
@@ -1,39 +1,18 @@
 const GitHubStrategy = require('passport-github').Strategy;
 const Passport = require('passport');
-const inflection = require('inflection');
 const config = require('../../config');
-const { User } = require('../models');
+
 
 const passport = new Passport.Passport();
 
 const options = config.passport.github.externalOptions;
+options.passReqToCallback = true;
 
-const onSuccess = (accessToken, _refreshToken, _profile, callback) => {
-  const username = _profile.username.toLowerCase();
-  const { maxAge } = config.session.cookie;
-  const isExpired = (date, timeLimit) => (new Date() - date) > timeLimit;
-
-  User.findOne({
-    attributes: ['signedInAt'],
-    where: {
-      username,
-    },
-  })
-    .then((user) => {
-      const productTitle = inflection.titleize(config.app.product);
-
-      if (!user) {
-        throw new Error(`You must be a ${productTitle} user with a connected GitHub account.`);
-      }
-
-      if (!user.signedInAt || isExpired(user.signedInAt, maxAge)) {
-        const maxAgeHours = Math.ceil(maxAge / (1000 * 60 * 60));
-        throw new Error(`You have not logged-in to ${productTitle} within the past ${maxAgeHours} hours. Please log in to ${productTitle} and try again.`);
-      }
-
-      callback(null, { accessToken });
-    })
-    .catch(callback);
+const onSuccess = (req, accessToken, _refreshToken, _profile, callback) => {
+  console.log(req)
+    // check req against sites
+    //    .catch(callback);
+    callback(null, { accessToken });
 };
 
 passport.use(new GitHubStrategy(options, onSuccess));

--- a/api/external-auth/passport.js
+++ b/api/external-auth/passport.js
@@ -2,17 +2,11 @@ const GitHubStrategy = require('passport-github').Strategy;
 const Passport = require('passport');
 const config = require('../../config');
 
-
 const passport = new Passport.Passport();
-
 const options = config.passport.github.externalOptions;
-options.passReqToCallback = true;
 
-const onSuccess = (req, accessToken, _refreshToken, _profile, callback) => {
-  console.log(req)
-    // check req against sites
-    //    .catch(callback);
-    callback(null, { accessToken });
+const onSuccess = async (accessToken, _refreshToken, _profile, callback) => {
+  callback(null, { accessToken });
 };
 
 passport.use(new GitHubStrategy(options, onSuccess));

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "express-session": "^1.15.6",
     "express-slow-down": "^1.4.0",
     "express-winston": "^4.0.5",
+    "extract-domain": "^2.4.8",
     "helmet": "^4.6.0",
     "inflection": "^1.13.1",
     "ioredis": "^4.27.6",

--- a/test/api/requests/external-auth.test.js
+++ b/test/api/requests/external-auth.test.js
@@ -12,7 +12,7 @@ describe('External authentication request', () => {
   describe('GET /external/auth/github', () => {
     before(async () => {
       const siteUser = await factory.user();
-      factory.site({
+      await factory.site({
         demoBranch: 'demo-branch',
         demoDomain: 'https://demo.example.gov',
         domain: 'https://example.gov',

--- a/test/api/requests/external-auth.test.js
+++ b/test/api/requests/external-auth.test.js
@@ -28,7 +28,7 @@ describe('External authentication request', () => {
 
       request(app)
         .get('/external/auth/github')
-        .set('Referer', 'site.cloud.gov')
+        .set('Referer', 'https://site.cloud.gov')
         .expect('Location', /^https:\/\/github.com\/login\/oauth\/authorize.*/)
         .expect(302, done);
 
@@ -40,7 +40,7 @@ describe('External authentication request', () => {
 
       request(app)
         .get('/external/auth/github')
-        .set('Referer', 'example.gov')
+        .set('Referer', 'https://example.gov')
         .expect('Location', /^https:\/\/github.com\/login\/oauth\/authorize.*/)
         .expect(302, done);
 
@@ -50,7 +50,7 @@ describe('External authentication request', () => {
     it('should error for non-registered sites', async () => {
       const res = await request(app)
         .get('/external/auth/github')
-        .set('Referer', 'failure.gov')
+        .set('Referer', 'https://failure.gov')
         .expect(200);
 
       expect(res.text.trim()).to.match(/^<script nonce=".*">(.|\n)*authorization:github:error:{"message":"Please login from a registered cloud.gov Pages site"}(.|\n)*<\/script>$/g);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4996,6 +4996,13 @@ express@^4.17.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+extract-domain@^2.4.8:
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/extract-domain/-/extract-domain-2.4.8.tgz#7430cdc7a50d1630983f669c76bff530031e65b8"
+  integrity sha512-a8iBD5igEYApP22uMSkRy02s4IaUaJ54phxHWRxbQXgTkzXfhOMoXN0kWzo8hqfZRZRebuLyKecXZSlMvHOLNg==
+  optionalDependencies:
+    psl "^1.8.0"
+
 eyes@0.1.x:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
@@ -7347,11 +7354,6 @@ nan@^2.14.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
-nan@^2.14.1:
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
-  integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
-
 nan@^2.15.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.16.0.tgz#664f43e45460fb98faf00edca0bb0d7b8dce7916"
@@ -8461,6 +8463,11 @@ proxyquire@^2.1.3:
     fill-keys "^1.0.2"
     module-not-found-error "^1.0.1"
     resolve "^1.11.1"
+
+psl@^1.8.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
+  integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
 
 pstree.remy@^1.1.7:
   version "1.1.8"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Disable checking cloud.gov Pages/Federalist membership for external auth
- Enabled checking site referrer information to see that the Netlify CMS app is running at a cloud.gov registered domain
- Note: An Events API call was added to log an audit even for each external authentication request. It is currently only logging the `referer` and also uses a dummy `Site` model to ensure the method doesn't error.
- Towards #3957

## security considerations
External users are no longer checked to see that they use cloud.gov Pages/Federalist but they are instead checked to see if the site `Referer` is a `cloud.gov` domain (generated url) or registered domain (by querying the `Sites` list). There is an additional (existing) check implemented by `netlify-cms` directly which ensures the OAuth'ed GitHub user has write access to the site they'd like to edit. 
