### PR TITLE
Chore: update status page link

### DIFF
--- a/views/base.njk
+++ b/views/base.njk
@@ -114,7 +114,7 @@
                 </a>
               </li>
               <li>
-                <a class="usa-nav-link" href="https://federalist.statuspage.io">
+                <a class="usa-nav-link" href="https://cloudgov.statuspage.io">
                   <span>Status<span>
                 </a>
               </li>


### PR DESCRIPTION
## Changes proposed in this pull request:
- update StatusPage link to cloudgov.statuspage.io (replacing cloudgov.statuspage.io)

## security considerations
None
