### PR TITLE
fix: list 100 organization on site page

### DIFF
--- a/admin-client/src/pages/Site.svelte
+++ b/admin-client/src/pages/Site.svelte
@@ -25,7 +25,7 @@
   $: id = $router.params.id;
   $: sitePromise = fetchSite(id);
   $: buildsPromise = fetchBuilds({ site: id, limit: 10 });
-  $: orgsPromise = fetchOrganizations();
+  $: orgsPromise = fetchOrganizations({ limit: 100 });
   $: usersPromise = fetchUsers({ site: id });
   $: uevsPromise = fetchUserEnvironmentVariables({ site: id });
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- query 100 organizations on the site page
- close #3969 
- on quick scan it doesn't look like there are other places to add this limit

## security considerations
None
