### PR TITLE
fix: Fixes the offest queries when return logs from s3

### DIFF
--- a/api/controllers/build-log.js
+++ b/api/controllers/build-log.js
@@ -6,7 +6,7 @@ const BuildLogs = require('../services/build-logs');
 async function getBuildLogsFromS3(build, state, offset, limit) {
   const origin = 's3';
 
-  const output = await BuildLogs.getBuildLogs(build, offset, offset + limit - 1);
+  const { output, byteLength } = await BuildLogs.getBuildLogs(build, offset, offset + limit - 1);
 
   if (!output) {
     return {
@@ -24,7 +24,7 @@ async function getBuildLogsFromS3(build, state, offset, limit) {
     state,
     origin,
     offset,
-    output_count: output.length,
+    output_count: byteLength,
     output,
   };
 }

--- a/api/services/build-logs/build-logs.js
+++ b/api/services/build-logs/build-logs.js
@@ -70,10 +70,13 @@ const BuildLogs = {
         params.Range = `bytes=${startBytes}-${endBytes}`;
       }
       const response = await this.s3().getObject(build.logsS3Key, params);
-      return response.Body.toString().split('\n');
+      const output = response.Body.toString().split('\n');
+      const byteLength = response.ContentLength;
+
+      return { output, byteLength };
     } catch (error) {
       if (error.code === 'InvalidRange') {
-        return null;
+        return { output: null, byteLength: 0 };
       }
       throw error;
     }

--- a/frontend/components/site/siteBuildLogTable.jsx
+++ b/frontend/components/site/siteBuildLogTable.jsx
@@ -5,10 +5,11 @@ import PropTypes from 'prop-types';
 
 function SiteBuildLogTable({ buildLogs, buildState }) {
   const buildLogRef = useRef(null);
-  const scrollType = buildState === 'created' ? 'smooth' : 'none';
+  const scrollType = ['created', 'processing', 'queued', 'tasked']
+    .includes(buildState) ? 'smooth' : 'none';
 
   const scrollToLast = useCallback((node, state) => {
-    if (node && ['created', 'error'].includes(state)) {
+    if (node && ['created', 'error', 'processing', 'queued', 'tasked'].includes(state)) {
       // eslint-disable-next-line no-param-reassign
       node.scrollTop = node.scrollHeight;
     }

--- a/frontend/hooks/useBuildLogs.js
+++ b/frontend/hooks/useBuildLogs.js
@@ -27,7 +27,7 @@ export const useBuildLogs = (id) => {
         state,
       };
 
-      if (state === 'created') {
+      if (['created', 'processing', 'queued', 'tasked'].includes(state)) {
         if (fetchOffest === 0) {
           setResults(updatedResults);
         } else {

--- a/test/api/unit/services/BuildLogs.test.js
+++ b/test/api/unit/services/BuildLogs.test.js
@@ -134,17 +134,23 @@ describe('BuildLogs Service', () => {
 
     it('returns the byte range of the logs as an array of strings', async () => {
       const key = 'owner/repo/1';
+      const string = 'hel';
+      const contentLength = new Blob([string]).size
 
       const build = { logsS3Key: key };
       getObjectStub.resolves(
-        { Body: Buffer.from('hel') }
+        {
+          Body: Buffer.from(string),
+          ContentLength: contentLength,
+        }
       );
 
-      const result = await BuildLogs.getBuildLogs(build, 0, 2);
+      const { output, byteLength } = await BuildLogs.getBuildLogs(build, 0, contentLength);
 
-      sinon.assert.calledOnceWithExactly(getObjectStub, key, { Range: 'bytes=0-2' });
-      expect(result).to.have.length(1);
-      expect(result[0]).to.equal('hel');
+      sinon.assert.calledOnceWithExactly(getObjectStub, key, { Range: `bytes=0-${contentLength}` });
+      expect(output).to.have.length(1);
+      expect(output[0]).to.equal(string);
+      expect(byteLength).to.equal(contentLength)
     });
 
     it('returns byte range of the logs and splits string by newline', async () => {
@@ -152,18 +158,23 @@ describe('BuildLogs Service', () => {
       const line1 = 'hello'
       const line2 = 'world'
       const multiline = `${line1}\n${line2}`
+      const contentLength = new Blob([multiline]).size
 
       const build = { logsS3Key: key };
       getObjectStub.resolves(
-        { Body: Buffer.from(multiline) }
+        {
+          Body: Buffer.from(multiline),
+          ContentLength: contentLength,
+        }
       );
 
-      const result = await BuildLogs.getBuildLogs(build, 0, 2);
+      const { output, byteLength } = await BuildLogs.getBuildLogs(build, 0, contentLength);
 
-      sinon.assert.calledOnceWithExactly(getObjectStub, key, { Range: 'bytes=0-2' });
-      expect(result).to.have.length(2);
-      expect(result[0]).to.equal(line1);
-      expect(result[1]).to.equal(line2);
+      sinon.assert.calledOnceWithExactly(getObjectStub, key, { Range: `bytes=0-${contentLength}` });
+      expect(output).to.have.length(2);
+      expect(output[0]).to.equal(line1);
+      expect(output[1]).to.equal(line2);
+      expect(byteLength).to.equal(contentLength);
     });
 
     it('returns null if range cannott be satisified', async () => {
@@ -174,10 +185,11 @@ describe('BuildLogs Service', () => {
       error.code = 'InvalidRange';
       getObjectStub.rejects(error);
 
-      const result = await BuildLogs.getBuildLogs(build, 100, 199);
+      const { output, byteLength } = await BuildLogs.getBuildLogs(build, 100, 199);
 
       sinon.assert.calledOnceWithExactly(getObjectStub, key, { Range: 'bytes=100-199' });
-      expect(result).to.be.null;
+      expect(output).to.be.null;
+      expect(byteLength).to.equal(0)
     });
   });
 });


### PR DESCRIPTION
Apart of https://github.com/cloud-gov/pages-core/issues/2474

## Changes proposed in this pull request:
- Fixes the offset returned when retrieving build logs from S3
- Adds additional build states to retry useBuildLogs query

## security considerations
None
