### PR TITLE
Add uaa email search to admin user page

### DIFF
--- a/api/models/user.js
+++ b/api/models/user.js
@@ -55,8 +55,10 @@ const associate = ({
         [Op.or]: [
           { username: { [Op.substring]: search } },
           { email: { [Op.substring]: search } },
+          { '$UAAIdentity.email$': { [Op.substring]: search } },
         ],
       };
+      query.include = UAAIdentity;
     }
     return query;
   });

--- a/test/api/unit/models/user.test.js
+++ b/test/api/unit/models/user.test.js
@@ -180,6 +180,23 @@ describe('User model', () => {
 
       expect(users.map(u => u.id)).to.have.members([user.id]);
     });
+
+    it('returns the user by UAA email substring', async () => {
+      const [user1, user2] = await Promise.all([
+        createUser(),
+        createUser(),
+      ]);
+
+      await Promise.all([
+        createUAAIdentity({ userId: user1.id, email: 'jeff.probst@survivor.gov' }),
+        createUAAIdentity({ userId: user2.id, email: 'rob.mariano@survivor.gov' }),
+      ]);
+
+      const users = await User.scope(User.searchScope('probst')).findAll();
+
+      expect(users.length === 1);
+      expect(users.map(u => u.id)).to.have.members([user1.id]);
+    });
   });
 
   describe('withUAAIdentity', () => {


### PR DESCRIPTION
## Changes proposed in this pull request:
- feat: add uaa email search to admin user page, close #3995

## security considerations
None