### PR TITLE
don't throw 404 errors on github auth revocation token missing

### DIFF
--- a/api/services/GitHub.js
+++ b/api/services/GitHub.js
@@ -269,7 +269,7 @@ module.exports = {
       data,
       headers,
     }).catch((err) => {
-      if (err.status !== 404) {
+      if (err.response.status !== 404) {
         throw err;
       }
     });


### PR DESCRIPTION
## Changes proposed in this pull request:
- Close #4001 
- The error object returned from `axios` is different from the Github API SDK, hence the need for one extra property

## security considerations
None
