### PR TITLE
fix: Removes scope from UEV model in favor of Site scope forUser

### DIFF
--- a/api/controllers/user-environment-variable.js
+++ b/api/controllers/user-environment-variable.js
@@ -26,8 +26,7 @@ module.exports = wrapHandlers({
     }
 
     const uevs = await UserEnvironmentVariable
-      .forSiteUser(user)
-      .findAll({ where: { siteId } });
+      .findAll({ where: { siteId: site.id } });
 
     const json = serializeMany(uevs);
 
@@ -72,11 +71,18 @@ module.exports = wrapHandlers({
     const { params, user } = req;
     const { id, site_id: siteId } = params;
 
+    const site = await Site.forUser(user).findByPk(siteId)
+      .catch(() => null);
+
+    if (!site) {
+      return res.notFound();
+    }
+
     const uev = await UserEnvironmentVariable
-      .forSiteUser(user)
       .findOne({
         where: {
-          id, siteId,
+          id,
+          siteId: site.id,
         },
       });
 

--- a/api/models/user-environment-variable.js
+++ b/api/models/user-environment-variable.js
@@ -1,23 +1,9 @@
-const associate = ({ Site, User, UserEnvironmentVariable }) => {
+const associate = ({ Site, UserEnvironmentVariable }) => {
   // Associations
   UserEnvironmentVariable.belongsTo(Site, {
     foreignKey: 'siteId',
     allowNull: false,
   });
-
-  // Scopes
-  UserEnvironmentVariable.addScope('forSiteUser', user => ({
-    include: [{
-      model: Site,
-      required: true,
-      include: [{
-        model: User,
-        where: {
-          id: user.id,
-        },
-      }],
-    }],
-  }));
 };
 
 module.exports = (sequelize, DataTypes) => {
@@ -47,7 +33,6 @@ module.exports = (sequelize, DataTypes) => {
     updatedAt: false,
   });
   UserEnvironmentVariable.associate = associate;
-  UserEnvironmentVariable.forSiteUser = user => UserEnvironmentVariable
-    .scope({ method: ['forSiteUser', user] });
+
   return UserEnvironmentVariable;
 };

--- a/test/api/unit/models/user-environment-variable.test.js
+++ b/test/api/unit/models/user-environment-variable.test.js
@@ -3,36 +3,6 @@ const factories = require('../../support/factory');
 const { UserEnvironmentVariable } = require('../../../../api/models');
 
 describe('UserEnvironmentVariable model', () => {
-  describe('.forSiteUser', () => {
-    it('returns values for site owners', async () => {
-      const userPromise = factories.user();
-      const site = await factories.site({ users: Promise.all([userPromise]) });
-      const user = await userPromise;
-      const uev = await factories.userEnvironmentVariable.create({ site });
-
-      const uevs = await UserEnvironmentVariable.forSiteUser(user).findAll();
-
-      expect(uevs.length).to.eq(1);
-      expect(uevs[0].id).to.eq(uev.id);
-    });
-
-    it('does not return values for other users  not belonging to site', async () => {
-      const user1Promise = factories.user();
-      const user2 = await factories.user();
-      const site = await factories.site({ users: Promise.all([user1Promise]) });
-      await factories.userEnvironmentVariable.create({ site });
-
-      const uevs = await UserEnvironmentVariable.forSiteUser(user2).findAll();
-
-      expect(uevs).to.be.empty;
-    });
-
-    it('always returns an empty string for the hint', async () => {
-      const uev = await factories.userEnvironmentVariable.create({ value: 'abc123' });
-      expect(uev.hint).to.equal('');
-    });
-  });
-
   describe('requires unique name per site', () => {
     it('allows the same name for different sites', async () => {
       const name = 'foobarbaz';


### PR DESCRIPTION
Addresses Issue #4007 

## Changes proposed in this pull request:
- Removes `forSiteUser` scope from UserEnvironmentVariable model
- Get, Create, Delete routes use the Site model's `forUser` scope to determine if the user can take an action on the site's environment variable
- Adds tests for an org member's ability to take actions

## security considerations
- none
