### PR TITLE
Feat main build logs 4016

### DIFF
--- a/frontend/components/site/siteBuildLogTable.jsx
+++ b/frontend/components/site/siteBuildLogTable.jsx
@@ -29,6 +29,8 @@ function SiteBuildLogTable({ buildLogs, buildState }) {
         let style = null;
         if (source.includes('[main]')) {
           style = { fontWeight: 'bold' };
+        } else if (source.includes('[monitor]')) {
+          style = { opacity: 0.7 };
         }
 
         return (

--- a/frontend/components/site/siteBuildLogTable.jsx
+++ b/frontend/components/site/siteBuildLogTable.jsx
@@ -26,9 +26,13 @@ function SiteBuildLogTable({ buildLogs, buildState }) {
     >
       {buildLogs.map((source, index) => {
         const key = `build-log-span-${index}`;
+        let style = null;
+        if (source.includes('[main]')) {
+          style = { fontWeight: 'bold' };
+        }
 
         return (
-          <p key={key}>{source}</p>
+          <p style={style} key={key}>{source}</p>
         );
       })}
       <p className="build-log-cursor" />


### PR DESCRIPTION
## Changes proposed in this pull request:
- add inline styling for build logs, close #4016
<img width="774" alt="Screen Shot 2023-01-05 at 5 41 51 PM" src="https://user-images.githubusercontent.com/7108211/210894686-1ba8ac0a-9fa0-45a7-9361-a3113206ee68.png">



## security considerations
None
