### PR TITLE
use basic-vpc as s3 plan in all environments

### DIFF
--- a/api/utils/cfApiClient.js
+++ b/api/utils/cfApiClient.js
@@ -1,8 +1,5 @@
 const CloudFoundryAuthClient = require('./cfAuthClient');
 const HttpClient = require('./httpClient');
-const config = require('../../config');
-
-const { appEnv } = config.app;
 
 function filterEntity(res, name, field = 'name') {
   const errMsg = `Not found: Entity @${field} = ${name}`;
@@ -21,7 +18,7 @@ function findEntity(res, name, field) {
 
 function findS3ServicePlan(res, name, s3ServicePlanId) {
   const filtered = filterEntity(res, name);
-
+  // TODO: remove dependency on s3ServicePlanId and remove this block
   if (name === 'basic-public') {
     const servicePlan = filtered.find(f => f.entity.unique_id === s3ServicePlanId);
     if (!servicePlan) {
@@ -183,12 +180,8 @@ class CloudFoundryAPIClient {
     ));
   }
 
-  createSiteBucket(name, spaceGuid, s3ServicePlanId, keyIdentifier = 'key', serviceName = 'basic-public') {
-    let serviceNameToUse = serviceName;
-    if (appEnv !== 'production') {
-      serviceNameToUse = 'basic-vpc';
-    }
-    return this.createS3ServiceInstance(name, serviceNameToUse, spaceGuid, s3ServicePlanId)
+  createSiteBucket(name, spaceGuid, s3ServicePlanId, keyIdentifier = 'key', serviceName = 'basic-vpc') {
+    return this.createS3ServiceInstance(name, serviceName, spaceGuid, s3ServicePlanId)
       .then(res => this.createServiceKey(name, res.metadata.guid, keyIdentifier));
   }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Use the new `basic-vpc` s3 plan for bucket creation in all environments
- Note potential to deprecate use of `s3ServicePlanId` across the application

## security considerations
Adds ingress restrictions on S3 buckets
