### PR TITLE
Feat federalist GitHub deprecation

### DIFF
--- a/.cloudgov/vars/production.yml
+++ b/.cloudgov/vars/production.yml
@@ -6,7 +6,7 @@ instances: 2
 env: production
 env_postfix: ''
 log_level: info
-feature_auth_github: 'true'
+feature_auth_github: 'false'
 feature_auth_uaa: 'false'
 feature_bull_site_build_queue: 'true'
 uaa_host: https://uaa.fr.cloud.gov

--- a/test/api/requests/main.test.js
+++ b/test/api/requests/main.test.js
@@ -62,7 +62,6 @@ describe('Main Site', () => {
         .get('/blahblahpage')
         .set('Cookie', cookie)
         .expect(404);
-      expect(response.text.indexOf('Log out')).to.be.above(-1);
       expect(response.text.indexOf('404 / Page not found')).to.be.above(-1);
     });
   });
@@ -116,7 +115,6 @@ describe('Main Site', () => {
           .set('Cookie', cookie)
           .expect(200))
         .then((response) => {
-          expect(response.text.indexOf('Log out')).to.be.above(-1);
           expect(response.text.indexOf('<div id="js-app" class="usa-grid"></div>')).to.be.above(-1);
           done();
         })

--- a/views/home.njk
+++ b/views/home.njk
@@ -17,6 +17,16 @@
               <p class="usa-alert-text">If this is your first time logging in to {{ appName }}, please use Github authentication. You will be prompted to migrate to a cloud.gov account. Starting in the next few weeks, only cloud.gov authentication will be supported.</p>
             </div>
           </div>
+          {% else %}
+          <div class="usa-alert usa-alert-warning">
+            <div class="usa-alert-body">
+              <p>
+                {{ appName }} is now officially
+                <a href="https://pages.cloud.gov">cloud.gov Pages!</a>
+                Head there to login and migrate your user account or check out more about the transition <a href="https://cloud.gov/pages/federalist-migration/">here</a>.
+              </p>
+            </div>
+          </div>
           {% endif %}
           {% if authGithub %}
             <div class="well-gray-lightest text-center">

--- a/views/home.njk
+++ b/views/home.njk
@@ -11,13 +11,7 @@
         </div>
         <div class="usa-width-one-half">
           <p>This is a U.S. government service. Your use indicates your consent to monitoring, recording, and no expectation of privacy. Misuse is subject to criminal and civil penalties. <a href="/system-use">Read more details.</a><br></p>
-          {% if appName === 'Pages' %}
-          <div class="usa-alert usa-alert-warning">
-            <div class="usa-alert-body">
-              <p class="usa-alert-text">If this is your first time logging in to {{ appName }}, please use Github authentication. You will be prompted to migrate to a cloud.gov account. Starting in the next few weeks, only cloud.gov authentication will be supported.</p>
-            </div>
-          </div>
-          {% else %}
+          {% if appName !== 'Pages' %}
           <div class="usa-alert usa-alert-warning">
             <div class="usa-alert-body">
               <p>
@@ -28,24 +22,29 @@
             </div>
           </div>
           {% endif %}
-          {% if authGithub %}
-            <div class="well-gray-lightest text-center">
-              <a href="/login/github">
-                <button class="usa-button">
-                  <img src="/images/github-logo.png" alt="github logo"> Agree and continue with GitHub
-                </button>
-              </a>
-            </div>
-          {% endif%}
           {% if authUAA %}
+          <div class="well-gray-lightest text-center">
+            <a href="/login">
+              <button class="usa-button">
+                Login with cloud.gov
+              </button>
+            </a>
+          </div>
             &nbsp;
-            <div class="text-center"> 
-              <p>If you have previously migrated to {{ appName }}</p>
-              <a href="/login">
-                  Continue with cloud.gov authentication
-              </a>
-            </div>
           {% endif %}
+          {% if authGithub %}
+            <div class="usa-alert usa-alert-warning">
+              <div class="usa-alert-body">
+                <p class="usa-alert-text">If this is your first time logging in to {{ appName }}, please use Github authentication. You will be prompted to migrate to a cloud.gov account.</p>
+              </div>
+              <div class="text-center"> 
+                <a href="/login/github">
+                  Agree and continue with GitHub
+                </a>
+              </div>
+            </div>    
+          {% endif%}
+
           <p></p>
           {% if authUAA %}
             <p>If your office uses {{ appName }}, and you have any questions, please reach out to us at {{ supportEmail }}.</p>

--- a/views/migrate.njk
+++ b/views/migrate.njk
@@ -14,8 +14,7 @@
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">
             <fieldset>
               <legend class="usa-drop_text">Migrate to cloud.gov authentication</legend>
-              <span>or <a href="/sites">skip for now</a></span>
-              </br></br></br>
+              </br>
               <span>
                 Your user with Github username <strong>{{ username }}</strong> will be linked with the cloud.gov account associated with the email address you provide below.
                 </br></br>

--- a/views/navigation.njk
+++ b/views/navigation.njk
@@ -43,16 +43,12 @@
             <li class="nav-action">
               {% if authUAA and hasUAAIdentity %}
                 <a class="usa-button usa-button-white" href="/logout">Log out</a>
-              {% else %}
-                <a class="usa-button usa-button-white" href="/logout/github">Log out</a>
               {% endif %}
             </li>
           {% else %}
             <li  class="nav-action">
               {% if authUAA %}
                 <a href="/login" class="usa-button usa-button-white">Log in with cloud.gov</a>
-              {% else %}
-                <a href="/login/github" class="usa-button usa-button-white">Log in with Github</a>
               {% endif %}
             </li>
           {% endif %}


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update federalistapp.18f.gov home page to no longer allow sign in with Github and have a link taking them to cloud.gov Pages
- Make the UAA on cloud.gov Pages the main sign in option with Github as the secondary
- Force users who sign in to Github to setup their UAA account
- Close #4033

## Notes
- if users were previously logged in, they can view other links (like `/sites`) until token/session expiration
- the documentation link is askew on Federalist but I feel like it symbolizes we're about to shut it off

## Screenshots

![Screen Shot 2023-02-01 at 4 37 53 PM](https://user-images.githubusercontent.com/7108211/216169588-c3c3b774-a70b-4590-983d-5cabf043246d.png)

![Screen Shot 2023-02-01 at 4 41 57 PM](https://user-images.githubusercontent.com/7108211/216169864-e5433798-cd26-4ede-afec-bf47a82ff65c.png)

![Screen Shot 2023-02-01 at 4 43 29 PM](https://user-images.githubusercontent.com/7108211/216170112-5bfab4f9-0421-4467-9641-87144b1f824f.png)

## security considerations
Removes Github authentication
