### PR TITLE
[WIP] Fix remove site 4070

### DIFF
--- a/api/services/S3SiteRemover.js
+++ b/api/services/S3SiteRemover.js
@@ -84,6 +84,7 @@ const removeSite = async (site) => {
     `site/${site.owner}/${site.repository}`,
     `demo/${site.owner}/${site.repository}`,
     `preview/${site.owner}/${site.repository}`,
+    '_cache',
   ];
 
   let credentials;


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove `_cache` folder when deleting site bucket objects, close #4070 
- Remove the check for shared buckets (none remain) and associated tests

## Notes
- Currently there are three failing tests which were relying on shared bucket logic to collect S3 credentials from CF. I'd appreciate some assistance getting those in order as I don't fully follow the test/mock logic.

## security considerations
None
