### PR TITLE
chore: Update app stack to cflinuxfs4

### DIFF
--- a/apps/metrics/ci/pipeline.yml
+++ b/apps/metrics/ci/pipeline.yml
@@ -7,6 +7,7 @@ env-cf: &env-cf
   CF_PASSWORD: ((((deploy-env))-cf-password))
   CF_ORG: gsa-18f-federalist
   CF_SPACE: ((deploy-env))
+  CF_STACK: cflinuxfs4
 
 node-image: &node-image
   type: docker-image

--- a/apps/metrics/ci/tasks/deploy.sh
+++ b/apps/metrics/ci/tasks/deploy.sh
@@ -7,5 +7,5 @@ cf auth
 
 cf t -o $CF_ORG -s $CF_SPACE
 
-cf push $CF_APP_NAME --stack cflinuxfs4 \
+cf push $CF_APP_NAME --stack $CF_STACK \
   $(env | grep ^CFVAR_ | sed 's/CFVAR_/--var /')

--- a/apps/metrics/ci/tasks/deploy.sh
+++ b/apps/metrics/ci/tasks/deploy.sh
@@ -7,5 +7,5 @@ cf auth
 
 cf t -o $CF_ORG -s $CF_SPACE
 
-cf push $CF_APP_NAME \
+cf push $CF_APP_NAME --stack cflinuxfs4 \
   $(env | grep ^CFVAR_ | sed 's/CFVAR_/--var /')

--- a/ci/federalist-pipeline.yml
+++ b/ci/federalist-pipeline.yml
@@ -7,6 +7,7 @@ env-cf: &env-cf
   CF_PASSWORD: ((production-cf-password))
   CF_ORG: gsa-18f-federalist
   CF_SPACE: production
+  CF_STACK: cflinuxfs4
 
 node-image: &node-image
   type: docker-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -7,6 +7,7 @@ env-cf: &env-cf
   CF_PASSWORD: ((((deploy-env))-cf-password))
   CF_ORG: gsa-18f-federalist
   CF_SPACE: ((deploy-env))
+  CF_STACK: cflinuxfs4
 
 node-image: &node-image
   type: docker-image

--- a/ci/tasks/deploy.sh
+++ b/ci/tasks/deploy.sh
@@ -12,4 +12,4 @@ cf push $CF_APP_NAME \
   --path $CF_PATH \
   --manifest $CF_MANIFEST \
   --vars-file $CF_VARS_FILE \
-  --stack cflinuxfs4
+  --stack $CF_STACK

--- a/ci/tasks/deploy.sh
+++ b/ci/tasks/deploy.sh
@@ -11,4 +11,5 @@ cf push $CF_APP_NAME \
   --strategy rolling \
   --path $CF_PATH \
   --manifest $CF_MANIFEST \
-  --vars-file $CF_VARS_FILE
+  --vars-file $CF_VARS_FILE \
+  --stack cflinuxfs4


### PR DESCRIPTION
Apart of https://github.com/cloud-gov/pages-core/issues/4054

## Changes proposed in this pull request:
- Explicitly set stack via the `--stack` flag in `cf push`
- Updates stack to run on cflinuxfs4 via `CF_STACK` param 

## security considerations
Updates app to run on the latest base image: cflinuxfs4 stack (Ubuntu Jammy)