### PR TITLE
feat: Enable org status activation in org edit page

### DIFF
--- a/admin-client/src/components/Nav.svelte
+++ b/admin-client/src/components/Nav.svelte
@@ -49,6 +49,7 @@
 
 <div
   on:click|preventDefault={() => (isOpen ? toggleOpen() : '')}
+  on:keypress|preventDefault={() => (isOpen ? toggleOpen() : '')}
   class="usa-overlay {visible}" />
 <header class="usa-header usa-header--basic">
   <div class="usa-nav-container">
@@ -100,7 +101,7 @@
             <a class="usa-nav__link"  class:usa-current={currentPath === '/organizations'} href="/organizations">
               <span>Orgs</span>
             </a>
-          </li>  
+          </li>
           <li class="usa-nav__primary-item">
             <a class="usa-nav__link"  class:usa-current={currentPath === '/events'} href="/events">
               <span>Events</span>

--- a/admin-client/src/flows/index.js
+++ b/admin-client/src/flows/index.js
@@ -1,3 +1,4 @@
 export { default as destroySite } from './destroySite';
 export { default as login } from './login';
 export { default as logout } from './logout';
+export { default as organizations } from './organizations';

--- a/admin-client/src/flows/organizations.js
+++ b/admin-client/src/flows/organizations.js
@@ -1,0 +1,30 @@
+import page from 'page';
+import { notification } from '../stores';
+import { deactivateOrganization, activateOrganization } from '../lib/api';
+
+async function deactivate(id, redirectTo) {
+  // eslint-disable-next-line no-alert
+  if (!window.confirm('Are you sure you want to deactivate this organization?')) { return null; }
+  try {
+    await deactivateOrganization(id);
+    page(redirectTo);
+    return notification.setSuccess(`Organization ${id} deactivated successfully!`);
+  } catch (error) {
+    return notification.setError(`Unable to deactivate organization ${id}: ${error.message}`);
+  }
+}
+
+async function activate(id, redirectTo) {
+  try {
+    await activateOrganization(id);
+    page(redirectTo);
+    return notification.setSuccess(`Organization ${id} activated successfully!`);
+  } catch (error) {
+    return notification.setError(`Unable to activate organization ${id}: ${error.message}`);
+  }
+}
+
+export default {
+  activate,
+  deactivate,
+};

--- a/admin-client/src/pages/organization/Edit.svelte
+++ b/admin-client/src/pages/organization/Edit.svelte
@@ -3,10 +3,12 @@
   import { afterUpdate } from 'svelte';
   import { router } from '../../stores';
   import { Await, GridContainer } from '../../components';
+  import { organizations } from '../../flows';
   import { fetchOrganization, updateOrganization } from '../../lib/api';
 
   $: id = $router.params.id;
   $: orgPromise = fetchOrganization(id);
+  $: redirectTo = `/organizations/${id}/edit`;
 
   let submitting = false;
 
@@ -14,11 +16,7 @@
     submitting = true;
 
     const {
-      agency,
-      name,
-      sandbox,
-      selfAuthorized,
-      active,
+      agency, name, sandbox, selfAuthorized, active,
     } = event.target.elements;
 
     const params = {
@@ -34,31 +32,59 @@
     page(`/organizations/${id}`);
   }
 
-  afterUpdate(() => { submitting = false; });
+  afterUpdate(() => {
+    submitting = false;
+  });
 </script>
 
 <GridContainer classes={['display-flex', 'flex-justify-center']}>
   <Await on={orgPromise} let:response={org}>
     <form
       class="usa-form usa-form--large"
-      on:submit|preventDefault={handleSubmit} >
-
+      on:submit|preventDefault={handleSubmit}
+    >
       <legend class="usa-legend usa-legend--large">Edit Organization</legend>
 
       <p>
-        Required fields are marked with an asterisk (<abbr title="required" class="usa-hint usa-hint--required">*</abbr>).
+        Required fields are marked with an asterisk (<abbr
+          title="required"
+          class="usa-hint usa-hint--required">*</abbr
+        >).
       </p>
 
       <fieldset class="usa-fieldset">
-        <label class="usa-label" for="name">Organization Name<abbr title="required" class="usa-hint usa-hint--required">*</abbr></label>
+        <label class="usa-label" for="name"
+          >Organization Name<abbr
+            title="required"
+            class="usa-hint usa-hint--required">*</abbr
+          ></label
+        >
         <span class="usa-hint">Organization name must be globally unique</span>
-        <input type="text" class="usa-input" name="name" id="name" value={org.name} required>
+        <input
+          type="text"
+          class="usa-input"
+          name="name"
+          id="name"
+          value={org.name}
+          required
+        />
       </fieldset>
 
       <fieldset class="usa-fieldset">
-        <label class="usa-label" for="agency">Agency<abbr title="required" class="usa-hint usa-hint--required">*</abbr></label>
+        <label class="usa-label" for="agency"
+          >Agency<abbr title="required" class="usa-hint usa-hint--required"
+            >*</abbr
+          ></label
+        >
         <span class="usa-hint">Federal agency (GSA, OMB, etc...)</span>
-        <input type="text" class="usa-input" name="agency" id="agency" value={org.agency} required>
+        <input
+          type="text"
+          class="usa-input"
+          name="agency"
+          id="agency"
+          value={org.agency}
+          required
+        />
       </fieldset>
 
       <fieldset class="usa-fieldset">
@@ -104,7 +130,7 @@
         </div>
       </fieldset>
 
-      <fieldset class="usa-fieldset" disabled>
+      <fieldset class="usa-fieldset">
         <legend class="usa-legend usa-legend">Organization Status</legend>
         <div class="usa-radio">
           <input
@@ -114,6 +140,7 @@
             name="active"
             value="active"
             checked={org.isActive}
+            on:click={() => organizations.activate(id, redirectTo)}
           />
           <label class="usa-radio__label" for="active">Active</label>
         </div>
@@ -125,11 +152,17 @@
             name="active"
             value="inactive"
             checked={!org.isActive}
+            on:click={() => organizations.deactivate(id, redirectTo)}
           />
           <label class="usa-radio__label" for="inactive">Inactive</label>
         </div>
       </fieldset>
-      <input class="usa-button" type="submit" value="Update" disabled={submitting}>
+      <input
+        class="usa-button"
+        type="submit"
+        value="Update"
+        disabled={submitting}
+      />
     </form>
   </Await>
 </GridContainer>

--- a/admin-client/src/pages/organization/Index.svelte
+++ b/admin-client/src/pages/organization/Index.svelte
@@ -1,31 +1,8 @@
 <script>
-  import page from 'page';
-  import { notification } from '../../stores';
-  import { fetchOrganizations, deactivateOrganization, activateOrganization } from '../../lib/api';
+  import { organizations } from '../../flows';
+  import { fetchOrganizations } from '../../lib/api';
   import { formatDateTime } from '../../helpers/formatter';
   import { DataTable, PaginatedQueryPage } from '../../components';
-
-  async function deactivate(id) {
-    // eslint-disable-next-line no-alert
-    if (!window.confirm('Are you sure you want to deactivate this organization?')) { return null; }
-    try {
-      await deactivateOrganization(id);
-      page('/organizations');
-      return notification.setSuccess(`Organization ${id} deactivated successfully!`);
-    } catch (error) {
-      return notification.setError(`Unable to deactivate organization ${id}: ${error.message}`);
-    }
-  }
-
-  async function activate(id) {
-    try {
-      await activateOrganization(id);
-      page('/organizations');
-      return notification.setSuccess(`Organization ${id} activated successfully!`);
-    } catch (error) {
-      return notification.setError(`Unable to activate organization ${id}: ${error.message}`);
-    }
-  }
 </script>
 
 <PaginatedQueryPage path="organizations" query={fetchOrganizations} addAction let:data>
@@ -79,13 +56,13 @@
         {#if org.isActive}
         <button
           class="usa-button usa-button--secondary"
-          on:click={() => deactivate(org.id)}>
+          on:click={() => organizations.deactivate(org.id, '/organizations')}>
           Deactivate
         </button>
         {:else}
         <button
           class="usa-button"
-          on:click={() => activate(org.id)}>
+          on:click={() => organizations.activate(org.id, '/organizations')}>
           Activate
         </button>
         {/if}


### PR DESCRIPTION
Closes https://github.com/cloud-gov/pages-core/issues/4079

## Changes proposed in this pull request:
- Enables the org status radio select input on the org edit page
- Refactor org activation/deactivation functions into a flow for reusability across components

## security considerations
None