### PR TITLE
feat: Switch to using harden container for cf-image

### DIFF
--- a/apps/metrics/ci/pipeline.yml
+++ b/apps/metrics/ci/pipeline.yml
@@ -20,8 +20,8 @@ cf-image: &cf-image
   image_resource:
     type: registry-image
     source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
+      aws_access_key_id: ((ecr-aws-key))
+      aws_secret_access_key: ((ecr-aws-secret))
       repository: harden-concourse-task
       aws_region: us-gov-west-1
       tag: ((harden-concourse-task-tag))

--- a/apps/metrics/ci/pipeline.yml
+++ b/apps/metrics/ci/pipeline.yml
@@ -18,9 +18,13 @@ node-image: &node-image
 cf-image: &cf-image
   platform: linux
   image_resource:
-    type: docker-image
+    type: registry-image
     source:
-      repository: 18fgsa/concourse-task
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: harden-concourse-task
+      aws_region: us-gov-west-1
+      tag: ((harden-concourse-task-tag))
 
 test-metrics: &test-metrics
   - task: install-dev-deps-metrics

--- a/ci/federalist-pipeline.yml
+++ b/ci/federalist-pipeline.yml
@@ -18,9 +18,13 @@ node-image: &node-image
 cf-image: &cf-image
   platform: linux
   image_resource:
-    type: docker-image
+    type: registry-image
     source:
-      repository: 18fgsa/concourse-task
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: harden-concourse-task
+      aws_region: us-gov-west-1
+      tag: ((harden-concourse-task-tag))
 
 test-api: &test-api
   - in_parallel:

--- a/ci/federalist-pipeline.yml
+++ b/ci/federalist-pipeline.yml
@@ -20,8 +20,8 @@ cf-image: &cf-image
   image_resource:
     type: registry-image
     source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
+      aws_access_key_id: ((ecr-aws-key))
+      aws_secret_access_key: ((ecr-aws-secret))
       repository: harden-concourse-task
       aws_region: us-gov-west-1
       tag: ((harden-concourse-task-tag))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -18,9 +18,13 @@ node-image: &node-image
 cf-image: &cf-image
   platform: linux
   image_resource:
-    type: docker-image
+    type: registry-image
     source:
-      repository: 18fgsa/concourse-task
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: harden-concourse-task
+      aws_region: us-gov-west-1
+      tag: ((harden-concourse-task-tag))
 
 test-api: &test-api
   - in_parallel:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -20,8 +20,8 @@ cf-image: &cf-image
   image_resource:
     type: registry-image
     source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
+      aws_access_key_id: ((ecr-aws-key))
+      aws_secret_access_key: ((ecr-aws-secret))
       repository: harden-concourse-task
       aws_region: us-gov-west-1
       tag: ((harden-concourse-task-tag))


### PR DESCRIPTION
Related to https://github.com/cloud-gov/pages-core/issues/4077

## Changes proposed in this pull request:
- Update cf-image to use hardened container image

## security considerations
This adds the hardened container to run CF tasks
