### PR TITLE
lowercase all site tag metadata

### DIFF
--- a/admin-client/src/components/SiteCard.svelte
+++ b/admin-client/src/components/SiteCard.svelte
@@ -52,6 +52,9 @@
     margin-block-start: 0;
     margin-block-end: 0;
   }
+  span.usa-tag {
+    text-transform: unset;
+  }
 </style>
 
 <div class="padding-2 {bgColor}">
@@ -84,7 +87,7 @@
         <span class="usa-tag bg-orange">{awsBucketName}</span>
         <span class="usa-tag bg-accent-cool-dark">{s3ServiceName}</span>
         {#if organizationId}
-          <span class="usa-tag bg-indigo">ORG: {organizationId}</span>
+          <span class="usa-tag bg-indigo">org: {organizationId}</span>
         {/if}
       </div>
       <div class="tablet:grid-col-auto padding-bottom-1">

--- a/admin-client/src/components/SiteMetadata.svelte
+++ b/admin-client/src/components/SiteMetadata.svelte
@@ -66,3 +66,9 @@
     </div>
   </div>
 </div>
+
+<style>
+  span.usa-tag {
+    text-transform: unset;
+  }
+</style>


### PR DESCRIPTION
## Changes proposed in this pull request:
- Close #4082 
- Also lowercases remaining site metadata tags (service name is also helpful to be lowercase and this makes them all consistent)

<img width="253" alt="Screen Shot 2023-03-23 at 2 36 44 PM" src="https://user-images.githubusercontent.com/7108211/227318691-e5ae176c-f0dc-49c9-aa0e-c1736372ba9f.png">

<img width="460" alt="Screen Shot 2023-03-23 at 2 40 48 PM" src="https://user-images.githubusercontent.com/7108211/227318694-43285047-8064-4097-a382-554b1183f540.png">


## security considerations
None
