### PR TITLE
chore: Remove Jekyll template from core

### DIFF
--- a/config/templates.js
+++ b/config/templates.js
@@ -9,16 +9,6 @@ module.exports = {
     description: 'A flexible multi-page setup intended to introduce an agency or program. It offers an engaging Hero section for a current priority and a landing page layout designed to provide clarity and context for first time visitors. This template also offers navigation options for internal pages.',
     thumb: '/images/pages-uswds-v3-11ty-thumbnail.png',
   },
-  'uswds-jekyll': {
-    owner: 'cloud-gov',
-    repo: 'pages-uswds-jekyll',
-    branch: 'main',
-    engine: 'jekyll',
-    example: 'https://uswds-jekyll.pages.cloud.gov',
-    title: 'Jekyll - U.S. Web Design System v2.0',
-    description: 'A flexible multi-page setup intended to introduce an agency or program. It offers an engaging Hero section for a current priority and a landing page layout designed to provide clarity and context for first time visitors. This template also offers navigation options for internal pages.',
-    thumb: '/images/pages-uswds-v2-thumbnail.png',
-  },
   'uswds-gatsby': {
     owner: 'cloud-gov',
     repo: 'pages-uswds-gatsby',

--- a/public/swagger/Site.json
+++ b/public/swagger/Site.json
@@ -40,7 +40,7 @@
     },
     "engine": {
       "type": "string",
-      "enum": ["jekyll", "hugo", "static"]
+      "enum": ["jekyll", "hugo", "static", "node.js"]
     },
     "owner": {
       "type": "string"

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -450,8 +450,8 @@ describe('Site API', () => {
           owner: siteOwner,
           repository: siteRepository,
           defaultBranch: 'main',
-          engine: 'jekyll',
-          template: 'uswds-jekyll',
+          engine: 'node.js',
+          template: 'uswds-11ty',
         })
         .set('Cookie', cookie)
         .expect(200))
@@ -500,9 +500,9 @@ describe('Site API', () => {
           owner: siteOwner,
           repository: siteRepository,
           defaultBranch: 'main',
-          engine: 'jekyll',
+          engine: 'node.js',
           organizationId: org.id,
-          template: 'uswds-jekyll',
+          template: 'uswds-11ty',
         })
         .set('Cookie', cookie)
         .expect(200))

--- a/test/api/unit/services/SiteCreator.test.js
+++ b/test/api/unit/services/SiteCreator.test.js
@@ -342,7 +342,7 @@ describe('SiteCreator', () => {
     });
 
     context('when the site is created from a template', () => {
-      const template = 'uswds-jekyll';
+      const template = 'uswds-11ty';
       let user;
       let siteParams, name;
 
@@ -462,7 +462,7 @@ describe('SiteCreator', () => {
           .catch(done);
       });
 
-      it('should use jekyll as the build engine', (done) => {
+      it('should use node as the build engine', (done) => {
         factory.user()
           .then((model) => {
             user = model;
@@ -470,7 +470,7 @@ describe('SiteCreator', () => {
             githubAPINocks.webhook();
             return SiteCreator.createSite({ siteParams, user });
           }).then((site) => {
-            expect(site.engine).to.equal('jekyll');
+            expect(site.engine).to.equal('node.js');
             done();
           }).catch(done);
       });


### PR DESCRIPTION
Related to [#4100](https://github.com/cloud-gov/pages-core/issues/4100)


## Changes proposed in this pull request:
- Removes Jekyll template from template options on new site

## security considerations
The jekyll ecosystem support is waining and we are removing the option from our template deploy option.
