### PR TITLE
Fix site published files page

### DIFF
--- a/frontend/actions/publishedFileActions.js
+++ b/frontend/actions/publishedFileActions.js
@@ -15,9 +15,9 @@ const dispatchPublishedFilesReceivedAction = (files) => {
 };
 
 export default {
-  fetchPublishedFiles(site, branch, startAtKey) {
+  fetchPublishedFiles(id, branch, startAtKey) {
     dispatchPublishedfilesFetchStartedAction();
-    return api.fetchPublishedFiles(site, branch, startAtKey)
+    return api.fetchPublishedFiles(id, branch, startAtKey)
       .then(dispatchPublishedFilesReceivedAction);
   },
 };

--- a/frontend/components/site/SitePublishedFilesTable.jsx
+++ b/frontend/components/site/SitePublishedFilesTable.jsx
@@ -101,6 +101,8 @@ function renderPublishedFilesTable(files, name, currentPage, lastPage, setCurren
 
 function SitePublishedFilesTable() {
   const { id, name } = useParams();
+  console.log(`id : ${id}`);
+  console.log(`name : ${name}`);
   const publishedFiles = useSelector(state => state.publishedFiles);
 
   const [currentPage, setCurrentPage] = useState(0);

--- a/frontend/components/site/SitePublishedFilesTable.jsx
+++ b/frontend/components/site/SitePublishedFilesTable.jsx
@@ -101,8 +101,6 @@ function renderPublishedFilesTable(files, name, currentPage, lastPage, setCurren
 
 function SitePublishedFilesTable() {
   const { id, name } = useParams();
-  console.log(`id : ${id}`);
-  console.log(`name : ${name}`);
   const publishedFiles = useSelector(state => state.publishedFiles);
 
   const [currentPage, setCurrentPage] = useState(0);
@@ -129,11 +127,11 @@ function SitePublishedFilesTable() {
     }
   }, [publishedFiles]);
 
-  if (publishedFiles.isLoading || !publishedFiles.data) {
+  if (publishedFiles.isLoading) {
     return <LoadingIndicator />;
   }
 
-  if (!publishedFiles.data.files.length) {
+  if (!publishedFiles.data || !publishedFiles.data.files.length) {
     return (
       <AlertBanner
         status="info"

--- a/frontend/components/site/SitePublishedFilesTable.jsx
+++ b/frontend/components/site/SitePublishedFilesTable.jsx
@@ -127,7 +127,7 @@ function SitePublishedFilesTable() {
     }
   }, [publishedFiles]);
 
-  if (publishedFiles.isLoading) {
+  if (publishedFiles.isLoading || !publishedFiles.data) {
     return <LoadingIndicator />;
   }
 

--- a/frontend/components/site/SitePublishedFilesTable.jsx
+++ b/frontend/components/site/SitePublishedFilesTable.jsx
@@ -115,6 +115,9 @@ function SitePublishedFilesTable() {
   }, [currentPage]);
 
   useEffect(() => {
+    if (!publishedFiles.data) {
+      return;
+    }
     // either our data wasn't truncated or we need to store the last key for future data fetching
     if (!publishedFiles.data.isTruncated) {
       setLastPage(currentPage);

--- a/frontend/components/site/sitePublishedBranchesTable.jsx
+++ b/frontend/components/site/sitePublishedBranchesTable.jsx
@@ -36,7 +36,6 @@ function renderPublishedBranchesTable(data, site) {
   return (
     <div>
       <p>
-        { site.id }
         Use this page to see every version of your site&apos;s code published on
         {` ${globals.APP_NAME} `}
         and to audit the specific files that

--- a/frontend/util/federalistApi.js
+++ b/frontend/util/federalistApi.js
@@ -87,8 +87,8 @@ export default {
     return request(`site/${site.id}/published-branch`);
   },
 
-  fetchPublishedFiles(site, branch, startAtKey = null) {
-    let path = `site/${site.id}/published-branch/${branch}/published-file`;
+  fetchPublishedFiles(id, branch, startAtKey = null) {
+    let path = `site/${id}/published-branch/${branch}/published-file`;
     if (startAtKey) {
       path += `?startAtKey=${startAtKey}`;
     }

--- a/test/frontend/util/federalistApi.test.js
+++ b/test/frontend/util/federalistApi.test.js
@@ -119,12 +119,12 @@ describe('federalistApi', () => {
 
   describe('fetchPublishedFiles', () => {
     it('is defined', () => {
-      federalistApi.fetchPublishedFiles(testSite, testBranch);
+      federalistApi.fetchPublishedFiles(testSite.id, testBranch);
       testRouteCalled('getPublishedFiles');
     });
 
     it('works with the startAtKey param', () => {
-      federalistApi.fetchPublishedFiles(testSite, testBranch, 'boop');
+      federalistApi.fetchPublishedFiles(testSite.id, testBranch, 'boop');
       testRouteCalled('getPublishedFilesWithQueryParam');
     });
   });


### PR DESCRIPTION
The site published files ("View files") page at sites/id/published/branch errors out for at least one reason (function signature mismatch). This PR addresses that as well as adding checks for a few possible timing issues where rendering might be attempted before `publishedFiles.data` has been initialized. 

This PR addresses #4129.

## Changes proposed in this pull request:
- `fetchPublishedFiles()` now takes `id` as its first parameter all the way up the call stack.
- Rendering of the table won't take place unless `publishedFiles.data` exists

## security considerations
None. This is intended to restore normal function of an existing application component.


