### PR TITLE
Make development build more developer friendly

### DIFF
--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -29,7 +29,7 @@ applications:
       - mailer
       - slack
     env:
-      NODE_ENV: production
+      NODE_ENV: ((node_env))
       APP_ENV: ((env))
       ADMIN_HOSTNAME: https://admin.((domain))
       APP_HOSTNAME: https://((domain))
@@ -71,7 +71,7 @@ applications:
     env:
       ADMIN_GITHUB_ORGANIZATION: 18F
       ADMIN_GITHUB_TEAM: federalist-admins
-      NODE_ENV: production
+      NODE_ENV: ((node_env))
       APP_ENV: ((env))
       APP_HOSTNAME: https://queues.((domain))
       LOG_LEVEL: ((log_level))

--- a/.cloudgov/vars/pages-dev.yml
+++ b/.cloudgov/vars/pages-dev.yml
@@ -14,3 +14,4 @@ uaa_login_host: https://login.fr-stage.cloud.gov
 new_relic_app_name: web-pages-dev
 proxy_domain: sites.pages-dev.cloud.gov
 cf_cdn_space_name: sites-dev
+node_env: development

--- a/.cloudgov/vars/pages-production.yml
+++ b/.cloudgov/vars/pages-production.yml
@@ -14,3 +14,4 @@ uaa_login_host: https://login.fr.cloud.gov
 new_relic_app_name: web-pages-production
 proxy_domain: sites.pages.cloud.gov
 cf_cdn_space_name: sites
+node_env: production

--- a/.cloudgov/vars/pages-staging.yml
+++ b/.cloudgov/vars/pages-staging.yml
@@ -14,3 +14,4 @@ uaa_login_host: https://login.fr-stage.cloud.gov
 new_relic_app_name: web-pages-staging
 proxy_domain: sites.pages-staging.cloud.gov
 cf_cdn_space_name: sites-staging
+node_env: production

--- a/ci/pipeline-dev.yml
+++ b/ci/pipeline-dev.yml
@@ -149,7 +149,7 @@ jobs:
           run:
             dir: src-api
             path: bash
-            args: [-c, yarn build]
+            args: [-c, yarn build-dev]
 
       - task: deploy-api
         config:

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "scripts": {
     "build": "webpack --config webpack.production.config.js",
+    "build-dev": "webpack --config webpack.development.config.js",
     "start": "node index.js",
     "start-workers": "node ./api/workers/index.js",
     "start-bull-board:cg": "node -r ./api/bull-board/cfEnv.js ./api/bull-board/index.js",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "scripts": {
     "build": "webpack --config webpack.production.config.js",
-    "build-dev": "webpack --config webpack.development.config.js",
+    "build-dev": "webpack --config webpack.development-build.config.js",
     "start": "node index.js",
     "start-workers": "node ./api/workers/index.js",
     "start-bull-board:cg": "node -r ./api/bull-board/cfEnv.js ./api/bull-board/index.js",

--- a/webpack.development-build.config.js
+++ b/webpack.development-build.config.js
@@ -1,0 +1,112 @@
+const path = require('path');
+const webpack = require('webpack');
+const autoprefixer = require('autoprefixer');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
+const { getFeatureFlags } = require('./webpack-utils');
+
+const RESOURCE_GENERATOR = {
+  filename: 'images/[contenthash][ext]',
+  publicPath: '/',
+};
+
+module.exports = {
+  mode: 'development',
+  entry: './frontend/main.jsx',
+  devtool: 'inline-source-map',
+  stats: 'minimal',
+  output: {
+    filename: 'js/bundle.js',
+    path: path.resolve(__dirname, 'public'),
+  },
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /(node_modules|bower_components|public\/)/,
+        loader: 'babel-loader',
+      },
+      {
+        test: /\.scss$/,
+        use: [
+          MiniCssExtractPlugin.loader,
+          {
+            loader: 'css-loader',
+            options: {
+              url: url => !url.includes('images'),
+            },
+          },
+          {
+            loader: 'postcss-loader',
+            options: {
+              sourceMap: true,
+              postcssOptions: {
+                plugins: [autoprefixer],
+              },
+            },
+          },
+          {
+            loader: 'sass-loader',
+            options: {
+              sassOptions: {
+                quietDeps: true,
+                loadPath: path.resolve(__dirname, 'node_modules/uswds/src/stylesheets/'),
+              },
+            },
+          },
+        ],
+      },
+      {
+        test: /\.(gif|png|jpe?g|ttf|woff2?|eot)$/i,
+        type: 'asset/resource',
+        generator: RESOURCE_GENERATOR,
+      },
+      {
+        test: /\.svg$/i,
+        oneOf: [
+          {
+            // For .svg files in public/images/icons/, use the react-svg loader
+            // so that they can be loaded as React components
+            include: path.resolve(__dirname, 'public/images/icons'),
+            use: [
+              'babel-loader',
+              {
+                loader: 'react-svg-loader',
+                options: {
+                  svgo: {
+                    plugins: [{ removeViewBox: false }],
+                  },
+                },
+              },
+            ],
+          },
+          {
+            // For all other .svg files, fallback to asset/resource
+            type: 'asset/resource',
+            generator: RESOURCE_GENERATOR,
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [
+    // Make sure this is the first plugin!!!
+    new MiniCssExtractPlugin({ filename: 'styles/styles.css' }),
+    // When webpack bundles moment, it includes all of its locale files,
+    // which we don't need, so we'll use this plugin to keep them out of the
+    // bundle
+    new webpack.IgnorePlugin({ resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/}),
+    new webpack.EnvironmentPlugin([
+      ...getFeatureFlags(process.env),
+      'APP_HOSTNAME',
+      'PRODUCT',
+    ]),
+    new WebpackManifestPlugin({
+      fileName: '../webpack-manifest.json',
+      publicPath: '',
+    }),
+  ],
+};


### PR DESCRIPTION
## Changes proposed in this pull request:
- parametrize NODE_ENV for pages-dev development build
- use separate webpack config for development build

## security considerations
Sourcemaps and other development artifacts included in a build (but only in the dev environment) 
