### PR TITLE
Remediation of contrast errors

### DIFF
--- a/frontend/sass/_variables.scss
+++ b/frontend/sass/_variables.scss
@@ -4,7 +4,7 @@ $serif: 'Merriweather', serif;
 $white: #fff;
 $white-shaded: #eef4fb;
 
-$color-blue: #1d5c87;
+$color-blue: #1c5982;
 $color-blue-dark: #112e51;
 $color-blue-bright: rgb(5, 104, 253);
 

--- a/frontend/sass/_variables.scss
+++ b/frontend/sass/_variables.scss
@@ -4,8 +4,8 @@ $serif: 'Merriweather', serif;
 $white: #fff;
 $white-shaded: #eef4fb;
 
-$color-blue: #287db5;
-$color-blue-dark: #175c8a;
+$color-blue: #1d5c87;
+$color-blue-dark: #112e51;
 $color-blue-bright: rgb(5, 104, 253);
 
 $color-gray: #526577;


### PR DESCRIPTION
I have repeated the WAVE scan against dev with the changes proposed here and have confirmed that they remediate all of the contrast errors noted in #4132.

## Changes proposed in this pull request:
- Darken theme `color-blue` which is used 
  - link text on primary (white) background
  - link text on secondary (very light grey) background)
  - "button"-styled link background (presented with white text)
- Dark theme `color-blue-dark` which may or may not be used, but I thought I should probably keep it darker than `color-blue`. I decided to make it match the footer background (a dark blue given the name `color-gray-darker`).

## security considerations
None. This is a styling change in the theme.

## Screenshots
Without this change: 
<img width="1005" alt="image" src="https://user-images.githubusercontent.com/12150/236259003-5be1869f-bc81-46a4-8434-9adee694b112.png">

With this change: 
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/12150/236259146-3e939eca-dbad-4448-8f1a-a879c1e916d4.png">

Without this change:
<img width="117" alt="image" src="https://user-images.githubusercontent.com/12150/236259285-8c0ca1ec-783e-4e25-b5f2-e4eae07a20bf.png">

With this change: 
<img width="117" alt="image" src="https://user-images.githubusercontent.com/12150/236259373-fe1be84c-d747-4b9e-b574-7f88cd61f461.png">
