### PR TITLE
Add 'cloud.gov Pages' context to Home link to improve screen reader navigation

### DIFF
--- a/views/navigation.njk
+++ b/views/navigation.njk
@@ -4,7 +4,7 @@
       <div class="usa-navbar">
         <div class="usa-logo" id="basic-logo">
           <em class="usa-logo-text">
-            <a href="/" title="Home" aria-label="Home">{{ appName }}</a>
+            <a href="/" title="cloud.gov Pages Home" aria-label="cloud.gov Pages Home">{{ appName }}</a>
           </em>
         </div>
         <button class="usa-menu-btn">Menu</button>


### PR DESCRIPTION
This PR makes the accessibility improvement documented in https://github.com/cloud-gov/pages-core/issues/4136:

To sighted users the home link displays as a logo representing cloud.gov Pages followed by the word "Pages". But without this change a screen reader user who tab-navigates to this link only hears "Home". 

## Changes proposed in this pull request:
- Home (`/`) navigation link `title` and `aria-label` changed from "Home" to "cloud.gov Pages Home"

I experimented with changing just the `title` or just the `aria-label` but — at least with macOS voiceover — when these two attributes differ they are _both_ read. Changing them both avoids this needless and potentially annoying repetition.

## security considerations
None. This is an HTML attribute change to improve the navigation experience for screen reader users.
