### PR TITLE
feat: Add fail stuck builds queue and breakout timeout builds queue

### DIFF
--- a/api/bull-board/app.js
+++ b/api/bull-board/app.js
@@ -12,10 +12,12 @@ const slowDown = require('express-slow-down');
 const {
   ArchiveBuildLogsQueue,
   DomainQueue,
+  FailStuckBuildsQueue,
   MailQueue,
   SiteDeletionQueue,
   ScheduledQueue,
   SlackQueue,
+  TimeoutBuildTasksQueue,
 } = require('../queues');
 
 const passport = require('./passport');
@@ -42,10 +44,12 @@ createBullBoard({
     new BullAdapter(createQueue('site-build-queue')),
     new BullMQAdapter(new ArchiveBuildLogsQueue(connection)),
     new BullMQAdapter(new DomainQueue(connection)),
+    new BullMQAdapter(new FailStuckBuildsQueue(connection)),
     new BullMQAdapter(new MailQueue(connection)),
     new BullMQAdapter(new SiteDeletionQueue(connection)),
     new BullMQAdapter(new SlackQueue(connection)),
     new BullMQAdapter(new ScheduledQueue(connection)),
+    new BullMQAdapter(new TimeoutBuildTasksQueue(connection)),
   ],
   serverAdapter,
 });

--- a/api/queues/FailStuckBuildsQueue.js
+++ b/api/queues/FailStuckBuildsQueue.js
@@ -1,0 +1,14 @@
+const { Queue } = require('bullmq');
+
+const FailStuckBuildsQueueName = 'fail-stuck-builds';
+
+class FailStuckBuildsQueue extends Queue {
+  constructor(connection) {
+    super(FailStuckBuildsQueueName, { connection });
+  }
+}
+
+module.exports = {
+  FailStuckBuildsQueue,
+  FailStuckBuildsQueueName,
+};

--- a/api/queues/TimeoutBuildTasksQueue.js
+++ b/api/queues/TimeoutBuildTasksQueue.js
@@ -1,0 +1,14 @@
+const { Queue } = require('bullmq');
+
+const TimeoutBuildTasksQueueName = 'timeout-build-tasks';
+
+class TimeoutBuildTasksQueue extends Queue {
+  constructor(connection) {
+    super(TimeoutBuildTasksQueueName, { connection });
+  }
+}
+
+module.exports = {
+  TimeoutBuildTasksQueue,
+  TimeoutBuildTasksQueueName,
+};

--- a/api/queues/index.js
+++ b/api/queues/index.js
@@ -1,15 +1,19 @@
 const { ArchiveBuildLogsQueue, ArchiveBuildLogsQueueName } = require('./ArchiveBuildLogsQueue');
 const { DomainQueue, DomainQueueName } = require('./DomainQueue');
+const { FailStuckBuildsQueue, FailStuckBuildsQueueName } = require('./FailStuckBuildsQueue');
 const { MailQueue, MailQueueName } = require('./MailQueue');
 const { ScheduledQueue, ScheduledQueueName } = require('./ScheduledQueue');
 const { SiteDeletionQueue, SiteDeletionQueueName } = require('./SiteDeletionQueue');
 const { SlackQueue, SlackQueueName } = require('./SlackQueue');
+const { TimeoutBuildTasksQueue, TimeoutBuildTasksQueueName } = require('./TimeoutBuildTasksQueue');
 
 module.exports = {
   ArchiveBuildLogsQueue,
   ArchiveBuildLogsQueueName,
   DomainQueue,
   DomainQueueName,
+  FailStuckBuildsQueue,
+  FailStuckBuildsQueueName,
   MailQueue,
   MailQueueName,
   SiteDeletionQueue,
@@ -18,4 +22,6 @@ module.exports = {
   ScheduledQueueName,
   SlackQueue,
   SlackQueueName,
+  TimeoutBuildTasksQueue,
+  TimeoutBuildTasksQueueName,
 };

--- a/api/services/FailStuckBuilds.js
+++ b/api/services/FailStuckBuilds.js
@@ -1,0 +1,62 @@
+const moment = require('moment');
+const { Op } = require('sequelize');
+const { Build, BuildLog } = require('../models');
+
+const BUILD_STUCK_MINUTES = 10;
+
+async function checkStuckBuilds() {
+  const date = new Date();
+  const now = moment(date);
+  const buildQueueTime = now.clone().subtract(BUILD_STUCK_MINUTES, 'minutes');
+
+  const options = {
+    attributes: ['id'],
+    where: {
+      state: {
+        [Op.in]: [
+          Build.States.Created,
+          Build.States.Tasked,
+        ],
+      },
+      updatedAt: {
+        [Op.lt]: buildQueueTime.toDate(),
+      },
+    },
+    returning: ['id'],
+  };
+
+  const builds = await Build.findAll(options);
+
+  return builds.map(b => b.id);
+}
+
+async function failBuilds(buildIds) {
+  const [, updated] = await Build.update({ state: Build.States.Error }, {
+    where: {
+      id: {
+        [Op.in]: buildIds,
+      },
+    },
+    returning: ['id', 'state'],
+  });
+
+  const bulkLogs = updated.map(record => ({
+    build: record.id,
+    source: 'ALL',
+    output: 'An error occurred while trying to build this branch. Please rebuild branch.',
+  }));
+
+  await BuildLog.bulkCreate(bulkLogs);
+
+  return updated.map(b => b);
+}
+
+async function runFailStuckBuilds() {
+  const buildIds = await checkStuckBuilds();
+
+  if (buildIds.length === 0) return null;
+
+  return failBuilds(buildIds);
+}
+
+module.exports = { runFailStuckBuilds };

--- a/api/workers/jobProcessors/archiveBuildLogsDaily.js
+++ b/api/workers/jobProcessors/archiveBuildLogsDaily.js
@@ -5,19 +5,7 @@ const BuildLogs = require('../../services/build-logs');
 const { Build } = require('../../models');
 const Mailer = require('../../services/mailer');
 const Slacker = require('../../services/slacker');
-
-function createJobLogger(job) {
-  let logs = [];
-  return {
-    log(msg) {
-      logs.push(job.log(msg));
-    },
-    async flush() {
-      await Promise.all(logs);
-      logs = [];
-    },
-  };
-}
+const { createJobLogger } = require('./utils');
 
 async function archiveBuildLogsDaily(job) {
   const logger = createJobLogger(job);

--- a/api/workers/jobProcessors/failStuckBuilds.js
+++ b/api/workers/jobProcessors/failStuckBuilds.js
@@ -9,11 +9,16 @@ async function failStuckBuilds(job) {
   const results = await runFailStuckBuilds();
 
   if (!results) {
-    logger.log('No builds where stuck');
-  } else {
-    const buildIds = results.map(r => r.id);
-    logger.log(`The following builds were failed: ${buildIds.join(', ')}`);
+    const message = 'No builds where stuck';
+    logger.log(message);
+
+    return message;
   }
+
+  const buildIds = results.map(r => r.id);
+  const message = `The following builds were failed: ${buildIds.join(', ')}`;
+  logger.log(message);
+  return message;
 }
 
 module.exports = failStuckBuilds;

--- a/api/workers/jobProcessors/failStuckBuilds.js
+++ b/api/workers/jobProcessors/failStuckBuilds.js
@@ -1,0 +1,19 @@
+const { runFailStuckBuilds } = require('../../services/FailStuckBuilds');
+const { createJobLogger } = require('./utils');
+
+async function failStuckBuilds(job) {
+  const logger = createJobLogger(job);
+
+  logger.log('Failing stuck builds');
+
+  const results = await runFailStuckBuilds();
+
+  if (!results) {
+    logger.log('No builds where stuck');
+  }
+
+  const buildIds = results.map(r => r.id);
+  logger.log(`The following builds were failed: ${buildIds.join(', ')}`);
+}
+
+module.exports = failStuckBuilds;

--- a/api/workers/jobProcessors/failStuckBuilds.js
+++ b/api/workers/jobProcessors/failStuckBuilds.js
@@ -10,10 +10,10 @@ async function failStuckBuilds(job) {
 
   if (!results) {
     logger.log('No builds where stuck');
+  } else {
+    const buildIds = results.map(r => r.id);
+    logger.log(`The following builds were failed: ${buildIds.join(', ')}`);
   }
-
-  const buildIds = results.map(r => r.id);
-  logger.log(`The following builds were failed: ${buildIds.join(', ')}`);
 }
 
 module.exports = failStuckBuilds;

--- a/api/workers/jobProcessors/index.js
+++ b/api/workers/jobProcessors/index.js
@@ -1,5 +1,6 @@
 const archiveBuildLogsDaily = require('./archiveBuildLogsDaily');
 const destroySiteInfra = require('./destroySiteInfra');
+const failStuckBuilds = require('./failStuckBuilds');
 const multiJobProcessor = require('./multiJobProcessor');
 const nightlyBuilds = require('./nightlyBuilds');
 const timeoutBuilds = require('./timeoutBuilds');
@@ -9,6 +10,7 @@ const cleanSandboxOrganizations = require('./cleanSandboxOrganizations');
 module.exports = {
   archiveBuildLogsDaily,
   destroySiteInfra,
+  failStuckBuilds,
   multiJobProcessor,
   nightlyBuilds,
   timeoutBuilds,

--- a/api/workers/jobProcessors/utils.js
+++ b/api/workers/jobProcessors/utils.js
@@ -1,0 +1,14 @@
+function createJobLogger(job) {
+  let logs = [];
+  return {
+    log(msg) {
+      logs.push(job.log(msg));
+    },
+    async flush() {
+      await Promise.all(logs);
+      logs = [];
+    },
+  };
+}
+
+module.exports = { createJobLogger };

--- a/test/api/unit/services/FailStuckBuilds.test.js
+++ b/test/api/unit/services/FailStuckBuilds.test.js
@@ -1,0 +1,82 @@
+const { expect } = require('chai');
+const moment = require('moment');
+const { Op } = require('sequelize');
+
+const factory = require('../../support/factory');
+const { runFailStuckBuilds } = require('../../../../api/services/FailStuckBuilds');
+const { Build, BuildLog, sequelize } = require('../../../../api/models');
+
+const { Created, Processing, Queued, Tasked } = Build.States;
+
+function setBuildUpdatedAt(build, date) {
+  return sequelize.query(
+    'UPDATE build set "updatedAt" = ? WHERE id = ?',
+    { replacements: [date, build.id] }
+  ).then(() => build.reload());
+}
+
+describe('FailStuckBuilds', () => {
+  beforeEach(() => {
+    BuildLog.truncate();
+    Build.truncate();
+  });
+
+  afterEach(() => {
+    BuildLog.truncate();
+    Build.truncate();
+  });
+
+  it('fails builds that have been created or tasked for over 10 minutes', async () => {
+    const now = moment();
+
+    const [b1, b2, b3] = await Promise.all([
+      // should be failed
+      factory.build({ state: Created })
+        .then(build => setBuildUpdatedAt(build, now.clone().subtract(11, 'minutes').toDate())),
+      factory.build({ state: Created })
+        .then(build => setBuildUpdatedAt(build, now.clone().subtract(20, 'minutes').toDate())),
+      factory.build({ state: Tasked })
+        .then(build => setBuildUpdatedAt(build, now.clone().subtract(20, 'minutes').toDate())), ,
+
+      // should be ignored
+      factory.build({ state: Created }),
+      factory.build({ state: Tasked }),
+      factory.build({ state: Processing }),
+      factory.build({ state: Processing })
+        .then(build => setBuildUpdatedAt(build, now.clone().subtract(20, 'minutes').toDate())), ,
+      factory.build({ state: Queued })
+        .then(build => setBuildUpdatedAt(build, now.clone().subtract(20, 'minutes').toDate())), ,
+    ]);
+
+    const results = await runFailStuckBuilds();
+    const buildIds = results.map(r => r.id)
+    const logs = await BuildLog.findAll({
+      attributes: ['build', 'source', 'output'],
+      where: {
+        build: {
+          [Op.in]: buildIds
+        }
+      }
+    })
+
+    expect(results.length).to.equal(3);
+    expect(buildIds).to.have.members([b1.id, b2.id, b3.id]);
+    expect(results.map(r => r.state)).to.include('error');
+    expect(logs.map(l => l.source)).to.include('ALL');
+    expect(logs.map(l => l.output)).to.include('An error occurred while trying to build this branch. Please rebuild branch.');
+  });
+
+  it('fails no builds because none have been created or tasked for over 10 minutes', async () => {
+    const builds = await Promise.all([
+      factory.build({ state: Created }),
+      factory.build({ state: Tasked }),
+      factory.build({ state: Processing }),
+      factory.build({ state: Queued }),
+    ]);
+
+    const results = await runFailStuckBuilds();
+
+    expect(results).to.be.equal(null);
+    expect(builds).to.have.length(4)
+  });
+});


### PR DESCRIPTION
Related to https://github.com/cloud-gov/pages-core/issues/4026


## Changes proposed in this pull request:
- Adds queue to fail stuck builds that are in created or tasked for over 10 minutes
- Breaks out the timeout build tasks queue for transparency

## security considerations
None
