### PR TITLE
Add an admin view to see the number of production sites per org

### DIFF
--- a/admin-client/src/Router.svelte
+++ b/admin-client/src/Router.svelte
@@ -66,6 +66,8 @@
   page('/organizations/new', queryString, render(Pages.Organization.New));
   page('/organizations/:id', queryString, render(Pages.Organization.Show));
   page('/organizations/:id/edit', queryString, render(Pages.Organization.Edit));
+  page('/organizations-report', queryString, render(Pages.Organization.Report));
+  page('/reports', queryString, render(Pages.Reports));
   page('*', render(Pages.NotFound));
   page();
 </script>

--- a/admin-client/src/components/Nav.svelte
+++ b/admin-client/src/components/Nav.svelte
@@ -108,6 +108,11 @@
             </a>
           </li>
           <li class="usa-nav__primary-item">
+            <a class="usa-nav__link"  class:usa-current={currentPath === '/reports'} href="/reports">
+              <span>Reports</span>
+            </a>
+          </li>
+          <li class="usa-nav__primary-item">
             <NavButton action={logout}>Logout</NavButton>
           </li>
         {:else}

--- a/admin-client/src/components/PaginatedQueryPage.svelte
+++ b/admin-client/src/components/PaginatedQueryPage.svelte
@@ -10,6 +10,7 @@
   export let path;
   export let query;
   export let addAction = false;
+  export let noSearch = false;
   export let fields = {};
   export let title = null;
   export let expanded = false;
@@ -117,6 +118,7 @@
             </li>
           </ul>
         {/if}
+        {#if ! noSearch}
         <form
           class="usa-search usa-search--small flex-align-center"
           role="search"
@@ -147,6 +149,7 @@
             <span class="usa-sr-only">Search</span>
           </button>
         </form>
+        {/if}
       </nav>
     </div>
     <div class="tag-container usa-nav-container margin-top-1 margin-bottom-2">

--- a/admin-client/src/components/PaginatedQueryPage.svelte
+++ b/admin-client/src/components/PaginatedQueryPage.svelte
@@ -118,7 +118,7 @@
             </li>
           </ul>
         {/if}
-        {#if ! noSearch}
+        {#if !noSearch}
         <form
           class="usa-search usa-search--small flex-align-center"
           role="search"

--- a/admin-client/src/pages/Reports.svelte
+++ b/admin-client/src/pages/Reports.svelte
@@ -1,0 +1,9 @@
+<script>
+  import { GridContainer, PageTitle } from '../components';
+</script>
+<GridContainer>
+  <PageTitle>Reports</PageTitle>
+    <ul>
+      <li><a href="/organizations-report">Organizations With Published Sites</a></li>
+    </ul>
+</GridContainer>

--- a/admin-client/src/pages/index.js
+++ b/admin-client/src/pages/index.js
@@ -4,6 +4,7 @@ export { default as Events } from './Events.svelte';
 export { default as Home } from './Home.svelte';
 export { default as Login } from './Login.svelte';
 export { default as NotFound } from './NotFound.svelte';
+export { default as Reports } from './Reports.svelte';
 export { default as Site } from './Site.svelte';
 export { default as Sites } from './Sites.svelte';
 export * as Domain from './domain';

--- a/admin-client/src/pages/organization/Report.svelte
+++ b/admin-client/src/pages/organization/Report.svelte
@@ -1,0 +1,66 @@
+<script>
+  import { fetchOrganizationsReport, fetchOrganizationsReportCSV } from '../../lib/api';
+  import { PaginatedQueryPage, DataTable } from '../../components';
+
+  async function downloadCSV() {
+    const csv = await fetchOrganizationsReportCSV();
+    const blob = new Blob([csv], { type: 'application/octet-stream' });
+    const aElement = document.createElement('a');
+    aElement.setAttribute('download', 'organization-report.csv');
+    const href = URL.createObjectURL(blob);
+    aElement.href = href;
+    aElement.setAttribute('target', '_blank');
+    aElement.click();
+    URL.revokeObjectURL(href);
+  }
+
+  const fields = {
+    organization: {
+      type: 'select-auto',
+      options: (meta) => meta.orgs.map((org) => ({
+        name: org.name,
+        value: org.id,
+      })),
+    },
+  };
+</script>
+
+<PaginatedQueryPage path="organizations-report" title="Organizations With Published Sites" query={fetchOrganizationsReport} {fields} noSearch let:data>
+  <div>
+    <button type="button" class="usa-button margin-left-1" on:click={downloadCSV}>Download CSV of All Published Sites</button>
+  </div>
+  <DataTable data={data}>
+    <tr slot="header">
+      <th scope="col">Organization</th>
+      <th scope="col">Agency</th>
+      <th scope="col">Site</th>
+      <th scope="col">Domains</th>
+      <th scope="col">Engine</th>
+    </tr>
+    <tr slot="item" let:item={domain}>
+      <td>
+        {#if domain.Site && domain.Site.Organization}
+        <a href="/organizations/{domain.Site.Organization.id}">{domain.Site.Organization.name}</a>
+        {/if}
+      </td>
+      <td>
+        {#if domain.Site && domain.Site.Organization}
+          {domain.Site.Organization.agency}
+        {/if}
+      </td>
+      <td>
+        {#if domain.Site }
+          <a href="/sites/{domain.Site.id}">{domain.Site.repository}</a>
+        {/if}
+      </td>
+      <td>
+        <a href="/domains/{domain.id}">{domain.names}</a>
+      </td>
+      <td>
+        {#if domain.Site }
+          {domain.Site.engine}
+        {/if}
+      </td>
+    </tr>
+  </DataTable>
+</PaginatedQueryPage>

--- a/admin-client/src/pages/organization/index.js
+++ b/admin-client/src/pages/organization/index.js
@@ -2,3 +2,4 @@ export { default as Edit } from './Edit.svelte';
 export { default as New } from './New.svelte';
 export { default as Index } from './Index.svelte';
 export { default as Show } from './Show.svelte';
+export { default as Report } from './Report.svelte';

--- a/api/admin/routers/api.js
+++ b/api/admin/routers/api.js
@@ -35,6 +35,8 @@ apiRouter.put('/organizations/:id', AdminControllers.Organization.update);
 apiRouter.post('/organizations/:id/deactivate', authorize(['pages.admin']), AdminControllers.Organization.deactivate);
 apiRouter.post('/organizations/:id/activate', AdminControllers.Organization.activate);
 apiRouter.delete('/organization/:org_id/user/:user_id', authorize(['pages.admin']), AdminControllers.OrganizationRole.destroy);
+apiRouter.get('/organizations-report', AdminControllers.Domain.listPublished);
+apiRouter.get('/organizations-report.csv', AdminControllers.Domain.listPublishedCSV);
 apiRouter.put('/organization-role', AdminControllers.OrganizationRole.update);
 apiRouter.get('/roles', AdminControllers.Role.list);
 apiRouter.get('/sites', AdminControllers.Site.list);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "keywords": [],
   "dependencies": {
     "@bull-board/express": "4.11.3",
+    "@json2csv/plainjs": "^7.0.1",
     "@octokit/request": "^6.2.2",
     "@octokit/rest": "^18.5.2",
     "@socket.io/redis-adapter": "^7.0.0",
@@ -37,6 +38,7 @@
     "js-file-download": "^0.4.11",
     "js-yaml": "^4.1.0",
     "json-to-csv": "^1.0.0",
+    "json2csv": "juanjoDiaz/json2csv#v7.0.1",
     "jsonwebtoken": "^8.5.1",
     "moment": "^2.29.2",
     "newrelic": "^8.13.2",

--- a/scripts/create-dev-data.js
+++ b/scripts/create-dev-data.js
@@ -103,9 +103,11 @@ async function createData() {
    *              Organizations
    */
   console.log('Creating Organizations');
-  const [agency1, agency2, sandbox] = await Promise.all([
+  const [agency1, agency2, agency3, agency4, sandbox] = await Promise.all([
     Organization.create({ name: 'agency1', agency: 'GSA' }),
     Organization.create({ name: 'agency2', agency: 'GSA' }),
+    Organization.create({ name: 'agency3', agency: 'Bureau of Testing' }),
+    Organization.create({ name: 'agency4', agency: 'Demonstration Department' }),
     Organization.create({ name: 'user1@example.com', isSandbox: true }),
   ]);
 
@@ -116,6 +118,8 @@ async function createData() {
   const [
     user1,
     user2,
+    user3,
+    user4,
     userOrgless,
     managerNoGithub,
     managerWithGithub,
@@ -152,6 +156,26 @@ async function createData() {
       })
       .then(createUAAIdentity)
       .then(user => addUserToOrg(user, agency1, userRole)),
+
+    User
+      .create({
+        username: 'user3',
+        email: 'user3@example.com',
+        githubAccessToken: 'access-token',
+        githubUserId: 123456,
+      })
+      .then(createUAAIdentity)
+      .then(user => addUserToOrg(user, agency3, userRole)),
+
+    User
+      .create({
+        username: 'user4',
+        email: 'user4@example.com',
+        githubAccessToken: 'access-token',
+        githubUserId: 123456,
+      })
+      .then(createUAAIdentity)
+      .then(user => addUserToOrg(user, agency4, userRole)),
 
     User
       .create({
@@ -229,7 +253,7 @@ async function createData() {
    *                 Sites
    */
   console.log('Creating sites...');
-  const [site1, nodeSite, goSite] = await Promise.all([
+  const [site1, nodeSite, goSite, goSite2, nodeSite2, orglessSite] = await Promise.all([
     siteFactory({
       demoBranch: 'demo-branch',
       demoDomain: 'https://demo.example.gov',
@@ -256,6 +280,33 @@ async function createData() {
       users: [user1, user2, managerNoGithub],
     })
       .then(site => addSiteToOrg(site, agency2)),
+
+    siteFactory({
+      engine: 'hugo',
+      owner: user3.username,
+      repository: 'another-example-hugo-site',
+      users: [user3, managerWithGithub],
+      demoBranch: 'demo3',
+    })
+      .then(site => addSiteToOrg(site, agency3)),
+
+    siteFactory({
+      engine: 'node.js',
+      owner: user4.username,
+      repository: 'another-example-node-site',
+      users: [user4, managerWithGithub],
+      demoBranch: 'demo4',
+    })
+      .then(site => addSiteToOrg(site, agency4)),
+
+    siteFactory({
+      engine: 'node.js',
+      owner: userOrgless.username,
+      repository: 'an-orgless-node-site',
+      users: [userOrgless, managerWithGithub],
+      demoBranch: 'demo5',
+    }),
+
   ]);
 
   await site1.createUserEnvironmentVariable({
@@ -464,6 +515,43 @@ async function createData() {
       serviceName: 'foo.example.gov-ext',
       state: 'provisioned',
     }),
+    Domain.create({
+      context: 'site',
+      names: 'bar.example.gov',
+      siteId: goSite2.id,
+      origin: 'bar-foo-baz.app.cloud.gov',
+      path: `/site/${nodeSite.owner}/${nodeSite.repository}`,
+      serviceName: 'bar.example.gov-ext',
+      state: 'provisioned',
+    }),
+    Domain.create({
+      context: 'site',
+      names: 'qux.example.gov',
+      siteId: nodeSite2.id,
+      origin: 'quz-baz-bar.app.cloud.gov',
+      path: `/site/${nodeSite2.owner}/${nodeSite2.repository}`,
+      serviceName: 'qux.example.gov-ext',
+      state: 'provisioned',
+    }),
+    Domain.create({
+      context: 'site',
+      names: 'vanity.qux.example.gov',
+      siteId: nodeSite2.id,
+      origin: 'quz-baz-bar.app.cloud.gov',
+      path: `/site/${nodeSite2.owner}/${nodeSite2.repository}`,
+      serviceName: 'vanity.qux.example.gov-ext',
+      state: 'provisioned',
+    }),
+    Domain.create({
+      context: 'site',
+      names: 'orgless.example.gov',
+      siteId: orglessSite.id,
+      origin: 'orgless.app.cloud.gov',
+      path: `/site/${orglessSite.owner}/${orglessSite.repository}`,
+      serviceName: 'orgless.example.gov-ext',
+      state: 'provisioned',
+    }),
+
   ]);
 }
 

--- a/test/api/admin/requests/domain.test.js
+++ b/test/api/admin/requests/domain.test.js
@@ -1,0 +1,87 @@
+const request = require('supertest');
+const { expect } = require('chai');
+
+const { authenticatedSession } = require('../../support/session');
+const factory = require('../../support/factory');
+
+const config = require('../../../../config');
+const { Domain, Site, User, Organization } = require('../../../../api/models');
+const sessionConfig = require('../../../../api/admin/sessionConfig');
+const app = require('../../../../api/admin');
+
+describe('Admin - Domains API', () => {
+  afterEach(() => Promise.all([
+    User.truncate(),
+    Domain.truncate(),
+    Site.truncate(),
+    Organization.truncate(),
+  ]));
+
+  describe('GET /admin/organizations-report', () => {
+    it('should require admin authentication', async () => {
+      const response = await request(app)['get']('/organizations-report').expect(401);
+      expect(response.body.message).to.equal('Unauthorized');
+    });
+
+    it('returns all published sites with their organizations and domains', async () => {
+      const user = await factory.user();
+
+      const org = await factory.organization.create();
+      const site = await factory.site({organizationId: org.id });
+      const domain = await factory.domain.create({ siteId: site.id, state: "provisioned" });
+
+      const orglessSite = await factory.site();
+      const orglessDomain = await factory.domain.create({ siteId: orglessSite.id, state: "provisioned" });
+
+      const cookie = await authenticatedSession(user, sessionConfig);
+      const { body } = await request(app)
+        .get('/organizations-report')
+        .set('Cookie', cookie)
+        .set('Origin', config.app.adminHostname)
+        .expect(200);
+
+      expect(body.data.length).to.equal(2);
+      expect(body.data[0]['id']).to.equal(domain.id);
+      expect(body.data[0]['Site']['id']).to.equal(site.id);
+      expect(body.data[0]['Site']['Organization']['id']).to.equal(org.id);
+
+      expect(body.data[1]['id']).to.equal(orglessDomain.id);
+      expect(body.data[1]['Site']['id']).to.equal(orglessSite.id);
+      expect(body.data[1]['Site']['Organization']).to.be.undefined;
+    });
+  });
+
+  describe('GET /admin/organizations-report.csv', () => {
+    it('should require admin authentication', async () => {
+      const response = await request(app)['get']('/organizations-report.csv').expect(401);
+      expect(response.body.message).to.equal('Unauthorized');
+    });
+
+    it('returns all published sites with their organizations and domains', async () => {
+      const user = await factory.user();
+
+      const org = await factory.organization.create({name: 'Test Org', agency: 'Test Agency'});
+      const site = await factory.site({organizationId: org.id });
+      const domain = await factory.domain.create({ siteId: site.id, state: "provisioned" });
+
+      const orglessSite = await factory.site();
+      const orglessDomain = await factory.domain.create({ siteId: orglessSite.id, state: "provisioned" });
+
+      const cookie = await authenticatedSession(user, sessionConfig);
+      const response  = await request(app)
+        .get('/organizations-report.csv')
+        .set('Cookie', cookie)
+        .set('Origin', config.app.adminHostname)
+        .expect(200);
+      expect(response.headers["content-type"]).to.equal('text/csv; charset=utf-8');
+      expect(response.headers["content-disposition"]).to.equal('attachment; filename="organizations-report.csv"');
+      [header,...data] = response.text.split(/\n/);
+      expect(header).to.equal('"Organization","Agency","Site","Domain","Engine"');
+      expect(data.length).to.equal(2);
+      expect(data[0]).to.equal(`"${org.name}","${org.agency}","${site.repository}","${domain.names}","${site.engine}"`);
+      expect(data[1]).to.equal(`,,"${orglessSite.repository}","${orglessDomain.names}","${orglessSite.engine}"`);
+    });
+  });
+
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,6 +1166,20 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@json2csv/formatters@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@json2csv/formatters/-/formatters-7.0.1.tgz#c025f0795f9bbab480de77e2248ab593987296b9"
+  integrity sha512-eCmYKIIoFDXUB0Fotet2RmcoFTtNLXLmSV7j6aEQH/D2GiO749Uan3ts03PtAhXpE11QghxBjS0toXom8VQNBw==
+
+"@json2csv/plainjs@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@json2csv/plainjs/-/plainjs-7.0.1.tgz#361d849f04a2a5013c7880738f08b6bc193c24eb"
+  integrity sha512-UAdaZwahrUeYhMYYilJwDsRfE7wDRsmGMsszYH67j8FLD5gZitqG38RXpUgHEH0s6YjsY8iKYWeEQ19WILncFA==
+  dependencies:
+    "@json2csv/formatters" "^7.0.1"
+    "@streamparser/json" "^0.0.15"
+    lodash.get "^4.4.2"
+
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
@@ -1503,6 +1517,11 @@
     notepack.io "~2.2.0"
     socket.io-adapter "^2.4.0"
     uid2 "0.0.3"
+
+"@streamparser/json@^0.0.15":
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/@streamparser/json/-/json-0.0.15.tgz#405fbe94877ce0cbd3cf650b4d9186a0ec6acd0a"
+  integrity sha512-6oikjkMTYAHGqKmcC9leE4+kY4Ch4eiTImXUN/N4d2bNGBYs0LJ/tfxmpvF5eExSU7iiPlV9jYlADqvj3NWA3Q==
 
 "@supercharge/promise-pool@^1.5.0":
   version "1.9.0"
@@ -6247,6 +6266,10 @@ json2csv@^3.4.2:
     lodash.set "^4.3.0"
     lodash.uniq "^4.5.0"
     path-is-absolute "^1.0.0"
+
+json2csv@juanjoDiaz/json2csv#v7.0.1:
+  version "7.0.1"
+  resolved "https://codeload.github.com/juanjoDiaz/json2csv/tar.gz/b43c7dd556b7afc9728ecc31ccc96c8c76056f09"
 
 json5@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This pull request addresses #4118 

## Changes proposed in this pull request:
- Adds an option to PaginatedQueryPage to omit the search form
- Adds API endpoint `/organizations-report` which returns a list of all production sites by organization.
- Adds API endpoint `/organizations-report.csv` which returns the same results in CSV format.
- Adds admin client page `/organizations-report` which presents the list returned from the new API endpoint.
- Implements filtering the admin report view by organization
- Implements downloading the full CSV from the admin report view
- Adds admin client page and nav item `/reports` which establishes a home for this and future admin reports

## security considerations
None. The data presented is only available to authenticated admin/support users, and only represents data already available to those users.
