### PR TITLE
fix: Specify Node 18.15 instead of 18 to resolve pipeline failures.

### DIFF
--- a/Dockerfile-app
+++ b/Dockerfile-app
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:18.15
 
 WORKDIR /app
 

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   app:
-    image: node:18
+    image: node:18.15
     volumes:
       - ../..:/app
     depends_on:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -13,7 +13,7 @@ node-image: &node-image
   type: docker-image
   source:
     repository: node
-    tag: 18
+    tag: 18.15
 
 cf-image: &cf-image
   platform: linux
@@ -595,7 +595,7 @@ resources:
     type: docker-image
     source:
       repository: node
-      tag: 18
+      tag: 18.15
 
   - name: slack
     type: slack-notification


### PR DESCRIPTION
This PR addresses #4152, which @drewbo suggested is probably caused by https://github.com/nodejs/node/issues/43064 

## Changes proposed in this pull request:
- Specify Node image tag `18.15` instead of `18` 

## security considerations
This specifies a more specific minor version consistent with what was previously being used for builds. Instead of getting a newer minor version of Node 18 we are pinned to a specific minor version, which is an important detail, but not a problem at this time.