### PR TITLE
fix: Remove spurious menu button from paginated admin views.

### DIFF
--- a/admin-client/src/components/PaginatedQueryPage.svelte
+++ b/admin-client/src/components/PaginatedQueryPage.svelte
@@ -61,7 +61,6 @@
             +
           </a>
         {/if}
-        <button class="usa-menu-btn">Menu</button>
       </div>
       <nav class="usa-nav">
         <button class="usa-nav__close">


### PR DESCRIPTION
Addresses #4153

### Dev screenshot showing that this is all better:
![image](https://github.com/cloud-gov/pages-core/assets/12150/6377e2ea-a7f9-41b4-88ed-24d0eb87e3d9)

## Changes proposed in this pull request:
- Removes spurious "Menu" button from PaginatedQueryPage component used in admin views

## security considerations
None 
