### PR TITLE
Fix organization scope on Build model.

### DIFF
--- a/api/models/build.js
+++ b/api/models/build.js
@@ -42,8 +42,10 @@ const associate = ({
   Build.addScope('byOrg', id => ({
     include: [{
       model: Site,
+      required: true,
       include: [{
         model: Organization,
+        required: true,
         where: { id },
       }],
     }],

--- a/test/api/unit/models/build.test.js
+++ b/test/api/unit/models/build.test.js
@@ -350,6 +350,30 @@ describe('Build model', () => {
     });
   });
 
+  describe('.orgScope()', () => {
+    it('returns builds by organization', async () => {
+      const organizationA = await factory.organization.create({name: 'Org A'});
+      const siteA = await factory.site({organizationId: organizationA.id });
+      const buildA1 = await factory.build({site: siteA.id});
+      const buildA2 = await factory.build({site: siteA.id});
+
+      const siteAA = await factory.site({organizationId: organizationA.id });
+      const buildAA = await factory.build({site: siteAA.id});
+
+      const organizationB = await factory.organization.create({name: 'Org B'});
+      const siteB = await factory.site({organizationId: organizationB.id });
+      const buildB = await factory.build({site: siteB.id});
+
+      const siteD = await factory.site(); // Site without an Organization
+      const buildD = await factory.build({site: siteD.id});
+
+      const result = await Build.scope(Build.orgScope(organizationA.id)).findAll();
+
+      expect(result.map(build => build.id)).to.have.members([buildA1.id, buildA2.id, buildAA.id]);
+      expect(result.map(build => build.id)).to.not.have.members([buildB.id, buildD.id]);
+    });
+  });
+
   describe('forSiteUser scope', () => {
     it('returns the build for the associated user', async () => {
       const user = await factory.user();


### PR DESCRIPTION
This addresses #4155 

I based the Domain organization scope in #4145 on the existing one on the Build model and in unit testing I discovered the existing approach does not work as intended. 

When a scope matches on a nested association using this approach:
```
include: [{
  model: AssociatedModel,
  include: [{
    model: NestedAssociatedModel,
    where: { id },
  }],
}],
```
it returns both those instances of the model where the nested associated model matches on `id` _and_ those instances where it does not — for the latter case simply omitting the columns of both the nested and the directly associated model. 

It is not enough simply to add `required: true` on the nested associated model like
```
include: [{
  model: Site,
  include: [{
    model: Organization,
    required: true,
    where: { id },
  }],
}],
```

A `required: true` must be declared on the directly associated model as well:
```
include: [{
  model: Site,
  required: true,
  include: [{
    model: Organization,
    required: true,
    where: { id },
  }],
}],
```

I believe no code calls the Build organization scope at this time — including, prior to this PR, any test code. 

## Changes proposed in this pull request:
- Add a unit test for the Build organization scope which shows the bug in the absence of the new
- Fix to the organization scope on the Build model

## security considerations
None. This fixes a lurking bug in code that is not yet being called.