### PR TITLE
Remove js-file-download dependency.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,18 @@ const finalRules = {
   'sonarjs/no-identical-functions': [0],
 };
 
+const overrides = [
+  {
+    files: ["frontend/components/site/downloadBuildLogsButton.jsx"],
+    env: {
+      'browser': true,
+      'node': true
+    },
+  },
+];
+
 module.exports = {
+  overrides,
   extends: ['airbnb', 'plugin:sonarjs/recommended', 'plugin:no-unsanitized/DOM'],
   rules: finalRules,
   parserOptions: {

--- a/frontend/components/site/downloadBuildLogsButton.jsx
+++ b/frontend/components/site/downloadBuildLogsButton.jsx
@@ -2,13 +2,19 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import fileDownload from 'js-file-download';
 
 function DownloadBuildLogsButton(props) {
   function downloadBuildLogs() {
     const { buildLogsData = [], buildId } = props;
     const text = buildLogsData.map(source => `${source}\n`);
-    fileDownload(text, `build-log-${buildId}.txt`);
+    const blob = new Blob([text], { type: 'text/plain' });
+    const aElement = document.createElement('a');
+    aElement.setAttribute('download', `build-log-${buildId}.txt`);
+    const href = URL.createObjectURL(blob);
+    aElement.href = href;
+    aElement.setAttribute('target', '_blank');
+    aElement.click();
+    URL.revokeObjectURL(href);
   }
 
   return (

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "helmet": "^4.6.0",
     "inflection": "^1.13.1",
     "ioredis": "^4.27.6",
-    "js-file-download": "^0.4.11",
     "js-yaml": "^4.1.0",
     "json-to-csv": "^1.0.0",
     "json2csv": "juanjoDiaz/json2csv#v7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6123,11 +6123,6 @@ jmespath@0.16.0:
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
   integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
 
-js-file-download@^0.4.11:
-  version "0.4.12"
-  resolved "https://registry.yarnpkg.com/js-file-download/-/js-file-download-0.4.12.tgz#10c70ef362559a5b23cdbdc3bd6f399c3d91d821"
-  integrity sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg==
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
Fixes #4158

## Changes proposed in this pull request:
- Remove `js-file-download` dependency from build log download button, and thereby the entire project.
- Establish central ESLint config to clean up linting approach in front end files. This will subsequently be utilized in addressing #4163.

## Testing
As a user, log into Pages and view build logs for a site that has them (e.g. in the local dev environment, `user1/example-node-site`'s `main`). The "Download the logs" button should function as it does in production, generating and downloading a `txt` file containing the build log data.

## security considerations
None. This removes a dependency, replacing it with code that takes advantage of a modern browser feature. 
