### PR TITLE
Move globals from frontend source files into ESLint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,7 @@ const finalRules = {
 
 const overrides = [
   {
-    files: ["frontend/components/site/downloadBuildLogsButton.jsx"],
+    files: ["frontend/**/*"],
     env: {
       'browser': true,
       'node': true

--- a/frontend/actions/organizationActions.js
+++ b/frontend/actions/organizationActions.js
@@ -1,5 +1,3 @@
-/* global window:true */
-
 import federalist from '../util/federalistApi';
 import alertActions from './alertActions';
 import { dispatch } from '../store';

--- a/frontend/actions/siteActions.js
+++ b/frontend/actions/siteActions.js
@@ -1,5 +1,3 @@
-/* global window:true */
-
 import federalist from '../util/federalistApi';
 import alertActions from './alertActions';
 

--- a/frontend/actions/userActions.js
+++ b/frontend/actions/userActions.js
@@ -1,5 +1,3 @@
-/* global window:true */
-
 import federalist from '../util/federalistApi';
 import alertActions from './alertActions';
 import { dispatch } from '../store';

--- a/frontend/actions/userEnvironmentVariableActions.js
+++ b/frontend/actions/userEnvironmentVariableActions.js
@@ -1,4 +1,3 @@
-/* global window:true */
 import federalist from '../util/federalistApi';
 import { httpError } from './actionCreators/alertActions';
 import {

--- a/frontend/components/GithubAuthButton.jsx
+++ b/frontend/components/GithubAuthButton.jsx
@@ -1,4 +1,3 @@
-/* global window */
 import React from 'react';
 import PropTypes from 'prop-types';
 

--- a/frontend/components/organization/Edit.jsx
+++ b/frontend/components/organization/Edit.jsx
@@ -1,4 +1,3 @@
-/* global window */
 import React, { useEffect, useReducer } from 'react';
 import { useParams } from 'react-router-dom';
 import { success } from 'react-notification-system-redux';

--- a/frontend/components/site/SiteSettings/index.jsx
+++ b/frontend/components/site/SiteSettings/index.jsx
@@ -1,4 +1,3 @@
-/* global window:true */
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { useParams, useNavigate } from 'react-router-dom';

--- a/frontend/main.jsx
+++ b/frontend/main.jsx
@@ -1,5 +1,3 @@
-/* global document:true */
-
 import '@babel/polyfill';
 import { createRoot } from 'react-dom/client';
 import React from 'react';

--- a/frontend/store.js
+++ b/frontend/store.js
@@ -1,4 +1,3 @@
-/* global window */
 import {
   combineReducers, compose, createStore, applyMiddleware,
 } from 'redux';

--- a/frontend/util/federalistApi.js
+++ b/frontend/util/federalistApi.js
@@ -1,5 +1,3 @@
-/* global window:true */
-
 import fetch from './fetch';
 import alertActions from '../actions/alertActions';
 


### PR DESCRIPTION
Fixes #4163 

## Changes proposed in this pull request:
- Expand scope of ESLint `browser`/`node` override from `downloadBuildLogsButton.jsx` to `frontend/**/*`
- Remove ESLint globals for `document` and `window` from ten frontend source files

## security considerations
None. This simplifies and centralizes and approach to frontend linting configuration and does not affect running code.
