### PR TITLE
Replaces Federalist logo with Pages logo on Pages Admin header

### DIFF
--- a/admin-client/src/components/Nav.svelte
+++ b/admin-client/src/components/Nav.svelte
@@ -36,14 +36,18 @@
   }
 
   .usa-logo a {
-    background-image: url("/images/logo.svg");
-    background-position: center;
+    background-image: url("/images/pages-logo.svg");
+    background-position: left;
     background-repeat: no-repeat;
-    background-size: contain;
-    color: transparent;
+    background-size: 20px;
+    color: white;
     display: inline-block;
     height: auto;
     text-decoration: none;
+    padding-left: 26px;
+    font-weight: 400;
+    font-size: 20px;
+    line-height: 47px;
   }
 </style>
 
@@ -61,7 +65,7 @@
             href="/"
             title="Home"
             aria-label="Home">
-            Pages
+            Pages Admin
           </a>
         </em>
       </div>


### PR DESCRIPTION
Fixes #4186 

## Changes proposed in this pull request:
- Uses Pages logo instead of Federalist logo in Admin header

Before: 
<img width="144" alt="image" src="https://github.com/cloud-gov/pages-core/assets/12150/dd77500b-939e-4c5b-b62e-dafc326d34ed">

After: 
<img width="162" alt="image" src="https://github.com/cloud-gov/pages-core/assets/12150/ed7b9ce2-601f-409e-a544-8f06c9b30549">

## security considerations
None. Adjusts header content and styling, not functionality.
