### PR TITLE
chore: automate changelog creation on release

### DIFF
--- a/.cz.json
+++ b/.cz.json
@@ -1,0 +1,47 @@
+{
+  "commitizen": {
+    "name": "cz_customize",
+    "version_scheme": "semver",
+    "version_provider": "npm",
+    "update_changelog_on_bump": true,
+    "major_version_zero": false,
+    "bump_message": "chore: release $new_version",
+    "gpg_sign": true,
+    "changelog_incremental": true,
+    "customize": {
+      "message_template": "{{change_type}}:{% if show_message %} {{message}}{% endif %}",
+      "example": "feat: this feature enable customize through config file",
+      "schema": "<type>: <body>",
+      "schema_pattern": "^((build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w \\-'])+([\\s\\S]*))|Merge.*",
+      "bump_pattern": "^(.+!|BREAKING CHANGE|chore|docs|feat|fix|perf|refactor|revert|style|test):",
+      "bump_map": {
+          ".+!": "MAJOR",
+          "BREAKING CHANGE": "MAJOR",
+          "feat": "MINOR",
+          "fix": "PATCH",
+          "chore": "PATCH",
+          "docs": "PATCH",
+          "perf": "PATCH",
+          "refactor": "PATCH",
+          "revert": "MINOR",
+          "style": "PATCH",
+          "test": "PATCH"
+      },
+      "change_type_order": ["Breaking Changes", "Added", "Fixed", "Performance", "Reverted", "Maintenance", "Documentation"],
+      "commit_parser": "^((?P<change_type>chore|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE)(?:\\((?P<scope>[^()\r\n]*)\\)|\\()?(?P<breaking>!)?|\\w+!):\\s(?P<message>.*)?",
+      "changelog_pattern": "^(.+!|BREAKING CHANGE|chore|docs|feat|fix|perf|refactor|revert|style|test):",
+      "change_type_map": {
+        "BREAKING CHANGE": "Breaking Changes",
+        "chore": "Maintenance",
+        "docs": "Documentation",
+        "feat": "Added",
+        "fix": "Fixed",
+        "perf": "Performance",
+        "refactor": "Maintenance",
+        "revert": "Reverted",
+        "style": "Maintenance",
+        "test": "Maintenance"
+      }
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.0 (2023-07-19)
+
+Work done prior to the release schedule

--- a/ci/pipeline-release-deploy.yml
+++ b/ci/pipeline-release-deploy.yml
@@ -1,0 +1,59 @@
+############################
+#  SHARED
+
+cf-image: &cf-image
+  platform: linux
+  image_resource:
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr-aws-key))
+      aws_secret_access_key: ((ecr-aws-secret))
+      repository: harden-concourse-task
+      aws_region: us-gov-west-1
+      tag: ((harden-concourse-task-tag))
+
+jobs:
+- name: configure-pipeline
+  plan:
+  - get: src
+    trigger: true
+    params: {depth: 1}
+  - set_pipeline: self
+    file: src/ci/pipeline-release-deploy.yml
+    instance_vars:
+        deploy-env: release
+        git-branch: ((git-branch))
+        product: ((product))
+
+- name: update-release-branch
+  plan:
+  - get: src
+    trigger: true
+  - task: update-release-branch
+    config:
+      <<: *cf-image
+      inputs:
+        - name: src
+      params:
+        GH_EMAIL: ((pages-operations-github-user-info.email))
+        GH_USERNAME: ((pages-operations-github-user-info.username))
+        GH_BOT_GPG_KEY: ((pages-operations-github-user-gpg.private_key))
+        GH_BOT_SSH_KEY: ((pages-gpg-operations-github-sshkey.private_key))
+        GH_BOT_GPG_TRUST: ((pages-operations-github-user-gpg-trust))
+        GH_TOKEN: ((pages-operations-ci-github-token))
+      run:
+        dir: src
+        path: ci/tasks/update-release-branch.sh
+
+############################
+#  RESOURCES
+
+resources:
+  - name: src
+    type: git
+    icon: github
+    source:
+      uri: git@github.com:cloud-gov/pages-core.git
+      branch: ((git-branch))
+      commit_verification_keys: ((cloud-gov-pages-gpg-keys))
+      private_key: ((pages-gpg-operations-github-sshkey.private_key))

--- a/ci/tasks/update-release-branch.sh
+++ b/ci/tasks/update-release-branch.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# SSH setup
+echo "$GH_BOT_SSH_KEY" > ssh.key
+chmod 600 ssh.key
+eval "$(ssh-agent -s)"
+ssh-add ssh.key
+mkdir ~/.ssh
+ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+# GPG setup
+echo "$GH_BOT_GPG_KEY" > private.key
+gpg --import private.key
+echo "$GH_BOT_GPG_TRUST" > trustdb
+gpg --import-ownertrust trustdb
+
+# git setup
+git config user.email $GH_EMAIL
+git config user.name $GH_USERNAME
+git config commit.gpgSign true
+git checkout -b release
+
+# install GH cli
+type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+&& sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+&& sudo apt update \
+&& sudo apt install gh -y
+gh config set prompt disabled
+
+# install and run commitizen: https://commitizen-tools.github.io/commitizen/
+export PATH="/root/.local/bin:$PATH"
+pip install --user -U Commitizen
+release_body=`cz bump --dry-run --changelog`
+cz bump --yes
+bump_status=$?
+
+# if we have a bump, commit, update/create PR
+if [[ $bump_status -eq 0 ]]
+then
+  commit_msg=`git log -1 --pretty=%B`
+  git push origin release --force --tags
+  gh pr view release
+  pr_status=$?
+  if [[ $pr_status -eq 0 ]]
+  then
+    gh pr edit \
+    --title "$commit_msg" \
+    --body "## :robot: This is an automated release PR
+$release_body
+## security considerations
+Noted in individual PRs
+"
+  else
+    gh pr create \
+    --title "$commit_msg" \
+    --body "## :robot: This is an automated release PR
+$release_body
+## security considerations
+Noted in individual PRs
+" \
+    --base main \
+    --head release
+  fi
+else
+  echo "no update to the release"
+fi


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds a new pipeline which does the following:
  - Checks out `main`
  - Tries to run [commitizen](https://commitizen-tools.github.io/commitizen/), specifically `cz bump` which automatically increases the version, based on the commits since the last version.
  - If this succeeds, creates/updates the `release` branch and a corresponding PR
- This PR only completes the first half of the work described in https://github.com/cloud-gov/product/issues/2563 (creating the release PR), the next step will be having our production deployments trigger only on tags and include a github release

## security considerations
Concourse uses a Github bot (and associated credentials) to make release commits to this repo
