### PR TITLE
chore: release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 0.1.0 (2023-08-02)
+
+### Added
+
+- Restructure site model with site branch config relation
+- Add report of published sites per org and Reports admin menu item.
+- Enable omission of search form in PaginatedQueryPage.
+
+### Fixed
+
+- Pages logo replaces Federalist logo in Pages Admin header (#4186)
+- Remove dependencies on json-to-csv and abandoned json2csv version
+- Move globals from frontend source files into ESLint config.
+- Remove js-file-download dependency.
+
+### Maintenance
+
+- fix minor issues in release pipeline, gh status checks (#4162)
+- create new production deployment on tag
+- add automated release PRs
+- Add nightly builds queue to bull board #4198
+- Update nightly builds queue query #4198
+- document use of conventional commits
+
 ## 0.0.0 (2023-07-19)
 
 Work done prior to the release schedule

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pages-core",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "",
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
## :robot: This is an automated release PR
chore: release 0.1.0
tag to create: 0.1.0
increment detected: MINOR

## 0.1.0 (2023-08-02)

### Added

- Restructure site model with site branch config relation
- Add report of published sites per org and Reports admin menu item.
- Enable omission of search form in PaginatedQueryPage.

### Fixed

- Pages logo replaces Federalist logo in Pages Admin header (#4186)
- Remove dependencies on json-to-csv and abandoned json2csv version
- Move globals from frontend source files into ESLint config.
- Remove js-file-download dependency.

### Maintenance

- fix minor issues in release pipeline, gh status checks (#4162)
- create new production deployment on tag
- add automated release PRs
- Add nightly builds queue to bull board #4198
- Update nightly builds queue query #4198
- document use of conventional commits
## security considerations
Noted in individual PRs
