### PR TITLE
Build dev/test webpack assets in non-version-controlled directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "scripts": {
     "build": "webpack --config webpack.production.config.js",
+    "build:test": "webpack --config webpack.test.config.js",
     "start": "node index.js",
     "start-workers": "node ./api/workers/index.js",
     "start-bull-board:cg": "node -r ./api/bull-board/cfEnv.js ./api/bull-board/index.js",
@@ -73,7 +74,7 @@
     "test": "yarn test:prepare && yarn test:server && yarn test:client",
     "test:cleandb": "NODE_ENV=test node migrate.js reset",
     "test:cover": "yarn test:prepare && yarn test:server:cover && yarn test:client:cover",
-    "test:prepare": "NODE_ENV=test yarn migrate:up && NODE_ENV=production yarn build",
+    "test:prepare": "NODE_ENV=test yarn migrate:up && yarn build:test",
     "test:server": "NODE_ENV=test JWT_SECRET=shh USER_AUDITOR=user_auditor mocha --exit --timeout 2500 --recursive ./test/api",
     "test:client": "NODE_ENV=test mocha --exit --require @babel/register test/frontend/_mochaSetup.js --recursive \"./test/frontend/**/*.{js,jsx}\"",
     "test:server:cover": "NODE_ENV=test JWT_SECRET=shh USER_AUDITOR=user_auditor nyc --report-dir ./coverage/server mocha --exit --timeout 2500 --recursive ./test/api",

--- a/test/api/requests/main.test.js
+++ b/test/api/requests/main.test.js
@@ -128,10 +128,10 @@ describe('Main Site', () => {
           .set('Cookie', cookie)
           .expect(200))
         .then((response) => {
-          const stylesBundleRe = /<link rel="stylesheet" href="\/styles\/styles\.[a-z0-9]*\.css">/;
+          const stylesBundleRe = /<link rel="stylesheet" href="\/\/dist\/styles\/styles\.css">/;
           expect(response.text.search(stylesBundleRe)).to.be.above(-1);
 
-          const jsBundleRe = /<script src="\/js\/bundle\.[a-z0-9]*\.js"><\/script>/;
+          const jsBundleRe = /<script src="\/\/dist\/js\/bundle\.js"><\/script>/;
           expect(response.text.search(jsBundleRe)).to.be.above(-1);
           done();
         })

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -1,0 +1,118 @@
+const path = require('path');
+const webpack = require('webpack');
+const autoprefixer = require('autoprefixer');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
+const { getFeatureFlags } = require('./webpack-utils');
+
+const RESOURCE_GENERATOR = {
+  filename: 'images/[contenthash][ext]',
+  publicPath: '/',
+};
+
+const config = {
+  mode: 'production',
+  entry: './frontend/main.jsx',
+  output: {
+    filename: 'js/bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+    publicPath: '/dist/',
+  },
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /(node_modules|bower_components|public\/)/,
+        loader: 'babel-loader',
+      },
+      {
+        test: /\.scss$/,
+        use: [
+          MiniCssExtractPlugin.loader,
+          {
+            loader: 'css-loader',
+            options: {
+              url: url => !url.includes('images'),
+            },
+          },
+          {
+            loader: 'postcss-loader',
+            options: {
+              sourceMap: process.env.NODE_ENV === 'development',
+              postcssOptions: {
+                plugins: [autoprefixer],
+              },
+            },
+          },
+          {
+            loader: 'sass-loader',
+            options: {
+              sassOptions: {
+                quietDeps: true,
+                loadPath: path.resolve(__dirname, 'node_modules/uswds/src/stylesheets/'),
+              },
+            },
+          },
+        ],
+      },
+      {
+        test: /\.(gif|png|jpe?g|ttf|woff2?|eot)$/i,
+        type: 'asset/resource',
+        generator: RESOURCE_GENERATOR,
+      },
+      {
+        test: /\.svg$/i,
+        oneOf: [
+          {
+            // For .svg files in public/images/icons/, use the react-svg loader
+            // so that they can be loaded as React components
+            include: path.resolve(__dirname, 'public/images/icons'),
+            use: [
+              'babel-loader',
+              {
+                loader: 'react-svg-loader',
+                options: {
+                  svgo: {
+                    plugins: [{ removeViewBox: false }],
+                  },
+                },
+              },
+            ],
+          },
+          {
+            // For all other .svg files, fallback to asset/resource
+            type: 'asset/resource',
+            generator: RESOURCE_GENERATOR,
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [
+    // Make sure this is the first plugin!!!
+    new MiniCssExtractPlugin({ filename: `styles/styles${process.env.NODE_ENV === 'production' ? '.[contenthash]' : ''}.css` }),
+    // When webpack bundles moment, it includes all of its locale files,
+    // which we don't need, so we'll use this plugin to keep them out of the
+    // bundle
+    new webpack.IgnorePlugin({ resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ }),
+    new WebpackManifestPlugin({
+      fileName: '../webpack-manifest.json',
+      publicPath: '/dist/',
+    }),
+    new webpack.EnvironmentPlugin([
+      ...getFeatureFlags(process.env),
+      'APP_HOSTNAME',
+      'PRODUCT',
+    ]),
+  ],
+};
+
+if (process.env.NODE_ENV === 'development') {
+  config.devtool = 'inline-source-map';
+  config.stats = 'minimal';
+}
+
+module.exports = config;


### PR DESCRIPTION
Fixes #4191

## Changes proposed in this pull request:
- Add webpack test config that puts assets in existing gitignored `/dist/` instead of `/public/`
- Add `build:test` task that uses the test webpack config
- Use `build:test` instead of `build` from `test:prepare`

## security considerations
None. This is a dev/test change to reduce the risk of accidentally committing things that needn't be committed.
