### PR TITLE
fix: Fixed branchViewLink to use updated branch config and domain model #4032

### DIFF
--- a/api/serializers/domain.js
+++ b/api/serializers/domain.js
@@ -7,6 +7,8 @@ const attributes = {
   context: '',
   names: '',
   state: '',
+  siteId: '',
+  siteBranchConfigId: '',
   SiteBranchConfig: sbc => sbc && sbcSerializer.serialize(sbc),
   Site: (site, _, isSystemAdmin) => site && siteSerializer.serializeNew(site, isSystemAdmin),
   createdAt: 'date',

--- a/api/serializers/site-branch-config.js
+++ b/api/serializers/site-branch-config.js
@@ -8,15 +8,15 @@ const allowedAttributes = [
   's3Key',
 ];
 
-function serialize(userEnvVar) {
-  const object = userEnvVar.get({
+function serialize(sbc) {
+  const object = sbc.get({
     plain: true,
   });
   return pick(allowedAttributes, object);
 }
 
-function serializeMany(userEnvVars) {
-  return userEnvVars.map(serialize);
+function serializeMany(sbc) {
+  return sbc.map(serialize);
 }
 
 module.exports = { serialize, serializeMany };

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       CLOUD_FOUNDRY_OAUTH_TOKEN_URL: https://login.example.com/oauth/token
       CF_API_USERNAME: deploy_user
       CF_API_PASSWORD: deploy_pass
+      PROXY_DOMAIN: localhost:1337
   db:
     image: postgres:11-alpine
     environment:

--- a/ci/pipeline-dev.yml
+++ b/ci/pipeline-dev.yml
@@ -67,6 +67,7 @@ jobs:
             params:
               APP_HOSTNAME: https://((((deploy-env))-pages-domain))
               NODE_ENV: development
+              PROXY_DOMAIN: sites.((((deploy-env))-pages-domain))
 
           - task: deploy-api
             file: src/ci/partials/deploy.yml

--- a/ci/pipeline-production.yml
+++ b/ci/pipeline-production.yml
@@ -68,6 +68,7 @@ jobs:
         image: node
         params:
           APP_HOSTNAME: https://((((deploy-env))-pages-domain))
+          PROXY_DOMAIN: sites.((((deploy-env))-pages-domain))
 
       - task: deploy-api
         file: src/ci/partials/deploy.yml

--- a/ci/pipeline-staging.yml
+++ b/ci/pipeline-staging.yml
@@ -173,6 +173,7 @@ jobs:
         image: node
         params:
           APP_HOSTNAME: https://((((deploy-env))-pages-domain))
+          PROXY_DOMAIN: sites.((((deploy-env))-pages-domain))
 
       - task: deploy-api
         file: src/ci/partials/deploy.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       CLOUD_FOUNDRY_OAUTH_TOKEN_URL: https://login.example.com/oauth/token
       CF_API_USERNAME: deploy_user
       CF_API_PASSWORD: deploy_pass
+      PROXY_DOMAIN: localhost:1337
   bull-board:
     build:
       dockerfile: Dockerfile-app

--- a/frontend/components/site/PagesHeader.jsx
+++ b/frontend/components/site/PagesHeader.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { IconView } from '../icons';
 import GitHubLink from '../GitHubLink';
 
 const PagesHeader = ({
-  owner, repository, title, viewLink,
+  owner, repository, title,
 }) => (
   <div className="page-header usa-grid-full">
     <div className="usa-width-two-thirds">
@@ -18,16 +17,6 @@ const PagesHeader = ({
     </div>
     <div className="usa-width-one-third header-actions">
       <GitHubLink text="View repo" owner={owner} repository={repository} />
-      <a
-        alt="View this site"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="view-site-link"
-        href={viewLink}
-      >
-        View site
-        <IconView />
-      </a>
     </div>
   </div>
 );
@@ -36,7 +25,6 @@ PagesHeader.propTypes = {
   owner: PropTypes.string.isRequired, // Owner (org or user) of the repo
   repository: PropTypes.string.isRequired, // Name of the repo
   title: PropTypes.string.isRequired, // Title of the section we are on
-  viewLink: PropTypes.string.isRequired,
 };
 
 export default PagesHeader;

--- a/frontend/components/site/siteBuilds.jsx
+++ b/frontend/components/site/siteBuilds.jsx
@@ -169,7 +169,6 @@ function SiteBuilds() {
                           && (
                           <BranchViewLink
                             branchName={build.branch}
-                            viewLink={build.viewLink}
                             site={site}
                             showIcon
                             completedAt={build.completedAt}

--- a/frontend/components/siteContainer.jsx
+++ b/frontend/components/siteContainer.jsx
@@ -130,7 +130,6 @@ export function SiteContainer(props) {
           siteId={site.id}
           branch={params.branch || site.defaultBranch}
           fileName={params.fileName}
-          viewLink={site.viewLink}
         />
 
         <Outlet />

--- a/frontend/components/siteList/siteListItem.jsx
+++ b/frontend/components/siteList/siteListItem.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link, useNavigate } from 'react-router-dom';
 
-import { IconView } from '../icons';
 import PublishedState from './publishedState';
 import RepoLastVerified from './repoLastVerified';
 import GitHubLink from '../GitHubLink';
@@ -10,22 +9,6 @@ import ButtonLink from '../ButtonLink';
 import siteActions from '../../actions/siteActions';
 import { ORGANIZATION, USER } from '../../propTypes';
 import { sandboxMsg } from '../../util';
-
-function getViewLink(viewLink, repo) {
-  return (
-    <a
-      href={viewLink}
-      alt={`View the ${repo} site`}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="view-site-link"
-    >
-      View site
-      {' '}
-      <IconView />
-    </a>
-  );
-}
 
 function getSiteName(site) {
   return `${site.owner}/${site.repository}`;
@@ -73,7 +56,6 @@ function SiteListItem({ organization, site, user }) {
       </div>
       <div className="sites-list-item-actions">
         <GitHubLink text="View repo" owner={site.owner} repository={site.repository} />
-        { getViewLink(site.viewLink, site.repository) }
         {
           !organization
           && <ButtonLink clickHandler={handleRemoveSite(site, user, navigate)}>Remove</ButtonLink>

--- a/frontend/globals.js
+++ b/frontend/globals.js
@@ -2,4 +2,5 @@ export default {
   APP_HOSTNAME: process.env.APP_HOSTNAME,
   PRODUCT: process.env.PRODUCT,
   APP_NAME: 'Pages',
+  PROXY_DOMAIN: process.env.PROXY_DOMAIN,
 };

--- a/frontend/propTypes.js
+++ b/frontend/propTypes.js
@@ -26,10 +26,31 @@ export const SITE = PropTypes.shape({
   s3ServiceName: PropTypes.string,
   awsBucketName: PropTypes.string,
   awsBucketRegion: PropTypes.string,
-  organizationId: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-  ]),
+  organizationId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  Domains: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number,
+      names: PropTypes.string,
+      context: PropTypes.string,
+      origin: PropTypes.string,
+      path: PropTypes.string,
+      state: PropTypes.string,
+      createdAt: PropTypes.string,
+      updatedAt: PropTypes.string,
+      siteBranchConfigId: PropTypes.number,
+    })
+  ),
+  SiteBranchConfigs: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number,
+      branch: PropTypes.string,
+      s3Key: PropTypes.string,
+      config: PropTypes.string,
+      context: PropTypes.string,
+      createdAt: PropTypes.string,
+      updatedAt: PropTypes.string,
+    })
+  ),
   users: PropTypes.arrayOf(USER),
 });
 
@@ -61,10 +82,7 @@ export const BUILD_LOG_DATA = PropTypes.objectOf(PropTypes.arrayOf(BUILD_LOG));
 
 export const ORGANIZATION = PropTypes.shape({
   createdAt: PropTypes.string,
-  id: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.string,
-  ]).isRequired,
+  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   name: PropTypes.string.isRequired,
   updatedAt: PropTypes.string,
 });
@@ -76,10 +94,7 @@ export const ORGANIZATIONS = PropTypes.shape({
 
 export const ROLE = PropTypes.shape({
   createdAt: PropTypes.string,
-  id: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.string,
-  ]).isRequired,
+  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   name: PropTypes.string.isRequired,
   updatedAt: PropTypes.string,
 });

--- a/test/api/unit/services/Domain.test.js
+++ b/test/api/unit/services/Domain.test.js
@@ -199,7 +199,7 @@ describe('Domain Service', () => {
       sinon.spy(DomainQueue.prototype, 'add');
       const siteUpdateSpy = sinon.spy(
         DomainService,
-        'updateSiteForDeprovisionedDomain'
+        'rebuildAssociatedSite'
       );
 
       const domain = await DomainFactory.create({
@@ -211,7 +211,7 @@ describe('Domain Service', () => {
 
       await DomainService.checkDeprovisionStatus(domain.id);
 
-      await domain.reload();
+      await domain.reload({ include: [SiteBranchConfig]});
 
       sinon.assert.notCalled(DomainQueue.prototype.add);
       sinon.assert.calledOnceWithExactly(siteUpdateSpy, domain);
@@ -328,7 +328,7 @@ describe('Domain Service', () => {
       sinon.spy(DomainQueue.prototype, 'add');
       const siteUpdateSpy = sinon.spy(
         DomainService,
-        'updateSiteForProvisionedDomain'
+        'rebuildAssociatedSite'
       );
 
       const domain = await DomainFactory.create({
@@ -337,7 +337,7 @@ describe('Domain Service', () => {
 
       await DomainService.checkProvisionStatus(domain.id);
 
-      await domain.reload();
+      await domain.reload({ include: [SiteBranchConfig]});
 
       sinon.assert.calledOnceWithExactly(
         CloudFoundryAPIClient.prototype.fetchServiceInstance,
@@ -411,7 +411,8 @@ describe('Domain Service', () => {
       await site.reload({ include: [Build] });
       expect(site.Builds).to.have.length(0);
 
-      await DomainService.rebuildAssociatedSite(domain, site);
+      await domain.reload({ include: [SiteBranchConfig]})
+      await DomainService.rebuildAssociatedSite(domain);
 
       await site.reload({ include: [Build] });
       expect(site.Builds).to.have.length(1);
@@ -433,115 +434,12 @@ describe('Domain Service', () => {
       await site.reload({ include: [Build] });
       expect(site.Builds).to.have.length(0);
 
+      await domain.reload({ include: [SiteBranchConfig]})
       await DomainService.rebuildAssociatedSite(domain, site);
 
       await site.reload({ include: [Build] });
       expect(site.Builds).to.have.length(1);
       expect(site.Builds[0].branch).to.equal(site.demoBranch);
-    });
-  });
-
-  describe('.updateSiteForProvisionedDomain()', () => {
-    it('sets the domain name on the associated site if not previously set', async () => {
-      const site = await SiteFactory();
-      const domain = await DomainFactory.create({
-        siteId: site.id,
-        names: 'www.agency.gov',
-      });
-      const siteBuildSpy = sinon
-        .stub(DomainService, 'rebuildAssociatedSite')
-        .resolves();
-
-      expect(domain.names).to.eq('www.agency.gov');
-      expect(domain.context).to.eq('site');
-
-      await domain.reload({ include: [Site] });
-      expect(site.domain).to.eq(null);
-      expect(site.demoDomain).to.eq(null);
-
-      await DomainService.updateSiteForProvisionedDomain(domain);
-
-      await site.reload();
-      expect(site.domain).to.eq('https://www.agency.gov');
-      expect(site.demoDomain).to.eq(null);
-      sinon.assert.calledOnce(siteBuildSpy);
-    });
-
-    it('sets the demo domain name on the associated site if not previously set', async () => {
-      const site = await SiteFactory({ demoBranch: 'demo' });
-      const domain = await DomainFactory.create({
-        siteId: site.id,
-        context: Domain.Contexts.Demo,
-        names: 'www.agency.gov',
-      });
-      const siteBuildSpy = sinon
-        .stub(DomainService, 'rebuildAssociatedSite')
-        .resolves();
-
-      expect(domain.names).to.eq('www.agency.gov');
-      expect(domain.context).to.eq('demo');
-
-      await domain.reload({ include: [Site] });
-      expect(site.domain).to.eq(null);
-      expect(site.demoDomain).to.eq(null);
-
-      await DomainService.updateSiteForProvisionedDomain(domain);
-
-      await site.reload();
-      expect(site.domain).to.eq(null);
-      expect(site.demoDomain).to.eq('https://www.agency.gov');
-      sinon.assert.calledOnce(siteBuildSpy);
-    });
-
-    it('leaves the existing domain name on its associated site unchanged', async () => {
-      const site = await SiteFactory({ domain: 'https://example.gov' });
-      const domain = await DomainFactory.create({
-        siteId: site.id,
-        names: 'www.agency.gov',
-      });
-      const siteBuildSpy = sinon
-        .stub(DomainService, 'rebuildAssociatedSite')
-        .resolves();
-
-      expect(domain.names).to.eq('www.agency.gov');
-      expect(domain.context).to.eq('site');
-
-      await domain.reload({ include: [Site] });
-      expect(site.domain).to.eq('https://example.gov');
-      expect(site.demoDomain).to.eq(null);
-
-      await DomainService.updateSiteForProvisionedDomain(domain);
-
-      await site.reload();
-      expect(site.domain).to.eq('https://example.gov');
-      expect(site.demoDomain).to.eq(null);
-      sinon.assert.notCalled(siteBuildSpy);
-    });
-
-    it('leaves the existing domain name on its associated site unchanged', async () => {
-      const site = await SiteFactory({ demoDomain: 'https://example.gov' });
-      const domain = await DomainFactory.create({
-        siteId: site.id,
-        context: Domain.Contexts.Demo,
-        names: 'www.agency.gov',
-      });
-      const siteBuildSpy = sinon
-        .stub(DomainService, 'rebuildAssociatedSite')
-        .resolves();
-
-      expect(domain.names).to.eq('www.agency.gov');
-      expect(domain.context).to.eq('demo');
-
-      await domain.reload({ include: [Site] });
-      expect(site.domain).to.eq(null);
-      expect(site.demoDomain).to.eq('https://example.gov');
-
-      await DomainService.updateSiteForProvisionedDomain(domain);
-
-      await site.reload();
-      expect(site.domain).to.eq(null);
-      expect(site.demoDomain).to.eq('https://example.gov');
-      sinon.assert.notCalled(siteBuildSpy);
     });
   });
 
@@ -747,212 +645,6 @@ describe('Domain Service', () => {
 
       expect(DomainService.isSiteUrlManagedByDomain(site, [], 'demo')).to.be
         .true;
-    });
-  });
-
-  describe('.updateSiteForDeprovisionedDomain()', () => {
-    it('unsets a matching domain name on its associated site', async () => {
-      const site = await SiteFactory({ domain: 'https://www.agency.gov' });
-      const domain = await DomainFactory.create({
-        siteId: site.id,
-        names: 'www.agency.gov',
-        state: Domain.States.Provisioning,
-      });
-      const siteBuildSpy = sinon
-        .stub(DomainService, 'rebuildAssociatedSite')
-        .resolves();
-
-      expect(domain.names).to.eq('www.agency.gov');
-      expect(domain.context).to.eq('site');
-
-      await domain.reload({ include: [Site] });
-      expect(site.domain).to.eq('https://www.agency.gov');
-      expect(site.demoDomain).to.eq(null);
-
-      await DomainService.updateSiteForDeprovisionedDomain(domain);
-      await site.reload();
-      expect(site.domain).to.eq(null);
-      expect(site.demoDomain).to.eq(null);
-      sinon.assert.calledOnce(siteBuildSpy);
-    });
-
-    it('unsets a matching first domain name on its associated site', async () => {
-      const site = await SiteFactory({ domain: 'https://www.agency.gov' });
-      const domain = await DomainFactory.create({
-        siteId: site.id,
-        names: 'www.agency.gov,www.foo.gov,www.bar.gov',
-        state: Domain.States.Provisioning,
-      });
-      const siteBuildSpy = sinon
-        .stub(DomainService, 'rebuildAssociatedSite')
-        .resolves();
-
-      expect(domain.names).to.eq('www.agency.gov,www.foo.gov,www.bar.gov');
-      expect(domain.context).to.eq('site');
-
-      await domain.reload({ include: [Site] });
-      expect(site.domain).to.eq('https://www.agency.gov');
-      expect(site.demoDomain).to.eq(null);
-
-      await DomainService.updateSiteForDeprovisionedDomain(domain);
-      await site.reload();
-      expect(site.domain).to.eq(null);
-      expect(site.demoDomain).to.eq(null);
-      sinon.assert.calledOnce(siteBuildSpy);
-    });
-
-    it('unsets a matching non-first domain name on its associated site', async () => {
-      const site = await SiteFactory({ domain: 'https://www.agency.gov' });
-      const domain = await DomainFactory.create({
-        siteId: site.id,
-        names: 'www.foo.gov,www.agency.gov,www.bar.gov',
-        state: Domain.States.Provisioning,
-      });
-      const siteBuildSpy = sinon
-        .stub(DomainService, 'rebuildAssociatedSite')
-        .resolves();
-
-      expect(domain.names).to.eq('www.foo.gov,www.agency.gov,www.bar.gov');
-      expect(domain.context).to.eq('site');
-
-      await domain.reload({ include: [Site] });
-      expect(site.domain).to.eq('https://www.agency.gov');
-      expect(site.demoDomain).to.eq(null);
-
-      await DomainService.updateSiteForDeprovisionedDomain(domain);
-      await site.reload();
-      expect(site.domain).to.eq(null);
-      expect(site.demoDomain).to.eq(null);
-      sinon.assert.calledOnce(siteBuildSpy);
-    });
-
-    it('unsets a matching demo domain name on its associated site', async () => {
-      const site = await SiteFactory({ demoDomain: 'https://www.agency.gov' });
-      const domain = await DomainFactory.create({
-        siteId: site.id,
-        names: 'www.agency.gov',
-        context: Domain.Contexts.Demo,
-        state: Domain.States.Provisioning,
-      });
-      const siteBuildSpy = sinon
-        .stub(DomainService, 'rebuildAssociatedSite')
-        .resolves();
-
-      expect(domain.names).to.eq('www.agency.gov');
-      expect(domain.context).to.eq('demo');
-
-      await domain.reload({ include: [Site, SiteBranchConfig] });
-      expect(site.domain).to.eq(null);
-      expect(site.demoDomain).to.eq('https://www.agency.gov');
-
-      await DomainService.updateSiteForDeprovisionedDomain(domain);
-      await site.reload();
-      expect(site.domain).to.eq(null);
-      expect(site.demoDomain).to.eq(null);
-      sinon.assert.calledOnce(siteBuildSpy);
-    });
-
-    it('unsets a matching first demo domain name on its associated site', async () => {
-      const site = await SiteFactory({ demoDomain: 'https://www.agency.gov' });
-      const domain = await DomainFactory.create({
-        siteId: site.id,
-        names: 'www.agency.gov,www.foo.gov,www.bar.gov',
-        context: Domain.Contexts.Demo,
-        state: Domain.States.Provisioning,
-      });
-      const siteBuildSpy = sinon
-        .stub(DomainService, 'rebuildAssociatedSite')
-        .resolves();
-
-      expect(domain.names).to.eq('www.agency.gov,www.foo.gov,www.bar.gov');
-      expect(domain.context).to.eq('demo');
-
-      await domain.reload({ include: [Site] });
-      expect(site.domain).to.eq(null);
-      expect(site.demoDomain).to.eq('https://www.agency.gov');
-
-      await DomainService.updateSiteForDeprovisionedDomain(domain);
-      await site.reload();
-      expect(site.domain).to.eq(null);
-      expect(site.demoDomain).to.eq(null);
-      sinon.assert.calledOnce(siteBuildSpy);
-    });
-
-    it('unsets a matching non-first demo domain name on its associated site', async () => {
-      const site = await SiteFactory({ demoDomain: 'https://www.agency.gov' });
-      const domain = await DomainFactory.create({
-        siteId: site.id,
-        names: 'www.foo.gov,www.agency.gov,www.bar.gov',
-        context: Domain.Contexts.Demo,
-        state: Domain.States.Provisioning,
-      });
-      const siteBuildSpy = sinon
-        .stub(DomainService, 'rebuildAssociatedSite')
-        .resolves();
-
-      expect(domain.names).to.eq('www.foo.gov,www.agency.gov,www.bar.gov');
-      expect(domain.context).to.eq('demo');
-
-      await domain.reload({ include: [Site] });
-      expect(site.domain).to.eq(null);
-      expect(site.demoDomain).to.eq('https://www.agency.gov');
-
-      await DomainService.updateSiteForDeprovisionedDomain(domain);
-      await site.reload();
-      expect(site.domain).to.eq(null);
-      expect(site.demoDomain).to.eq(null);
-      sinon.assert.calledOnce(siteBuildSpy);
-    });
-
-    it('leaves a non-matching domain name on its associated site alone', async () => {
-      const site = await SiteFactory({ domain: 'https://example.gov' });
-      const domain = await DomainFactory.create({
-        siteId: site.id,
-        names: 'www.agency.gov',
-        state: Domain.States.Provisioning,
-      });
-      const siteBuildSpy = sinon
-        .stub(DomainService, 'rebuildAssociatedSite')
-        .resolves();
-
-      expect(domain.names).to.eq('www.agency.gov');
-      expect(domain.context).to.eq('site');
-
-      await domain.reload({ include: [Site] });
-      expect(site.domain).to.eq('https://example.gov');
-      expect(site.demoDomain).to.eq(null);
-
-      await DomainService.updateSiteForDeprovisionedDomain(domain);
-      await site.reload();
-      expect(site.domain).to.eq('https://example.gov');
-      expect(site.demoDomain).to.eq(null);
-      sinon.assert.notCalled(siteBuildSpy);
-    });
-
-    it('leaves a non-matching demo domain name on its associated site alone', async () => {
-      const site = await SiteFactory({ demoDomain: 'https://example.gov' });
-      const domain = await DomainFactory.create({
-        siteId: site.id,
-        names: 'www.agency.gov',
-        context: Domain.Contexts.Demo,
-        state: Domain.States.Provisioning,
-      });
-      const siteBuildSpy = sinon
-        .stub(DomainService, 'rebuildAssociatedSite')
-        .resolves();
-
-      expect(domain.names).to.eq('www.agency.gov');
-      expect(domain.context).to.eq('demo');
-
-      await domain.reload({ include: [Site] });
-      expect(site.domain).to.eq(null);
-      expect(site.demoDomain).to.eq('https://example.gov');
-
-      await DomainService.updateSiteForDeprovisionedDomain(domain);
-      await site.reload();
-      expect(site.domain).to.eq(null);
-      expect(site.demoDomain).to.eq('https://example.gov');
-      sinon.assert.notCalled(siteBuildSpy);
     });
   });
 

--- a/test/frontend/components/siteList/siteListItem.test.js
+++ b/test/frontend/components/siteList/siteListItem.test.js
@@ -156,25 +156,6 @@ describe('<SiteListItem />', () => {
     expect(wrapper.find('h5')).to.have.length(0);
   });
 
-  it('outputs a link tag to view the site', () => {
-    const siteWithBuilds = {
-      ...testSite,
-      builds: [{}],
-    };
-
-    wrapper = mountRouter(<SiteListItem site={siteWithBuilds} user={testUser} />);
-    const viewLink = wrapper.find('.sites-list-item-actions a');
-    expect(viewLink).to.have.length(1);
-    expect(viewLink.props()).to.contain({
-      href: testSite.viewLink,
-      alt: `View the ${testSite.repository} site`,
-      target: '_blank',
-      rel: 'noopener noreferrer',
-      className: 'view-site-link',
-    });
-    expect(viewLink.text()).to.equal('View site ');
-  });
-
   it('outputs a link to the GitHub repo', () => {
     const ghLink = wrapper.find('GitHubLink');
 

--- a/webpack.development-build.config.js
+++ b/webpack.development-build.config.js
@@ -106,6 +106,7 @@ module.exports = {
       ...getFeatureFlags(process.env),
       'APP_HOSTNAME',
       'PRODUCT',
+      'PROXY_DOMAIN',
     ]),
     new WebpackManifestPlugin({
       fileName: '../webpack-manifest.json',

--- a/webpack.development.config.js
+++ b/webpack.development.config.js
@@ -111,6 +111,7 @@ module.exports = {
       ...getFeatureFlags(process.env),
       'APP_HOSTNAME',
       'PRODUCT',
+      'PROXY_DOMAIN',
     ]),
     new BundleAnalyzerPlugin({
       analyzerHost: '0.0.0.0',

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -108,6 +108,7 @@ const config = {
       ...getFeatureFlags(process.env),
       'APP_HOSTNAME',
       'PRODUCT',
+      'PROXY_DOMAIN',
     ]),
   ],
 };

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -109,6 +109,7 @@ const config = {
       ...getFeatureFlags(process.env),
       'APP_HOSTNAME',
       'PRODUCT',
+      'PROXY_DOMAIN',
     ]),
   ],
 };


### PR DESCRIPTION
Close #4032

## Changes proposed in this pull request:
Frontend
- Updated `branchViewLink` to determine link based on branch, site branch configs, and domains
- Removed "View Site" links that weren't specific to a build branch.

Backend
- Updated site query to include related domains and site branch configs
- Simplified rebuild process after a domain CDN service is provisioned or deprovisioned

## security considerations
None
