### PR TITLE
Chore extend dependabot skips

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,17 @@ updates:
     open-pull-requests-limit: 0
     commit-message:
       prefix: '[ci skip] '
+  - package-ecosystem: npm
+    directory: /admin-client # admin client
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: '[ci skip] '
+  - package-ecosystem: npm
+    directory: /apps/metrics # metrics app
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: '[ci skip] '

--- a/admin-client/package.json
+++ b/admin-client/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "date-fns": "^2.15.0",
     "page": "^1.11.6",
-    "svelecte": "^3.16.0",
+    "svelecte": "^3.16.3",
     "svelte": "^3.0.0",
     "uswds": "^2.10.0"
   }

--- a/admin-client/yarn.lock
+++ b/admin-client/yarn.lock
@@ -1820,10 +1820,10 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-svelecte@^3.16.0:
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/svelecte/-/svelecte-3.16.0.tgz#1980774a93c9e74f469f4452d89721358067d899"
-  integrity sha512-BqGI1QhODCN6iHWWNsjMNwLDivxA6AUmcLOpMWa3v9FOJ5zpQdcOFwHgwuOS1itag9sqb8xqUH8P9/KuG6XEPg==
+svelecte@^3.16.3:
+  version "3.16.3"
+  resolved "https://registry.yarnpkg.com/svelecte/-/svelecte-3.16.3.tgz#cb834e746a4f35edbef25bda0bb39406e607938f"
+  integrity sha512-YSW+jr0JPlSi73O2Kw04ERMNEoxRwx9pQXTK5dSi3Ctzsu7lApefVlciHuX58uxoEbwzYVl+kTA1Dfx5DEQeYw==
   dependencies:
     svelte-tiny-virtual-list "^2.0.0"
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Extends dependabot configuration to cover all package.json files (#4217)
- Update svelecte for admin-client vulnerability

## security considerations
Closes a moderate security finding 
