### PR TITLE
fix: Site serializer domain and branch config pick

### DIFF
--- a/api/serializers/site.js
+++ b/api/serializers/site.js
@@ -92,12 +92,16 @@ const serializeObject = (site, isSystemAdmin) => {
   const json = serializeNew(site, isSystemAdmin);
 
   if (json.Domains) {
-    json.domains = site.Domains.map(d => pick(allowedDomainAttributes, d));
+    json.domains = site.Domains.map(
+      d => pick(allowedDomainAttributes, d.get({ plain: true }))
+    );
     delete json.Domains;
   }
 
   if (json.SiteBranchConfigs) {
-    json.siteBranchConfigs = site.SiteBranchConfigs.map(sbc => pick(allowedSBCAttributes, sbc));
+    json.siteBranchConfigs = site.SiteBranchConfigs.map(
+      sbc => pick(allowedSBCAttributes, sbc.get({ plain: true }))
+    );
     delete json.SiteBranchConfigs;
   }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fixes the site serializeObject serializer by setting domain and site branch config model install to `plain: true` to allow pick to work as expected.
- Adds test to verify pick of the models.

## security considerations
None
