### PR TITLE
perf: Update pages production app to 4 instance with 512mb

### DIFF
--- a/.cloudgov/vars/pages-production.yml
+++ b/.cloudgov/vars/pages-production.yml
@@ -1,8 +1,8 @@
 product: pages
 name: pages-production
 domain: pages.cloud.gov
-memory: 256MB
-instances: 2
+memory: 512MB
+instances: 4
 env: production
 env_postfix: -production
 log_level: info


### PR DESCRIPTION
## Changes proposed in this pull request:
- Scale pages production app to 4 instances
- Scale pages production app to 512MB per instance

## security considerations
None
