### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 0.3.0 (2023-10-10)
+
+### Added
+
+- implement build task runners, call CF API directly (#4259)
+- add build task queue and example worker (#4248)
+- add build task router and controller (#4169)
+- add DB models to support build task feature (#4184)
+- Allow users to create custom domains to prepare launch
+
+### Fixed
+
+- Admin UI for updated site branch configs and domains
+
+### Maintenance
+
+- Improve name and path and update published sites report
+- Update deps using json5 #4249
+- Update CF API to V3 #4112
+- update uaa war release download location
+- use correct path for release notes
+
 ## 0.2.1 (2023-08-22)
 
 ### Performance

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pages-core",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "",
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
## :robot: This is an automated release PR
chore: release 0.3.0
tag to create: 0.3.0
increment detected: MINOR

## 0.3.0 (2023-10-10)

### Added

- implement build task runners, call CF API directly (#4259)
- add build task queue and example worker (#4248)
- add build task router and controller (#4169)
- add DB models to support build task feature (#4184)
- Allow users to create custom domains to prepare launch

### Fixed

- Admin UI for updated site branch configs and domains

### Maintenance

- Improve name and path and update published sites report
- Update deps using json5 #4249
- Update CF API to V3 #4112
- update uaa war release download location
- use correct path for release notes

## security considerations
Noted in individual PRs 
