### PR TITLE
Add build task router and controller

### DIFF
--- a/api/controllers/build-task.js
+++ b/api/controllers/build-task.js
@@ -1,0 +1,63 @@
+const { wrapHandlers } = require('../utils');
+const { Build, BuildTask } = require('../models');
+
+module.exports = wrapHandlers({
+  find: async (req, res) => {
+    const { params, user } = req;
+    const { build_id: buildId, build_task_id: buildTaskId } = params;
+
+    // the build check essentially serves as an authorizer
+    const build = await Build.forSiteUser(user).findByPk(buildId);
+
+    if (!build) {
+      return res.notFound();
+    }
+
+    const task = await BuildTask.findOne({
+      where: { buildId, id: buildTaskId },
+      attributes: { exclude: ['token', 'deletedAt'] },
+    });
+
+    if (!task) {
+      return res.notFound();
+    }
+
+    return res.json(task);
+  },
+
+  list: async (req, res) => {
+    const { params, user } = req;
+    const { build_id: buildId } = params;
+
+    const build = await Build.forSiteUser(user).findByPk(buildId);
+
+    if (!build) {
+      return res.notFound();
+    }
+
+    const tasks = await BuildTask.findAll({
+      where: { buildId },
+      attributes: { exclude: ['token', 'deletedAt'] },
+    });
+
+    return res.json(tasks);
+  },
+
+  update: async (req, res) => {
+    const { params, body } = req;
+    const { build_task_id: buildTaskId, token } = params;
+
+    const task = await BuildTask.findByPk(buildTaskId);
+
+    if (!task) {
+      return res.notFound();
+    }
+    if (task.token !== token || ['success', 'skipped', 'error'].includes(task.status)) {
+      return res.forbidden();
+    }
+
+    await task.update(body);
+
+    return res.ok();
+  },
+});

--- a/api/routers/build-task.js
+++ b/api/routers/build-task.js
@@ -1,0 +1,9 @@
+const router = require('express').Router();
+const BuildTaskController = require('../controllers/build-task');
+const { sessionAuth } = require('../middlewares');
+
+router.get('/build/:build_id/tasks', sessionAuth, BuildTaskController.list);
+router.get('/build/:build_id/tasks/:build_task_id', sessionAuth, BuildTaskController.find);
+router.put('/tasks/:build_task_id/:token', BuildTaskController.update);
+
+module.exports = router;

--- a/api/routers/index.js
+++ b/api/routers/index.js
@@ -9,6 +9,7 @@ mainRouter.use(require('./main'));
 
 const apiRouter = express.Router();
 apiRouter.use(require('./build-log'));
+apiRouter.use(require('./build-task'));
 apiRouter.use(require('./build'));
 apiRouter.use(require('./domain'));
 apiRouter.use(require('./organization'));

--- a/migrations/20230907003657-build-tasks-token.js
+++ b/migrations/20230907003657-build-tasks-token.js
@@ -1,0 +1,10 @@
+const TABLE = 'build_task';
+
+exports.up = db => Promise.all([
+  db.addColumn(TABLE, 'token', { type: 'string', allowNull: false }),
+]);
+
+exports.down = db => Promise.all([
+  db.removeColumn(TABLE, 'token'),
+]);
+

--- a/public/swagger/BuildTask.json
+++ b/public/swagger/BuildTask.json
@@ -1,0 +1,47 @@
+{
+  "type": "object",
+  "required": [
+    "id",
+    "createdAt",
+    "buildId",
+    "buildTaskTypeId",
+    "status",
+    "updatedAt",
+    "name",
+    "artifact"
+  ],
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "createdAt": {
+      "type": "string"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "error",
+        "processing",
+        "skipped",
+        "success",
+        "queued",
+        "created"
+      ]
+    },
+    "buildId": {
+      "type": "number"
+    },
+    "buildTaskTypeId": {
+      "type": "number"
+    },
+    "name": {
+      "type": "string"
+    },
+    "artifact": {
+      "type": "string"
+    }
+  }
+}

--- a/public/swagger/index.yml
+++ b/public/swagger/index.yml
@@ -216,6 +216,67 @@ paths:
           description: Not found
           schema:
             $ref: 'Error.json'
+  /build/{build_id}/tasks:
+    parameters:
+      - name: build_id
+        in: path
+        description: The id of the build
+        type: integer
+        required: true
+    get:
+      summary: Fetch all build tasks associated with a build
+      responses:
+        200:
+          description: An array with the build tasks associated with the build
+          schema:
+            type: array
+            items:
+              $ref: 'BuildTask.json'
+        401:
+          description: Unauthorized
+          schema:
+            $ref: 'Error.json'
+        403:
+          description: Not authorized
+          schema:
+            $ref: 'Error.json'
+        404:
+          description: Not found
+          schema:
+            $ref: 'Error.json'
+  /build/{build_id}/tasks/{task_id}:
+    parameters:
+      - name: build_id
+        in: path
+        description: The id of the build
+        type: integer
+        required: true
+      - name: task_id
+        in: path
+        description: The id of the build task
+        type: integer
+        required: true
+    get:
+      summary: Fetch one build task associated with a build
+      responses:
+        200:
+          description: An object with a build task matching task_id and associated with the build
+          schema:
+            type: object
+            items:
+              $ref: 'BuildTask.json'
+        401:
+          description: Unauthorized
+          schema:
+            $ref: 'Error.json'
+        403:
+          description: Not authorized
+          schema:
+            $ref: 'Error.json'
+        404:
+          description: Not found
+          schema:
+            $ref: 'Error.json'
   /organization:
     get:
       summary: Fetch all of the current user's organizations
@@ -1214,3 +1275,32 @@ paths:
           description: Always an empty object
           schema:
             type: object
+  /tasks/{build_task_id}/{token}:
+    parameters:
+      - name: build_task_id
+        in: path
+        description: The id of the build task
+        type: integer
+        required: true
+      - name: token
+        in: path
+        description: The build tasks secret build task token.
+        type: string
+        required: true
+    put:
+      summary: Update build task information
+      responses:
+        200:
+          description: Acknowledgement that the build task was updated
+        400:
+          description: Bad request
+          schema:
+            $ref: 'Error.json'
+        403:
+          description: Not authorized
+          schema:
+            $ref: 'Error.json'
+        404:
+          description: Not found
+          schema:
+            $ref: 'Error.json'

--- a/test/api/requests/build-tasks.test.js
+++ b/test/api/requests/build-tasks.test.js
@@ -1,0 +1,195 @@
+const { expect } = require('chai');
+const request = require('supertest');
+const app = require('../../../app');
+const factory = require('../support/factory');
+const { authenticatedSession } = require('../support/session');
+const validateAgainstJSONSchema = require('../support/validateAgainstJSONSchema');
+const {
+  BuildTask, BuildTaskType, Build, User,
+} = require('../../../api/models');
+
+function clean() {
+  return Promise.all([
+    Build.truncate({ force: true, cascade: true }),
+    BuildTask.truncate({ force: true, cascade: true }),
+    BuildTaskType.truncate({ force: true, cascade: true }),
+    User.truncate({ force: true, cascade: true }),
+  ]);
+}
+
+async function prepTasks() {
+  const user = await factory.user();
+  const cookie = await authenticatedSession(user);
+  const site = await factory.site({ users: [user] });
+  const build = await factory.build({ user, site });
+
+  const task = await factory.buildTask({ build });
+  await factory.buildTask({ build });
+  return { cookie, build, task };
+}
+
+describe('Build Task API', () => {
+  before(async () => {
+    await clean();
+  });
+
+  afterEach(clean);
+
+  describe('GET /v0/build/:build_id/tasks', () => {
+    it('should require authentication', (done) => {
+      factory.buildTask().then(buildTask => request(app)
+        .get(`/v0/build/${buildTask.buildId}/tasks`)
+        .expect(403))
+        .then((response) => {
+          validateAgainstJSONSchema('GET', '/build/{build_id}/tasks', 403, response.body);
+          done();
+        }).catch(done);
+    });
+
+    it('should list build tasks', async () => {
+      const { cookie, build } = await prepTasks();
+
+      const response = await request(app)
+        .get(`/v0/build/${build.id}/tasks`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      validateAgainstJSONSchema('GET', '/build/{build_id}/tasks', 200, response.body);
+      expect(response.body).to.be.an('array');
+      expect(response.body).to.have.length(2);
+      expect(response.body[0]).to.have.keys([
+        'artifact',
+        'buildId',
+        'buildTaskTypeId',
+        'createdAt',
+        'id',
+        'name',
+        'status',
+        'updatedAt',
+      ]);
+    });
+
+    it('should not list build tasks if user is not associated to the build', async () => {
+      const anotherUser = await factory.user();
+      const differentCookie = await authenticatedSession(anotherUser);
+      const { build } = await prepTasks();
+
+      const response = await request(app)
+        .get(`/v0/build/${build.id}/tasks`)
+        .set('Cookie', differentCookie)
+        .expect(404);
+
+      validateAgainstJSONSchema('GET', '/build/{build_id}/tasks', 404, response.body);
+    });
+  });
+
+  describe('GET /v0/build/:build_id/tasks/:task_id', () => {
+    it('should require authentication', (done) => {
+      factory.buildTask().then(buildTask => request(app)
+        .get(`/v0/build/${buildTask.buildId}/tasks/${buildTask.id}`)
+        .expect(403))
+        .then((response) => {
+          validateAgainstJSONSchema('GET', '/build/{build_id}/tasks/{task_id}', 403, response.body);
+          done();
+        }).catch(done);
+    });
+
+    it('should fetch one build task', async () => {
+      const { cookie, build, task } = await prepTasks();
+
+      const response = await request(app)
+        .get(`/v0/build/${build.id}/tasks/${task.id}`)
+        .set('Cookie', cookie)
+        .expect(200);
+
+      validateAgainstJSONSchema('GET', '/build/{build_id}/tasks/{task_id}', 200, response.body);
+      expect(response.body).to.be.an('object');
+      expect(response.body).to.have.keys([
+        'artifact',
+        'buildId',
+        'buildTaskTypeId',
+        'createdAt',
+        'id',
+        'name',
+        'status',
+        'updatedAt',
+      ]);
+      expect(response.body.buildId).to.be.equal(build.id);
+    });
+
+    it('should not get build task if user is not associated to the build', async () => {
+      const anotherUser = await factory.user();
+      const differentCookie = await authenticatedSession(anotherUser);
+      const { build, task } = await prepTasks();
+
+      const response = await request(app)
+        .get(`/v0/build/${build.id}/tasks/${task.id}`)
+        .set('Cookie', differentCookie)
+        .expect(404);
+
+      validateAgainstJSONSchema('GET', '/build/{build_id}/tasks', 404, response.body);
+    });
+
+    it('should not get build task if the build is not associated to the build task', async () => {
+      const anotherBuild = await factory.build();
+      const { task, cookie } = await prepTasks();
+
+      const response = await request(app)
+        .get(`/v0/build/${anotherBuild.id}/tasks/${task.id}`)
+        .set('Cookie', cookie)
+        .expect(404);
+
+      validateAgainstJSONSchema('GET', '/build/{build_id}/tasks', 404, response.body);
+    });
+  });
+
+  describe('PUT /v0/tasks/:build_task_id/:token', () => {
+    it('should require a matching token', async () => {
+      const { task } = await prepTasks();
+
+      return request(app)
+        .put(`/v0/tasks/${task.id}/faketoken`)
+        .type('json')
+        .send({
+          name: 'name',
+          artifact: 'artifact',
+          status: 'created',
+        })
+        .expect(403);
+    });
+
+    it('should return a 404 when a task isn\'t found', async () => {
+      const { task } = await prepTasks();
+
+      return request(app)
+        .put(`/v0/tasks/1000/${task.token}`)
+        .type('json')
+        .send({
+          name: 'name',
+          artifact: 'artifact',
+          status: 'created',
+        })
+        .expect(404);
+    });
+
+    it('should update a build task', async () => {
+      const { task } = await prepTasks();
+      const newTask = {
+        name: 'new name',
+        artifact: 'new artifact',
+        status: 'created',
+      };
+
+      await request(app)
+        .put(`/v0/tasks/${task.id}/${task.token}`)
+        .type('json')
+        .send(newTask)
+        .expect(200);
+
+      const dbTask = await BuildTask.findByPk(task.id);
+      expect(dbTask.name).to.be.equal(newTask.name);
+      expect(dbTask.artifact).to.be.equal(newTask.artifact);
+      expect(dbTask.status).to.be.equal(newTask.status);
+    });
+  });
+});

--- a/test/api/support/factory/build-task-type.js
+++ b/test/api/support/factory/build-task-type.js
@@ -1,0 +1,23 @@
+const { BuildTaskType } = require('../../../../api/models');
+
+// eslint-disable-next-line no-underscore-dangle
+const _attributes = ({
+  name, description, metadata,
+} = {}) => ({
+  name: name || 'build task type name',
+  description: description || 'build task type description',
+  metadata: metadata || { some: 'metadata' },
+});
+
+const buildTaskType = overrides => Promise.props(_attributes(overrides))
+  .then((attributes) => {
+    Object.keys(attributes).forEach((key) => {
+      if (attributes[key].sequelize) {
+        // eslint-disable-next-line no-param-reassign
+        attributes[key] = attributes[key].id;
+      }
+    });
+    return BuildTaskType.create(attributes);
+  });
+
+module.exports = buildTaskType;

--- a/test/api/support/factory/build-task.js
+++ b/test/api/support/factory/build-task.js
@@ -1,0 +1,29 @@
+const buildFactory = require('./build');
+const buildTaskTypeFactory = require('./build-task-type');
+const { BuildTask } = require('../../../../api/models');
+
+// eslint-disable-next-line no-underscore-dangle
+const _attributes = ({
+  build,
+  buildTaskType,
+  name,
+  artifact,
+} = {}) => ({
+  buildId: build || buildFactory(),
+  buildTaskTypeId: buildTaskType || buildTaskTypeFactory(),
+  name: name || 'build task name',
+  artifact: artifact || 'build task artifact',
+});
+
+const buildTask = overrides => Promise.props(_attributes(overrides))
+  .then((attributes) => {
+    Object.keys(attributes).forEach((key) => {
+      if (attributes[key].sequelize) {
+        // eslint-disable-next-line no-param-reassign
+        attributes[key] = attributes[key].id;
+      }
+    });
+    return BuildTask.create(attributes);
+  });
+
+module.exports = buildTask;

--- a/test/api/support/factory/index.js
+++ b/test/api/support/factory/index.js
@@ -1,5 +1,7 @@
 const bulkBuild = require('./bulkBuild');
 const { buildLog, bulkBuildLogs } = require('./build-log');
+const buildTaskType = require('./build-task-type');
+const buildTask = require('./build-task');
 const build = require('./build');
 const domain = require('./domain');
 const event = require('./event');
@@ -15,6 +17,8 @@ const userEnvironmentVariable = require('./user-environment-variable');
 module.exports = {
   buildLog,
   bulkBuildLogs,
+  buildTaskType,
+  buildTask,
   build,
   bulkBuild,
   domain,


### PR DESCRIPTION
## Changes proposed in this pull request:
- add build task router and controller
- close #4169

This includes some deviations from the initial proposal:
- the read routes don't include `/site/:site_id/` because the build ID can be used to authorize the user to read without it.
- the update route can now update any field (not just status) but includes a token check so that random users can't use it

This PR doesn't handle the full title of #4169 but it hits the acceptance criteria, happy to add more if needed

## security considerations
None