### PR TITLE
Add self authorization fields to organizations and published sites reports

### DIFF
--- a/admin-client/src/pages/organization/OrgsReport.svelte
+++ b/admin-client/src/pages/organization/OrgsReport.svelte
@@ -12,6 +12,7 @@
     <tr slot="header">
       <th scope="col">Organization</th>
       <th scope="col">Agency</th>
+      <th scope="col">Self Authorized</th>
     </tr>
     <tr slot="item" let:item={org}>
       <td>
@@ -19,6 +20,9 @@
       </td>
       <td>
         {org.agency}
+      </td>
+      <td>
+        {org.isSelfAuthorized ? 'Yes' : 'No'}
       </td>
     </tr>
   </DataTable>

--- a/admin-client/src/pages/organization/PublishedSitesReport.svelte
+++ b/admin-client/src/pages/organization/PublishedSitesReport.svelte
@@ -22,6 +22,7 @@
     <tr slot="header">
       <th scope="col">Organization</th>
       <th scope="col">Agency</th>
+      <th scope="col">Self Authorized</th>
       <th scope="col">Site</th>
       <th scope="col">Domains</th>
       <th scope="col">Engine</th>
@@ -35,6 +36,11 @@
       <td>
         {#if domain.Site && domain.Site.Organization}
           {domain.Site.Organization.agency}
+        {/if}
+      </td>
+      <td>
+        {#if domain.Site && domain.Site.Organization}
+          {domain.Site.Organization.isSelfAuthorized ? 'Yes' : 'No'}
         {/if}
       </td>
       <td>

--- a/api/admin/controllers/domain.js
+++ b/api/admin/controllers/domain.js
@@ -101,6 +101,10 @@ module.exports = wrapHandlers({
         value: 'Site.Organization.agency',
       },
       {
+        label: 'Self Authorized',
+        value: 'Site.Organization.isSelfAuthorized',
+      },
+      {
         label: 'Site',
         value: 'Site.repository',
       },

--- a/api/admin/controllers/organization.js
+++ b/api/admin/controllers/organization.js
@@ -69,6 +69,10 @@ module.exports = wrapHandlers({
         label: 'Agency',
         value: 'agency',
       },
+      {
+        label: 'Self Authorized',
+        value: 'isSelfAuthorized',
+      },
     ];
 
     const parser = new json2csv.Parser({ fields });

--- a/scripts/create-dev-data.js
+++ b/scripts/create-dev-data.js
@@ -164,7 +164,11 @@ async function createData() {
   const [agency1, agency2, agency3, agency4, sandbox] = await Promise.all([
     Organization.create({ name: 'agency1', agency: 'GSA' }),
     Organization.create({ name: 'agency2', agency: 'GSA' }),
-    Organization.create({ name: 'agency3', agency: 'Bureau of Testing' }),
+    Organization.create({
+      name: 'agency3',
+      agency: 'Bureau of Testing',
+      selfAuthorizedAt: addDays(new Date(), -183),
+    }),
     Organization.create({
       name: 'agency4',
       agency: 'Demonstration Department',

--- a/test/api/admin/requests/domain.test.js
+++ b/test/api/admin/requests/domain.test.js
@@ -111,6 +111,7 @@ describe('Admin - Domains API', () => {
       const org = await factory.organization.create({
         name: 'Test Org',
         agency: 'Test Agency',
+        selfAuthorizedAt: new Date(),
       });
       const site = await factory.site({ organizationId: org.id });
       const domain = await factory.domain.create({
@@ -140,14 +141,14 @@ describe('Admin - Domains API', () => {
       );
       [header, ...data] = response.text.split(/\n/);
       expect(header).to.equal(
-        '"Organization","Agency","Site","Domain","Engine"'
+        '"Organization","Agency","Self Authorized","Site","Domain","Engine"'
       );
       expect(data.length).to.equal(2);
       expect(data[0]).to.equal(
-        `"${org.name}","${org.agency}","${site.repository}","${domain.names}","${site.engine}"`
+        `"${org.name}","${org.agency}",true,"${site.repository}","${domain.names}","${site.engine}"`
       );
       expect(data[1]).to.equal(
-        `,,"${orglessSite.repository}","${orglessDomain.names}","${orglessSite.engine}"`
+        `,,,"${orglessSite.repository}","${orglessDomain.names}","${orglessSite.engine}"`
       );
     });
   });

--- a/test/api/admin/requests/organization.test.js
+++ b/test/api/admin/requests/organization.test.js
@@ -57,7 +57,10 @@ describe('Admin - Organizations API', () => {
       const user = await factory.user();
 
       const org1 = await factory.organization.create({agency: 'Agency 1'});
-      const org2 = await factory.organization.create({agency: 'Agency 2'});
+      const org2 = await factory.organization.create({
+        agency: 'Agency 2',
+        selfAuthorizedAt: new Date(),
+      });
 
       const cookie = await authenticatedSession(user, sessionConfig);
       const response = await request(app)
@@ -73,14 +76,14 @@ describe('Admin - Organizations API', () => {
       );
       [header, ...data] = response.text.split(/\n/);
       expect(header).to.equal(
-        '"Organization","Agency"'
+        '"Organization","Agency","Self Authorized"'
       );
       expect(data.length).to.equal(2);
       expect(data[0]).to.equal(
-        `"${org1.name}","${org1.agency}"`
+        `"${org1.name}","${org1.agency}",false`
       );
       expect(data[1]).to.equal(
-        `"${org2.name}","${org2.agency}"`
+        `"${org2.name}","${org2.agency}",true`
       );
     });
   });


### PR DESCRIPTION
Fixes #4266

## Changes proposed in this pull request:
- Adds "Self Authorized" column to Organizations and Published Sites reports, containing data from the Organization model.
- Adds self authorization values to one org in the test data.

## security considerations
None. This change makes data already available to admins available in two reports available to admins. 
