### PR TITLE
Change self authorized field from timestamp to boolean

### DIFF
--- a/admin-client/src/pages/organization/Index.svelte
+++ b/admin-client/src/pages/organization/Index.svelte
@@ -32,7 +32,7 @@
           regular
         {/if}
       </td>
-      <td>{formatDateTime(org.selfAuthorizedAt)}</td>
+      <td>{org.isSelfAuthorized ? 'Yes' : 'No'}</td>
       <td>
         {#if org.isActive}
           active

--- a/api/models/organization.js
+++ b/api/models/organization.js
@@ -119,20 +119,10 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: true,
     },
-    selfAuthorizedAt: {
-      type: DataTypes.DATE,
-      allowNull: true,
-    },
     isSelfAuthorized: {
-      type: DataTypes.VIRTUAL,
-      get() {
-        return !!this.selfAuthorizedAt;
-      },
-      set(isSelfAuthorized) {
-        if (this.isSelfAuthorized !== isSelfAuthorized) {
-          this.selfAuthorizedAt = isSelfAuthorized ? new Date() : null;
-        }
-      },
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
   }, {
     paranoid: true,

--- a/api/serializers/organization.js
+++ b/api/serializers/organization.js
@@ -10,7 +10,6 @@ const attributes = {
   daysUntilSandboxCleaning: '',
   isActive: '',
   agency: '',
-  selfAuthorizedAt: 'date',
   isSelfAuthorized: '',
 };
 

--- a/migrations/20231011151001-change-org-self-auth-to-boolean.js
+++ b/migrations/20231011151001-change-org-self-auth-to-boolean.js
@@ -1,0 +1,13 @@
+const TABLE = 'organization';
+
+exports.up = async db => {
+  await db.addColumn(TABLE, 'isSelfAuthorized', { type: 'boolean', notNull: true, defaultValue: false });
+  await db.runSql('update "organization" set "isSelfAuthorized" = TRUE where "selfAuthorizedAt" is not null');
+  await db.removeColumn(TABLE, 'selfAuthorizedAt');
+};
+
+exports.down = async db => {
+  await db.addColumn(TABLE, 'selfAuthorizedAt', { type: 'timestamp', allowNull: true });
+  await db.runSql('update "organization" set "selfAuthorizedAt" = CURRENT_DATE where "isSelfAuthorized" IS TRUE');
+  await db.removeColumn(TABLE, 'isSelfAuthorized');
+};

--- a/public/swagger/Organization.json
+++ b/public/swagger/Organization.json
@@ -33,9 +33,6 @@
         { "type": ["string"] }
       ]
     },
-    "selfAuthorizedAt": {
-      "type": "date-time"
-    },
     "isSelfAuthorized": {
       "type": "boolean"
     }

--- a/scripts/create-dev-data.js
+++ b/scripts/create-dev-data.js
@@ -167,7 +167,7 @@ async function createData() {
     Organization.create({
       name: 'agency3',
       agency: 'Bureau of Testing',
-      selfAuthorizedAt: addDays(new Date(), -183),
+      isSelfAuthorized: true,
     }),
     Organization.create({
       name: 'agency4',

--- a/test/api/admin/requests/domain.test.js
+++ b/test/api/admin/requests/domain.test.js
@@ -111,7 +111,7 @@ describe('Admin - Domains API', () => {
       const org = await factory.organization.create({
         name: 'Test Org',
         agency: 'Test Agency',
-        selfAuthorizedAt: new Date(),
+        isSelfAuthorized: true,
       });
       const site = await factory.site({ organizationId: org.id });
       const domain = await factory.domain.create({

--- a/test/api/admin/requests/organization.test.js
+++ b/test/api/admin/requests/organization.test.js
@@ -56,11 +56,8 @@ describe('Admin - Organizations API', () => {
     it('returns all organizations', async () => {
       const user = await factory.user();
 
-      const org1 = await factory.organization.create({agency: 'Agency 1'});
-      const org2 = await factory.organization.create({
-        agency: 'Agency 2',
-        selfAuthorizedAt: new Date(),
-      });
+      const org1 = await factory.organization.create({agency: 'Agency 1', isSelfAuthorized: false});
+      const org2 = await factory.organization.create({agency: 'Agency 2', isSelfAuthorized: true});
 
       const cookie = await authenticatedSession(user, sessionConfig);
       const response = await request(app)

--- a/test/api/unit/models/organization.test.js
+++ b/test/api/unit/models/organization.test.js
@@ -49,66 +49,6 @@ describe('Organization model', () => {
     expect(error.name).to.eq('SequelizeUniqueConstraintError');
   });
 
-  describe('isSelfAuthorized', () => {
-    it('is true when `selfAuthorizedAt` is present', () => {
-      const org = Organization.build({ name: 'foo', selfAuthorizedAt: new Date() });
-      expect(org.isSelfAuthorized).to.be.true;
-    });
-
-    it('is false when `selfAuthorizedAt` is absent', () => {
-      const org = Organization.build({ name: 'foo' });
-      expect(org.isSelfAuthorized).to.be.false;
-    });
-  });
-
-  describe('isSelfAuthorized(true)', () => {
-    describe('when `selfAuthorizedAt` is absent', () => {
-      const org = Organization.build({ name: 'foo' });
-
-      it('sets `selfAuthorizedAt` to the current date', () => {
-        const before = new Date();
-
-        expect(org.selfAuthorizedAt).to.be.undefined;
-        org.isSelfAuthorized = true;
-        expect(org.selfAuthorizedAt).to.be.within(before, new Date());
-      });
-    });
-
-    describe('when `selfAuthorizedAt` is present', () => {
-      const selfAuthorizedAt = new Date();
-      const org = Organization.build({ name: 'foo', selfAuthorizedAt });
-
-      it('does nothing', () => {
-        expect(org.selfAuthorizedAt).to.eq(selfAuthorizedAt);
-        org.isSelfAuthorized = true;
-        expect(org.selfAuthorizedAt).to.eq(selfAuthorizedAt);
-      });
-    });
-
-    describe('isSelfAuthorized(false)', () => {
-      describe('when `selfAuthorizedAt` is absent', () => {
-        const org = Organization.build({ name: 'foo' });
-
-        it('does nothing', () => {
-          expect(org.selfAuthorizedAt).to.be.undefined;
-          org.isSelfAuthorized = false;
-          expect(org.selfAuthorizedAt).to.be.undefined;
-        });
-      });
-
-      describe('when `selfAuthorizedAt` is present', () => {
-        const selfAuthorizedAt = new Date();
-        const org = Organization.build({ name: 'foo', selfAuthorizedAt });
-
-        it('sets `selfAuthorizedAt` to null', () => {
-          expect(org.selfAuthorizedAt).to.eq(selfAuthorizedAt);
-          org.isSelfAuthorized = false;
-          expect(org.selfAuthorizedAt).to.be.null;
-        });
-      });
-    });
-  });
-
   it('can have many users', async () => {
     const [org, user1, user2] = await Promise.all([
       orgFactory.create(),
@@ -207,9 +147,12 @@ describe('Organization model', () => {
 
   describe('.byName()', () => {
     it('returns organizations ordered by name', async () => {
-      const orgB = Organization.create({ name: 'Org B' });
-      const orgA = Organization.create({ name: 'Org A' });
-      const orgC = Organization.create({ name: 'Org C' });
+      const [orgB, orgA, orgC] = await Promise.all([
+        Organization.create({ name: 'Org B' }),
+        Organization.create({ name: 'Org A' }),
+        Organization.create({ name: 'Org C' }),
+      ]);
+
       const result = await Organization.scope('byName').findAll();
       expect(result.map((org) => org.id)).to.include.ordered.members([
         orgA.id,


### PR DESCRIPTION
Fixes #4268 

Modifies the organization model and table to store only a boolean for `isSelfAuthorized` instead of a timestamp.

## Changes proposed in this pull request:
- Replaces the `isSelfAuthorized` computed field on Organization with a real `isSelfAuthorized` field (boolean, non null, default false)
- Sets this field to true only for organizations where `selfAuthorizedAt` is not null.
- Removes the `selfAuthorizedAt` field from Organization

## Migration consideration:
The migration in this PR replaces timestamp data with boolean data. This is destructive, but allowable provided we do not need or want this timestamp data. The `down` callback on the migration does retain the key true/false data by setting the timestamp to the current time in place of `true`, which is consistent with the app behavior before this migration.

## security considerations
None. This is a change in the representation of data already available to admins. 