### PR TITLE
fix: Fixes domain checkProvisionStatus with new CF api response

### DIFF
--- a/api/services/Domain.js
+++ b/api/services/Domain.js
@@ -254,7 +254,7 @@ async function checkProvisionStatus(id) {
   const service = await cfApi().fetchServiceInstance(domain.serviceName);
   const {
     last_operation: { state: lastOperation },
-  } = service.entity;
+  } = service;
 
   switch (lastOperation) {
     case 'succeeded':

--- a/test/api/unit/services/Domain.test.js
+++ b/test/api/unit/services/Domain.test.js
@@ -302,7 +302,7 @@ describe('Domain Service', () => {
     it('sets the domain state to `provisioned` if successful', async () => {
       sinon
         .stub(CloudFoundryAPIClient.prototype, 'fetchServiceInstance')
-        .resolves({ entity: { last_operation: { state: 'succeeded' } } });
+        .resolves({ last_operation: { state: 'succeeded' } });
       sinon.spy(DomainQueue.prototype, 'add');
 
       const domain = await DomainFactory.create({
@@ -324,7 +324,7 @@ describe('Domain Service', () => {
     it('updates the associated site if successful', async () => {
       sinon
         .stub(CloudFoundryAPIClient.prototype, 'fetchServiceInstance')
-        .resolves({ entity: { last_operation: { state: 'succeeded' } } });
+        .resolves({ last_operation: { state: 'succeeded' } });
       sinon.spy(DomainQueue.prototype, 'add');
       const siteUpdateSpy = sinon.spy(
         DomainService,
@@ -350,7 +350,7 @@ describe('Domain Service', () => {
     it('sets the domain state to `failed` if failed', async () => {
       sinon
         .stub(CloudFoundryAPIClient.prototype, 'fetchServiceInstance')
-        .resolves({ entity: { last_operation: { state: 'failed' } } });
+        .resolves({ last_operation: { state: 'failed' } });
       sinon.spy(DomainQueue.prototype, 'add');
 
       const domain = await DomainFactory.create({
@@ -375,7 +375,7 @@ describe('Domain Service', () => {
     it('requeues the status check otherwise', async () => {
       sinon
         .stub(CloudFoundryAPIClient.prototype, 'fetchServiceInstance')
-        .resolves({ entity: { last_operation: { state: 'something else' } } });
+        .resolves({ last_operation: { state: 'something else' } });
       sinon.stub(DomainQueue.prototype, 'add');
 
       const domain = await DomainFactory.create({


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fixes the `checkProvisionStatus` function in the domain provisioning job to look at the new CF API V3 response structure

## security considerations
None
