### PR TITLE
chore: update slack release notes format and bump pattern matcher

### DIFF
--- a/.cz.json
+++ b/.cz.json
@@ -13,7 +13,7 @@
       "example": "feat: this feature enable customize through config file",
       "schema": "<type>: <body>",
       "schema_pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w \\-'])+([\\s\\S]*)",
-      "bump_pattern": "^(.+!|BREAKING CHANGE|chore|docs|feat|fix|perf|refactor|revert|style|test):",
+      "bump_pattern": "^(.+!|BREAKING CHANGE|chore|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\-\\.]+\\))?:",
       "bump_map": {
           ".+!": "MAJOR",
           "BREAKING CHANGE": "MAJOR",
@@ -29,7 +29,7 @@
       },
       "change_type_order": ["Breaking Changes", "Added", "Fixed", "Performance", "Reverted", "Maintenance", "Documentation"],
       "commit_parser": "^((?P<change_type>chore|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE)(?:\\((?P<scope>[^()\r\n]*)\\)|\\()?(?P<breaking>!)?|\\w+!):\\s(?P<message>.*)?",
-      "changelog_pattern": "^(.+!|BREAKING CHANGE|chore|docs|feat|fix|perf|refactor|revert|style|test):",
+      "changelog_pattern": "^(.+!|BREAKING CHANGE|chore|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\-\\.]+\\))?:",
       "change_type_map": {
         "BREAKING CHANGE": "Breaking Changes",
         "chore": "Maintenance",

--- a/ci/tasks/get-changelog-version.sh
+++ b/ci/tasks/get-changelog-version.sh
@@ -6,10 +6,11 @@ version=`cat .git/ref`
 
 awk -v version=$version '/^## / { if (p) { exit }; if ($2 == version) { p=1; next } } p && NF' CHANGELOG.md > releaselog.md
 
+cat releaselog.md | sed -E 's/### (.*)/\n*\1*/g' | sed -E 's/^-/•/g' > templog.md
+
 echo ":tada: New cloud.gov Pages Release :tada:
 
 https://github.com/cloud-gov/pages-core/releases/tag/$version
-
-`cat releaselog.md`
+`cat templog.md`
 " > slackrelease.md
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- update slack release notes format
- update bump pattern matcher (to include scopes like `feat(admin)`)

## security considerations
None