### PR TITLE
feat: add owasp zap scan task type migration (#4260)

### DIFF
--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -265,6 +265,8 @@ function defaultContext(req, res) {
   };
 }
 
+const DEFAULT_BUILD_TASK_PARAMS = "-p '{ \"STATUS_CALLBACK\": \"{{job.data.STATUS_CALLBACK}}\", \"TASK_ID\": {{job.data.TASK_ID}}, \"AWS_DEFAULT_REGION\": \"{{job.data.AWS_DEFAULT_REGION}}\", \"AWS_ACCESS_KEY_ID\": \"{{job.data.AWS_ACCESS_KEY_ID}}\", \"AWS_SECRET_ACCESS_KEY\": \"{{job.data.AWS_SECRET_ACCESS_KEY}}\", \"BUCKET\": \"{{job.data.BUCKET}}\" }'";
+
 module.exports = {
   buildEnum,
   generateS3ServiceName,
@@ -288,4 +290,5 @@ module.exports = {
   wrapHandler,
   wrapHandlers,
   defaultContext,
+  DEFAULT_BUILD_TASK_PARAMS,
 };

--- a/ci/pipeline-dev.yml
+++ b/ci/pipeline-dev.yml
@@ -92,6 +92,7 @@ jobs:
             image: cf-image
             params:
               <<: *env-cf
+              APP_ENV: ((deploy-env))
               CF_APP_NAME: pages-((deploy-env))
               CF_TASK_NAME: run-migrations
               CF_TASK_COMMAND: 'yarn run migrate:up'

--- a/ci/pipeline-production.yml
+++ b/ci/pipeline-production.yml
@@ -93,6 +93,7 @@ jobs:
         image: cf-image
         params:
           <<: *env-cf
+          APP_ENV: ((deploy-env))
           CF_APP_NAME: pages-((deploy-env))
           CF_TASK_NAME: run-migrations
           CF_TASK_COMMAND: 'yarn run migrate:up'

--- a/ci/pipeline-staging.yml
+++ b/ci/pipeline-staging.yml
@@ -198,6 +198,7 @@ jobs:
         image: cf-image
         params:
           <<: *env-cf
+          APP_ENV: ((deploy-env))
           CF_APP_NAME: pages-((deploy-env))
           CF_TASK_NAME: run-migrations
           CF_TASK_COMMAND: 'yarn run migrate:up'

--- a/migrations/20231025141411-btt-owasp-zap-scan.js
+++ b/migrations/20231025141411-btt-owasp-zap-scan.js
@@ -1,0 +1,32 @@
+const { DEFAULT_BUILD_TASK_PARAMS } = require('../api/utils');
+
+const TABLE = 'build_task_type';
+const TASK_TYPE_NAME = 'owasp-zap-scan'
+const env = process.env.APP_ENV || 'local'
+
+exports.up = async (db, callback) => {
+  await db.insert(TABLE,
+    ['name', 'description', 'metadata', 'createdAt', 'updatedAt', 'runner', 'startsWhen'],
+    [
+      TASK_TYPE_NAME,
+      'Runs an OWASP ZAP scan to find vulnerabilities in the built site',
+      {
+        "appName": `pages-owasp-zap-task-${env}`,
+        "template": {
+          "command": `zap/run_pages_task.py -t {{task.Build.url}} ${DEFAULT_BUILD_TASK_PARAMS}`,
+          "disk_in_mb": 3000
+        }
+      },
+      new Date(),
+      new Date(),
+      'cf_task',
+      'complete'
+    ],
+    callback
+  );
+};
+
+exports.down = async db => {
+  await db.runSql(`delete from "${TABLE}" where name=\'${TASK_TYPE_NAME}\'`);
+};
+


### PR DESCRIPTION
## Changes proposed in this pull request:
- add owasp zap scan task type migration
- close #4260

## Notes
I still really don't like having to add the dynamically set environment variables to the template but I also don't see a way around it for now

## security considerations
None 