### PR TITLE
Add end-to-end test framework via playwright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,9 @@ credentials*.json
 tmp
 ci/vars/.*
 uaa/cloudfoundry-identity-uaa-4.19.0.war
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/
+playwright/.auth/*
+!playwright/.auth/.gitkeep 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -57,19 +57,19 @@ Note that `npm run update-local-config` will need to be re-run with some frequen
 
 If local UAA authentication is not needed, Docker can be set up and started with these commands:
 
-1. Run `docker-compose build`.
-1. Run `docker-compose run --rm app yarn` to install dependencies.
-1. Run `docker-compose run --rm admin-client yarn` to install dependencies.
-1. Run `docker-compose run --rm app yarn migrate:up` to initialize the local database.
-1. Run `docker-compose run --rm app yarn create-dev-data` to create some fake development data for your local database.
-1. Run `docker-compose up` to start the development environment.
+1. Run `docker compose build`.
+1. Run `docker compose run --rm app yarn` to install dependencies.
+1. Run `docker compose run --rm admin-client yarn` to install dependencies.
+1. Run `docker compose run --rm app yarn migrate:up` to initialize the local database.
+1. Run `docker compose run --rm app yarn create-dev-data` to create some fake development data for your local database.
+1. Run `docker compose up` to start the development environment.
 
-Any time the node dependencies are changed (like from a recently completed new feature), `docker-compose run --rm app yarn` will need to be re-run to install updated dependencies after pulling the new code from GitHub.
+Any time the node dependencies are changed (like from a recently completed new feature), `docker compose run --rm app yarn` will need to be re-run to install updated dependencies after pulling the new code from GitHub.
 
-In order to make it possible to log in with local UAA authentication in a development environment it is necessary to also build and start the UAA container, which requires specifying a second docker-compose configuration file when executing the docker-compose commands which build containers or start the development environment, e.g.:
+In order to make it possible to log in with local UAA authentication in a development environment it is necessary to also build and start the UAA container, which requires specifying a second docker compose configuration file when executing the docker compose commands which build containers or start the development environment, e.g.:
 
-1. `docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml build`
-1. `docker-compose -f ./docker-compose.yml -f ./docker-compose.uaa.yml up`
+1. `docker compose -f ./docker compose.yml -f ./docker compose.uaa.yml build`
+1. `docker compose -f ./docker compose.yml -f ./docker compose.uaa.yml up`
 
 #### Check to see if everything is working correctly
 
@@ -78,16 +78,16 @@ In order to make it possible to log in with local UAA authentication in a develo
 
 **Pro tips:**
 
-In our Docker Compose environment, `app` is the name of the container where the Federalist web application runs. You can run any command in the context of the web application by running `docker-compose run --rm app <THE COMMAND>`.
+In our Docker Compose environment, `app` is the name of the container where the Federalist web application runs. You can run any command in the context of the web application by running `docker compose run --rm app <THE COMMAND>`.
 
 For example:
 
-- Use `docker-compose run --rm app yarn test` to run local testing on the app.
-- Use `docker-compose run --rm app yarn lint` to check that your local changes meet our linting standards.
+- Use `docker compose run --rm app yarn test` to run local testing on the app.
+- Use `docker compose run --rm app yarn lint` to check that your local changes meet our linting standards.
 
-Similarly you can run any command in the context of the database container `db` by running `docker-compose run --rm db <THE COMMAND>`.
+Similarly you can run any command in the context of the database container `db` by running `docker compose run --rm db <THE COMMAND>`.
 
-Note that when using `docker-compose run`, the docker network will not be exposed to your local machine. If you do need the network available, run `docker-compose run --rm --service-ports app <THE COMMAND>`.
+Note that when using `docker compose run`, the docker network will not be exposed to your local machine. If you do need the network available, run `docker compose run --rm --service-ports app <THE COMMAND>`.
 
 The `db` container is exposed on port `5433` of your host computer to make it easier to run commands on. For instance, you can open a `psql` session to it by running `psql -h localhost -p 5433 -d federalist -U postgres`.
 
@@ -325,29 +325,49 @@ When making code changes, be sure to write new or modify existing tests to cover
 The full test suite of both front and back end tests can be run via:
 
 ```sh
-docker-compose run --rm app yarn test
+docker compose run --rm app yarn test
 ```
 
 You can also just run back or front end tests via:
 
 ```sh
-docker-compose run --rm app yarn test:server  # for all back end tests
-docker-compose run --rm app yarn test:server:file ./test/api/<path/to/test.js> # to run a single back end test file
-docker-compose run --rm app yarn test:client  # for all front end tests
-docker-compose run --rm app yarn test:client:watch  # to watch and re-run front end tests
-docker-compose run --rm app yarn test:client:file ./test/frontend/<path/to/test.js> # to run a single front end test file
+docker compose run --rm app yarn test:server  # for all back end tests
+docker compose run --rm app yarn test:server:file ./test/api/<path/to/test.js> # to run a single back end test file
+docker compose run --rm app yarn test:client  # for all front end tests
+docker compose run --rm app yarn test:client:watch  # to watch and re-run front end tests
+docker compose run --rm app yarn test:client:file ./test/frontend/<path/to/test.js> # to run a single front end test file
 ```
 
 To view coverage reports as HTML:
 
 ```sh
-docker-compose run --rm app yarn test:cover
-docker-compose run --rm --service-ports app yarn serve-coverage
+docker compose run --rm app yarn test:cover
+docker compose run --rm --service-ports app yarn serve-coverage
 ```
 
 and then visit http://localhost:8080.
 
 For the full list of available commands that you can run with `yarn` or `npm`, see the `"scripts"` section of `package.json`.
+
+**End-to-end testing (experimental)**
+
+We also have end-to-end (e2e) testing available via [playwright](https://playwright.dev/). Before your first run, make sure you have Playwright and all the necessary dependencies:
+
+```sh
+yarn install playwright
+yarn playwright install-deps
+yarn playwright install
+```
+
+To run, start the application with `docker compose up` and then run the following commands:
+
+```sh
+docker compose run --rm app node scripts/create-test-users.js
+yarn test:e2e
+docker compose run --rm app node scripts/remove-test-users.js
+```
+
+Note that the create/remove test user scripts only need to be run once per day to create a new valid test session. You can also run Playwright tests with the [VSCode Extension](https://playwright.dev/docs/getting-started-vscode)
 
 ### Linting
 
@@ -358,13 +378,13 @@ Because this project was not initially written in a way that complies with our c
 To lint the files in a branch, run:
 
 ```sh
-docker-compose run --rm app yarn lint
+docker compose run --rm app yarn lint
 ```
 
 `eslint` also has a helpful auto-fix command that can be run by:
 
 ```sh
-docker-compose run --rm app node_modules/.bin/eslint --fix path/to/file.js
+docker compose run --rm app node_modules/.bin/eslint --fix path/to/file.js
 ```
 
 ## Feature Flags
@@ -463,3 +483,5 @@ This convention is enforced via [this ruleset](https://github.com/cloud-gov/page
 The benefit of adhering to this convention is that we can more easily reason about our commit history and also generate nice changelogs via [Commitizen](https://commitizen-tools.github.io/commitizen/).
 
 If you didn't follow this convention while making your commits locally or on a development branch, you'll still have an opportunity to edit the commit history to match the Convention Commits specification. While the code is on a non-default branch, you can perform an [interactive rebase](https://git-scm.com/docs/git-rebase) to rewrite the history.
+
+##

--- a/Dockerfile-pw
+++ b/Dockerfile-pw
@@ -1,0 +1,9 @@
+FROM node:18.15
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+
+RUN yarn install
+RUN yarn playwright install-deps
+RUN yarn playwright install

--- a/ci/partials/e2e-test.yml
+++ b/ci/partials/e2e-test.yml
@@ -1,0 +1,8 @@
+platform: linux
+inputs: [name: src]
+outputs: [name: src]
+run:
+  dir: src
+  path: ci/tasks/e2e-test.sh
+params:
+  PW_TEST_HTML_REPORT_OPEN: never

--- a/ci/partials/get-app-env.yml
+++ b/ci/partials/get-app-env.yml
@@ -1,0 +1,6 @@
+platform: linux
+inputs: [name: src]
+outputs: [name: src]
+run:
+  dir: src
+  path: ci/tasks/get-app-env.sh

--- a/ci/partials/remove-test-users.yml
+++ b/ci/partials/remove-test-users.yml
@@ -1,0 +1,7 @@
+platform: linux
+inputs: [name: src]
+outputs: [name: src]
+run:
+  dir: src
+  path: bash
+  args: [-c, yarn remove-test-users]

--- a/ci/pipeline-dev.yml
+++ b/ci/pipeline-dev.yml
@@ -277,6 +277,72 @@ jobs:
             <<: *env-cf
             CF_APP_NAME: pages-queues-ui-((deploy-env))
 
+  - name: e2e-test
+    plan:
+      - get: src
+        resource: pr-((deploy-env))
+        trigger: true
+        passed:
+        - test-and-deploy-api-pages
+        - test-and-deploy-admin-client-pages
+        - deploy-queues-ui-pages
+      - get: node
+      - get: cf-image
+      - put: gh-status
+        inputs: [src]
+        params: {state: pending}
+      - task: get-app-env
+        file: src/ci/partials/get-app-env.yml
+        image: cf-image
+        params:
+          <<: *env-cf
+          APP_ENV: ((deploy-env))
+          CF_APP_NAME: pages-((deploy-env))
+      - task: run-e2e-tests
+        file: src/ci/partials/e2e-test.yml
+        image: node
+        params:
+          APP_ENV: ((deploy-env))
+          APP_HOSTNAME: https://((((deploy-env))-pages-domain))
+          DOMAIN: ((((deploy-env))-pages-domain))
+          PRODUCT: pages
+        ensure:
+          do:
+          - task: remove-test-users
+            file: src/ci/partials/remove-test-users.yml
+            image: node
+            params:
+              APP_ENV: ((deploy-env))
+              PRODUCT: pages
+          - put: s3
+    on_failure:
+      in_parallel:
+        - put: gh-status
+          inputs: [src]
+          params: {state: failure}
+        - put: slack
+          params:
+            text: |
+              :x: FAILED: pages e2e testing on pages ((deploy-env))
+              <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME?vars.deploy-env="((deploy-env))"|View build details>
+            channel: ((slack-channel))
+            username: ((slack-username))
+            icon_url: ((slack-icon-url))
+    on_success:
+      in_parallel:
+        - put: gh-status
+          inputs: [src]
+          params: {state: success}
+        - put: slack
+          params:
+            text: |
+              :white_check_mark: SUCCESS: Successfully passed e2e testing on pages ((deploy-env))
+              <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME?vars.deploy-env="((deploy-env))"|View build details>
+            channel: ((slack-channel))
+            username: ((slack-username))
+            icon_url: ((slack-icon-url))
+
+
   - name: set-pipeline
     plan:
     - get: src
@@ -350,6 +416,18 @@ resources:
       aws_region: us-gov-west-1
       tag: ((harden-concourse-task-tag))
 
+  - name: s3
+    type: s3-resource
+    source:
+      access_key_id: ((test-results-access-key-id))
+      secret_access_key: ((test-results-secret-access-key))
+      bucket: ((test-results-bucket))
+      region: us-gov-west-1
+      change_dir_to: src
+      options:
+      - "--exclude '*'"
+      - "--include 'playwright-report/*'"
+
 ############################
 #  RESOURCE TYPES
 
@@ -370,3 +448,8 @@ resource_types:
     type: docker-image
     source:
       repository: cfcommunity/slack-notification-resource
+
+  - name: s3-resource
+    type: docker-image
+    source:
+      repository: 18fgsa/s3-resource-simple

--- a/ci/tasks/e2e-test.sh
+++ b/ci/tasks/e2e-test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+yarn install
+yarn playwright install-deps
+yarn playwright install
+
+export GIT_COMMIT=`git rev-parse HEAD`
+mkdir -p playwright-report/$APP_ENV/$GIT_COMMIT
+
+yarn create-test-users
+yarn playwright test

--- a/ci/tasks/get-app-env.sh
+++ b/ci/tasks/get-app-env.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+cf api $CF_API
+cf auth
+
+cf t -o $CF_ORG -s $CF_SPACE
+
+echo "VCAP_SERVICES={`cf env $CF_APP_NAME | tail -n+3 | awk -v RS= 'NR==1' | tail -n+2 | tr -d '\n'`" >> .env
+echo "VCAP_APPLICATION={`cf env $CF_APP_NAME | tail -n+3 | awk -v RS= 'NR==2' | tail -n+2 | tr -d '\n'`" >> .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ volumes:
   yarn:
   nm-app:
   nm-admin:
+  pw-deps:
 
 services:
   app:

--- a/e2e/auth-session.js
+++ b/e2e/auth-session.js
@@ -1,0 +1,40 @@
+const crypto = require('crypto');
+
+const sessionConfig = require('../api/init/sessionConfig');
+const factory = require('../test/api/support/factory');
+
+function authenticatedSession(user, cfg = sessionConfig, role = 'pages.admin') {
+  const sessionKey = crypto.randomBytes(8).toString('hex');
+
+  return Promise.resolve(user || factory.user())
+    .then((u) => {
+      const sessionBody = {
+        cookie: {
+          originalMaxAge: null,
+          expires: null,
+          httpOnly: true,
+          path: '/',
+        },
+        passport: {
+          user: u.id,
+        },
+        flash: {},
+        authenticated: true,
+        authenticatedAt: new Date(),
+        role,
+      };
+      return cfg.store.set(sessionKey, sessionBody);
+    })
+    .then(() => {
+      const signedSessionKey = `${sessionKey}.${crypto
+        .createHmac('sha256', cfg.secret)
+        .update(sessionKey)
+        .digest('base64')
+        .replace(/=+$/, '')}`;
+      return `${cfg.key}=s%3A${signedSessionKey}`;
+    });
+}
+
+module.exports = {
+  authenticatedSession,
+};

--- a/e2e/example.spec.js
+++ b/e2e/example.spec.js
@@ -1,0 +1,13 @@
+const { test, expect } = require('@playwright/test');
+
+test('has title', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page).toHaveTitle(/Pages/);
+});
+
+test('use cookie login', async ({ page }) => {
+  await page.goto('/sites');
+
+  await expect(page.getByText('Your sites')).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -102,7 +102,10 @@
     "migrate-build-notification-settings": "node ./scripts/migrate-build-notification-settings.js",
     "remove-bucket-website-configs": "node ./scripts/remove-bucket-website-configs.js",
     "check-object-paths": "node ./scripts/check-object-paths.js",
-    "queued-builds-check": "node ./scripts/queued-builds-check.js"
+    "queued-builds-check": "node ./scripts/queued-builds-check.js",
+    "test:e2e": "yarn playwright test",
+    "create-test-users": "DOTENV_CONFIG_PATH=.env node -r dotenv/config ./scripts/create-test-users.js",
+    "remove-test-users": "DOTENV_CONFIG_PATH=.env node -r dotenv/config ./scripts/remove-test-users.js"
   },
   "main": "index.js",
   "repository": {
@@ -118,7 +121,9 @@
     "@babel/preset-react": "^7.12.10",
     "@babel/register": "^7.22.15",
     "@cfaester/enzyme-adapter-react-18": "^0.6.0",
+    "@playwright/test": "^1.39.0",
     "@svgr/webpack": "8.0.1",
+    "@types/node": "^20.8.10",
     "autoprefixer": "^10.2.5",
     "aws-sdk-client-mock": "^3.0.0",
     "babel-eslint": "^10.0.1",
@@ -151,6 +156,7 @@
     "nock": "^13.0.5",
     "nodemon": "^2.0.6",
     "nyc": "^15.1.0",
+    "playwright": "^1.39.0",
     "postcss": "^8.3.0",
     "postcss-loader": "^5.3.0",
     "promise-props": "^1.0.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,83 @@
+// @ts-check
+const { defineConfig, devices } = require('@playwright/test');
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+
+const APP_ENV = process.env.APP_ENV || 'local';
+const GIT_COMMIT = process.env.GIT_COMMIT || 'local';
+
+module.exports = defineConfig({
+  testDir: './e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: [
+    ['html', { host: '0.0.0.0', outputFolder: `playwright-report/${APP_ENV}/${GIT_COMMIT}` }],
+  ],
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: process.env.APP_HOSTNAME || 'http://localhost:1337',
+    ignoreHTTPSErrors: true,
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+      },
+    },
+
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    /* Unsupported on Linux Arm64 :( */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+});

--- a/scripts/create-test-users.js
+++ b/scripts/create-test-users.js
@@ -1,0 +1,34 @@
+/* eslint-disable no-console */
+const fs = require('fs');
+const factory = require('../test/api/support/factory');
+const { authenticatedSession } = require('../e2e/auth-session');
+
+async function createUsers() {
+  const user = await factory.user({ username: 'test-e2e-user' });
+  const [name, value] = (await authenticatedSession(user)).split('=');
+  const cookie = {
+    name,
+    value,
+    domain: process.env.DOMAIN,
+    path: '/',
+    expires: (Number(new Date()) + (24 * 60 * 60 * 1000)) / 1000,
+    httpOnly: true,
+    secure: process.env.env === 'production',
+    sameSite: 'Lax',
+  };
+
+  fs.writeFileSync('playwright/.auth/user.json', JSON.stringify(
+    { cookies: [cookie] }
+  ));
+}
+
+createUsers()
+  .then(() => {
+    console.log('Done!');
+    process.exit();
+  })
+  .catch((error) => {
+    console.error('Uh oh, we have a problem!');
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/remove-test-users.js
+++ b/scripts/remove-test-users.js
@@ -1,0 +1,23 @@
+/* eslint-disable no-console */
+const { Op } = require('sequelize');
+const { User } = require('../api/models');
+
+async function removeUsers() {
+  await User.destroy({
+    where: {
+      username: { [Op.like]: '%-e2e-%' },
+    },
+    force: true,
+  });
+}
+
+removeUsers()
+  .then(() => {
+    console.log('Done!');
+    process.exit();
+  })
+  .catch((error) => {
+    console.error('Uh oh, we have a problem!');
+    console.error(error);
+    process.exit(1);
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2678,6 +2678,13 @@
   dependencies:
     "@octokit/openapi-types" "^14.0.0"
 
+"@playwright/test@^1.39.0":
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.39.0.tgz#d10ba8e38e44104499e25001945f07faa9fa91cd"
+  integrity sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==
+  dependencies:
+    playwright "1.39.0"
+
 "@polka/url@^1.0.0-next.20":
   version "1.0.0-next.21"
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
@@ -3470,6 +3477,13 @@
   version "15.14.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.14.9.tgz#bc43c990c3c9be7281868bbc7b8fdd6e2b57adfa"
   integrity sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==
+
+"@types/node@^20.8.10":
+  version "20.8.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.10.tgz#a5448b895c753ae929c26ce85cab557c6d4a365e"
+  integrity sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -7004,7 +7018,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.2:
+fsevents@2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -9916,6 +9930,20 @@ pkg-dir@^7.0.0:
   dependencies:
     find-up "^6.3.0"
 
+playwright-core@1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.39.0.tgz#efeaea754af4fb170d11845b8da30b2323287c63"
+  integrity sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==
+
+playwright@1.39.0, playwright@^1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.39.0.tgz#184c81cd6478f8da28bcd9e60e94fcebf566e077"
+  integrity sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==
+  dependencies:
+    playwright-core "1.39.0"
+  optionalDependencies:
+    fsevents "2.3.2"
+
 ports@1.1.x:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ports/-/ports-1.1.0.tgz#b701aa285e95dae8c96cda275217724a1f7f6c60"
@@ -12085,6 +12113,11 @@ underscore@^1.12.1:
   version "1.13.6"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Changes proposed in this pull request:
- A new job, `e2e-test`, is added to the dev CI pipeline.
- This job creates a test user in the dev database, uses the associated token to run skeleton [Playwright](https://playwright.dev/) tests, removes the test user, then uploads the resulting test report to S3.

## Notes
Possible improvements:
- Adding this to staging
- Making the test reports more discoverable

## security considerations
CI creates (and removes) a test user with access to the dev database 
