### PR TITLE
fix(ci): Update ci staging audit src

### DIFF
--- a/ci/pipeline-staging.yml
+++ b/ci/pipeline-staging.yml
@@ -419,7 +419,7 @@ jobs:
   - name: audit-dependencies
     plan: 
       - get: src
-        resource: pr
+        resource: src-((deploy-env))
         trigger: true
         passed: [set-pipeline]
       - get: node


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updates `src` in staging ci audit task to grab `src-((deploy-env))` commit instead of the `pr` commit. It was unable to run set-pipeline since audit task using the `pr` source did not interact with the set-pipeline task.

## security considerations
none
