### PR TITLE
chore: Add length limit validation before branch name regex

### DIFF
--- a/api/controllers/site-branch-config.js
+++ b/api/controllers/site-branch-config.js
@@ -6,7 +6,6 @@ const {
 } = require('../serializers/site-branch-config');
 const EventCreator = require('../services/EventCreator');
 const {
-  branchRegex,
   ValidationError,
   parseSiteConfig,
 } = require('../utils/validators');
@@ -31,10 +30,6 @@ function validate({ branch, config = {}, context } = {}) {
 
   if (context && typeof context !== 'string') {
     throw new ValidationError('Context must be a valid string.');
-  }
-
-  if (!branchRegex.test(branch)) {
-    throw new ValidationError('Branch name must be valid.');
   }
 
   if (

--- a/api/models/build.js
+++ b/api/models/build.js
@@ -3,7 +3,7 @@ const { Op } = require('sequelize');
 const URLSafeBase64 = require('urlsafe-base64');
 const SiteBuildQueue = require('../services/SiteBuildQueue');
 
-const { branchRegex, shaRegex, isEmptyOrUrl } = require('../utils/validators');
+const { isEmptyOrBranch, isEmptyOrUrl, shaRegex } = require('../utils/validators');
 const { buildUrl } = require('../utils/build');
 const { buildEnum } = require('../utils');
 
@@ -262,7 +262,7 @@ module.exports = (sequelize, DataTypes) => {
       branch: {
         type: DataTypes.STRING,
         validate: {
-          is: branchRegex,
+          isEmptyOrBranch,
         },
         allowNull: false,
       },

--- a/api/models/site-branch-config.js
+++ b/api/models/site-branch-config.js
@@ -1,5 +1,5 @@
 const { Op } = require('sequelize');
-const { branchRegex } = require('../utils/validators');
+const { isEmptyOrBranch } = require('../utils/validators');
 
 function associate({ Domain, SiteBranchConfig, Site }) {
   // Associations
@@ -30,7 +30,7 @@ function define(sequelize, DataTypes) {
         type: DataTypes.STRING,
         allowNull: true,
         validate: {
-          is: branchRegex,
+          isEmptyOrBranch,
         },
       },
       s3Key: {

--- a/api/models/site.js
+++ b/api/models/site.js
@@ -1,7 +1,7 @@
 const { Op } = require('sequelize');
 const { toInt } = require('../utils');
 const {
-  branchRegex, isEmptyOrUrl, isValidSubdomain,
+  isEmptyOrBranch, isEmptyOrUrl, isValidSubdomain,
 } = require('../utils/validators');
 
 const afterValidate = (site) => {
@@ -131,12 +131,6 @@ const beforeValidate = (site) => {
     site.owner = site.owner.toLowerCase(); // eslint-disable-line no-param-reassign
   }
 };
-
-function isEmptyOrBranch(value) {
-  if (value && value.length && !branchRegex.test(value)) {
-    throw new Error('Invalid branch name — branches can only contain alphanumeric characters, underscores, and hyphens.');
-  }
-}
 
 module.exports = (sequelize, DataTypes) => {
   const Site = sequelize.define('Site', {

--- a/api/utils/validators.js
+++ b/api/utils/validators.js
@@ -94,6 +94,16 @@ function parseSiteConfigs(siteConfigs) {
   return parsedSiteConfigs;
 }
 
+function isEmptyOrBranch(value) {
+  if (value?.length >= 300) {
+    throw new Error('Invalid branch name — branch names are limitted to 299 characters.');
+  }
+
+  if (value && value.length && !branchRegex.test(value)) {
+    throw new Error('Invalid branch name — branches can only contain alphanumeric characters, underscores, and hyphens.');
+  }
+}
+
 function isEmptyOrUrl(value) {
   const validUrlOptions = {
     require_protocol: true,
@@ -133,6 +143,7 @@ module.exports = {
   isValidYaml,
   parseSiteConfig,
   parseSiteConfigs,
+  isEmptyOrBranch,
   isEmptyOrUrl,
   ValidationError,
   validBasicAuthUsername,

--- a/test/api/unit/models/build.test.js
+++ b/test/api/unit/models/build.test.js
@@ -234,6 +234,9 @@ describe('Build model', () => {
   });
 
   describe('validations', () => {
+    const branchNameError = 'Validation error: Invalid branch name — branches can only contain alphanumeric characters, underscores, and hyphens.'
+    const branchNameLengthError = 'Validation error: Invalid branch name — branch names are limitted to 299 characters.'
+
     it('should require a site object before saving', () => {
       const buildPromise = Build.create({ user: 1, site: null });
 
@@ -286,7 +289,7 @@ describe('Build model', () => {
       });
 
       return expect(buildPromise).to.be
-        .rejectedWith(ValidationError, 'Validation error: Validation is on branch failed');
+        .rejectedWith(ValidationError, branchNameError);
     });
 
     it('requires a valid branch name before saving no end slash', () => {
@@ -298,7 +301,7 @@ describe('Build model', () => {
       });
 
       return expect(buildPromise).to.be
-        .rejectedWith(ValidationError, 'Validation error: Validation is on branch failed');
+        .rejectedWith(ValidationError, branchNameError);
     });
 
     it('requires a valid branch name before saving no begin /', () => {
@@ -310,7 +313,20 @@ describe('Build model', () => {
       });
 
       return expect(buildPromise).to.be
-        .rejectedWith(ValidationError, 'Validation error: Validation is on branch failed');
+        .rejectedWith(ValidationError, branchNameError);
+    });
+
+    it('requires a valid branch name before saving and it cannot be >= 300 characters /', () => {
+      const branch = Array(301).join("b")
+      const buildPromise = Build.create({
+        user: 1,
+        site: 1,
+        requestedCommitSha: 'a172b66c31e19d456a448041a5b3c2a70c32d8b7',
+        branch,
+      });
+
+      return expect(buildPromise).to.be
+        .rejectedWith(ValidationError, branchNameLengthError);
     });
   });
 

--- a/test/api/unit/models/site-branch-config.test.js
+++ b/test/api/unit/models/site-branch-config.test.js
@@ -13,13 +13,23 @@ describe('Site Branch Config model', () => {
   before(clean);
   afterEach(clean);
 
-  it('`branch` to be an with invalid branch name', async () => {
+  it('`branch` to be an invalid branch name', async () => {
     const instance = SiteBranchConfig.build({ branch: 'Th!s I$ an 1nvalid *branch name' });
     const error = await instance.validate().catch(e => e);
 
     expect(error).to.be.an('Error');
     expect(error.name).to.eq('SequelizeValidationError');
-    expect(error.errors.map(e => e.message)).to.include('Validation is on branch failed');
+    expect(error.errors.map(e => e.message)).to.include('Invalid branch name — branches can only contain alphanumeric characters, underscores, and hyphens.');
+  });
+
+  it('`branch` to be an invalid branch name length >= 300 characters', async () => {
+    const branch = Array(301).join("b")
+    const instance = SiteBranchConfig.build({ branch });
+    const error = await instance.validate().catch(e => e);
+
+    expect(error).to.be.an('Error');
+    expect(error.name).to.eq('SequelizeValidationError');
+    expect(error.errors.map(e => e.message)).to.include('Invalid branch name — branch names are limitted to 299 characters.');
   });
 
   it('`branch` cannot be null when context is not `preview`', async () => {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds length limit to branch name of < 300 characters
- Refactors validator for all instances of branch name validation
- Add tests to check branch name length


## security considerations
Adds length check branch before running the branch name regex
