### PR TITLE
Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.4.1 (2023-11-30)
+
+### Fixed
+
+- transform AWS SDK Readable to string
+- Add queue name for site build and build task  queues
+
+### Maintenance
+
+- Remove bull to complete bullmq transition
+- upgrade major deps from audit
+- update dependencies, minor patch bumps for pages core and admin client
+
 ## 0.4.0 (2023-11-16)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pages-core",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "",
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
## :robot: This is an automated release PR
chore: release 0.4.1
tag to create: 0.4.1
increment detected: PATCH

## 0.4.1 (2023-11-30)

### Fixed

- transform AWS SDK Readable to string
- Add queue name for site build and build task  queues

### Maintenance

- Remove bull to complete bullmq transition
- upgrade major deps from audit
- update dependencies, minor patch bumps for pages core and admin client

## security considerations
Noted in individual PRs 
