### PR TITLE
fix: Add queue name for site build and build task queues

### DIFF
--- a/api/services/BuildTaskQueue.js
+++ b/api/services/BuildTaskQueue.js
@@ -70,7 +70,8 @@ BuildTaskQueue.messageBodyForBuild = buildTask => buildContainerEnvironment(buil
 BuildTaskQueue.sendTaskMessage = async (buildTask) => {
   const message = await BuildTaskQueue.messageBodyForBuild(buildTask);
   await setupBucket(buildTask.Build);
-  return BuildTaskQueue.bullClient.add(message);
+
+  return BuildTaskQueue.bullClient.add('sendTaskMessage', message);
 };
 
 module.exports = BuildTaskQueue;

--- a/api/services/SiteBuildQueue.js
+++ b/api/services/SiteBuildQueue.js
@@ -129,7 +129,7 @@ SiteBuildQueue.sendBuildMessage = async (build, buildCount) => {
   const message = await SiteBuildQueue.messageBodyForBuild(build);
   await setupBucket(build, buildCount);
 
-  return SiteBuildQueue.bullClient.add(message);
+  return SiteBuildQueue.bullClient.add('sendBuildMessage', message);
 };
 
 module.exports = SiteBuildQueue;

--- a/test/api/unit/services/SiteBuildQueue.test.js
+++ b/test/api/unit/services/SiteBuildQueue.test.js
@@ -55,7 +55,9 @@ describe('SiteBuildQueue', () => {
 
       await SiteBuildQueue.sendBuildMessage(build, 2);
 
-      const params = sendMessageStub.firstCall.args[0];
+      const jobName = sendMessageStub.firstCall.args[0];
+      const params = sendMessageStub.firstCall.args[1];
+      expect(jobName).to.equal('sendBuildMessage');
       expect(params).to.have.property('environment');
       expect(params.environment.length).to.equal(15);
       expect(params).to.have.property('containerName');


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add name to kick off site build and build tasks queue jobs properly

## security considerations
none
