### PR TITLE
Implement users report limited to users with a UAA Identity

### DIFF
--- a/admin-client/src/Router.svelte
+++ b/admin-client/src/Router.svelte
@@ -68,7 +68,8 @@
   page('/organizations/:id/edit', queryString, render(Pages.Organization.Edit));
   page('/reports/organizations', queryString, render(Pages.Organization.OrgsReport));
   page('/reports/published-sites', queryString, render(Pages.Organization.PublishedSitesReport));
-  page('/reports/users', queryString, render(Pages.User.UsersReport));
+  page('/reports/all-users', queryString, render(Pages.User.UsersReport));
+  page('/reports/active-users', queryString, render(Pages.User.ActiveUsersReport));
   page('/reports', queryString, render(Pages.Reports));
   page('/tasks', queryString, render(Pages.Tasks));
   page('*', render(Pages.NotFound));

--- a/admin-client/src/lib/api.js
+++ b/admin-client/src/lib/api.js
@@ -286,6 +286,14 @@ async function fetchUsersReportCSV() {
   return getAttachedFile('/reports/users.csv').catch(() => []);
 }
 
+async function fetchActiveUsersReport(query = {}) {
+  return get('/reports/active-users', query).catch(() => []);
+}
+
+async function fetchActiveUsersReportCSV() {
+  return getAttachedFile('/reports/active-users.csv').catch(() => []);
+}
+
 async function inviteUser(params) {
   return post('/users/invite', params);
 }
@@ -343,6 +351,8 @@ export {
   fetchUsers,
   fetchUsersReport,
   fetchUsersReportCSV,
+  fetchActiveUsersReport,
+  fetchActiveUsersReportCSV,
   inviteUser,
   resendInvite,
   logout,

--- a/admin-client/src/pages/Reports.svelte
+++ b/admin-client/src/pages/Reports.svelte
@@ -6,6 +6,7 @@
     <ul>
       <li><a href="/reports/organizations">Organizations</a></li>
       <li><a href="/reports/published-sites">Organizations With Published Sites</a></li>
-      <li><a href="/reports/users">Users</a></li>
+      <li><a href="/reports/active-users">Active Users</a></li>
+      <li><a href="/reports/all-users">All Users</a></li>
     </ul>
 </GridContainer>

--- a/admin-client/src/pages/user/ActiveUsersReport.svelte
+++ b/admin-client/src/pages/user/ActiveUsersReport.svelte
@@ -1,19 +1,18 @@
 <script>
   import { formatDistanceStrict } from 'date-fns';
   import { downloadCSV } from '../../helpers/downloadCSV';
-  import { fetchUsersReport, fetchUsersReportCSV } from '../../lib/api';
+  import { fetchActiveUsersReport, fetchActiveUsersReportCSV } from '../../lib/api';
   import { PaginatedQueryPage, DataTable } from '../../components';
 </script>
 
-<PaginatedQueryPage path="reports/organizations" title="All Users" query={fetchUsersReport} noSearch let:data>
+<PaginatedQueryPage path="reports/organizations" title="Active Users" query={fetchActiveUsersReport} noSearch let:data>
   <div>
-    <button type="button" class="usa-button margin-left-1" on:click={() => downloadCSV(fetchUsersReportCSV, 'users.csv')}>Download CSV of All Users</button>
+    <button type="button" class="usa-button margin-left-1" on:click={() => downloadCSV(fetchActiveUsersReportCSV, 'active-users.csv')}>Download CSV of Active Users</button>
   </div>
   <DataTable data={data}>
     <tr slot="header">
       <th scope="col">ID</th>
-      <th scope="col">Github Email</th>
-      <th scope="col">UAA Email</th>
+      <th scope="col">Email</th>
       <th scope="col">Organizations</th>
       <th scope="col">Details</th>
       <th scope="col">Created</th>
@@ -22,11 +21,6 @@
     <tr slot="item" let:item={user}>
       <td>
         <a href="/organizations/{user.id}">{user.id}</a>
-      </td>
-      <td>
-        {#if user.email }
-          {user.email}
-        {/if}
       </td>
       <td>
         {#if user.UAAIdentity }

--- a/admin-client/src/pages/user/index.js
+++ b/admin-client/src/pages/user/index.js
@@ -2,3 +2,4 @@ export { default as Show } from './Show.svelte';
 export { default as Index } from './Index.svelte';
 export { default as Invite } from './Invite.svelte';
 export { default as UsersReport } from './UsersReport.svelte';
+export { default as ActiveUsersReport } from './ActiveUsersReport.svelte';

--- a/api/admin/routers/api.js
+++ b/api/admin/routers/api.js
@@ -41,6 +41,8 @@ apiRouter.get('/reports/published-sites', AdminControllers.Domain.listPublished)
 apiRouter.get('/reports/published-sites.csv', AdminControllers.Domain.listPublishedCSV);
 apiRouter.get('/reports/users', AdminControllers.User.listForUsersReport);
 apiRouter.get('/reports/users.csv', AdminControllers.User.listForUsersReportCSV);
+apiRouter.get('/reports/active-users', AdminControllers.User.listForActiveUsersReport);
+apiRouter.get('/reports/active-users.csv', AdminControllers.User.listForActiveUsersReportCSV);
 apiRouter.put('/organization-role', AdminControllers.OrganizationRole.update);
 apiRouter.get('/roles', AdminControllers.Role.list);
 apiRouter.get('/sites', AdminControllers.Site.list);

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -77,6 +77,12 @@ const associate = ({
   User.addScope('withUAAIdentity', {
     include: UAAIdentity,
   });
+  User.addScope('havingUAAIdentity', {
+    include: [{
+      model: UAAIdentity,
+      required: true,
+    }],
+  });
   User.addScope('withOrganizationRoles', {
     include: {
       model: OrganizationRole,

--- a/test/api/admin/requests/user.test.js
+++ b/test/api/admin/requests/user.test.js
@@ -10,7 +10,7 @@ const {
 } = require('../../../../api/models');
 const { createUAAIdentity } = require('../../support/factory/uaa-identity');
 
-describe('Admin - Organizations API', () => {
+describe('Admin - Users API', () => {
   let userRole;
   let managerRole;
 
@@ -87,6 +87,106 @@ describe('Admin - Organizations API', () => {
       const cookie = await authenticatedSession(user1, sessionConfig);
       const response = await request(app)
         .get('/reports/users.csv')
+        .set('Cookie', cookie)
+        .set('Origin', config.app.adminHostname)
+        .expect(200);
+      expect(response.headers['content-type']).to.equal(
+        'text/csv; charset=utf-8'
+      );
+      expect(response.headers['content-disposition']).to.equal(
+        'attachment; filename="users.csv"'
+      );
+      [header, ...data] = response.text.split(/\n/);
+      expect(header).to.equal(
+        '"ID","Email","Organizations","Details","Created","Last Signed In"'
+      );
+      expect(data.length).to.equal(2);
+      expect(data).to.include(
+        `${user1.id},"user1@example.com","${org1.name}|${org2.name}","${org1.name}: manager, ${org2.name}: user","${user1.createdAt.toISOString()}","${user1.signedInAt.toISOString()}"`
+      );
+      expect(data).to.include(
+        `${user2.id},"user2@example.com","${org1.name}","${org1.name}: user","${user2.createdAt.toISOString()}","${user2.signedInAt.toISOString()}"`
+      );
+    });
+  });
+
+  describe('GET /admin/reports/active-users', () => {
+    it('should require admin authentication', async () => {
+      const response = await request(app)
+        ['get']('/reports/active-users')
+        .expect(401);
+      expect(response.body.message).to.equal('Unauthorized');
+    });
+
+    it('returns all users with UAA identities', async () => {
+      const user1 = await factory.user();
+      createUAAIdentity({uaaId: 'user_id_1', email: 'user1@example.com', userId: user1.id });
+
+      const user2 = await factory.user();
+      createUAAIdentity({uaaId: 'user_id_2', email: 'user2@example.com', userId: user2.id });
+
+      const user3 = await factory.user();
+      const user4 = await factory.user();
+
+      const org1 = await factory.organization.create();
+      const org2 = await factory.organization.create();
+
+      org1.addUser(user1, { through: { roleId: managerRole.id } });
+      org1.addUser(user2, { through: { roleId: userRole.id } });
+      org2.addUser(user1, { through: { roleId: userRole.id } });
+
+      org1.addUser(user3, { through: { roleId: managerRole.id } });
+      org1.addUser(user4, { through: { roleId: userRole.id } });
+      org2.addUser(user3, { through: { roleId: userRole.id } });
+
+      const cookie = await authenticatedSession(user1, sessionConfig);
+      const { body } = await request(app)
+        .get('/reports/active-users')
+        .set('Cookie', cookie)
+        .set('Origin', config.app.adminHostname)
+        .expect(200);
+
+      expect(body.data.length).to.equal(2);
+      ids = body.data.map(user => user['id']);
+      expect(ids).to.include(user1.id);
+      expect(ids).to.include(user2.id);
+      expect(ids).to.not.include(user3.id);
+      expect(ids).to.not.include(user4.id);
+    });
+  });
+
+  describe('GET /admin/reports/active-users.csv', () => {
+    it('should require admin authentication', async () => {
+      const response = await request(app)
+        ['get']('/reports/active-users.csv')
+        .expect(401);
+      expect(response.body.message).to.equal('Unauthorized');
+    });
+
+    it('returns all users with UAA identities', async () => {
+      const user1 = await factory.user();
+      createUAAIdentity({uaaId: 'user_id_1', email: 'user1@example.com', userId: user1.id });
+
+      const user2 = await factory.user();
+      createUAAIdentity({uaaId: 'user_id_2', email: 'user2@example.com', userId: user2.id });
+
+      const user3 = await factory.user();
+      const user4 = await factory.user();
+
+      const org1 = await factory.organization.create();
+      const org2 = await factory.organization.create();
+
+      org1.addUser(user1, { through: { roleId: managerRole.id } });
+      org1.addUser(user2, { through: { roleId: userRole.id } });
+      org2.addUser(user1, { through: { roleId: userRole.id } });
+
+      org1.addUser(user3, { through: { roleId: managerRole.id } });
+      org1.addUser(user4, { through: { roleId: userRole.id } });
+      org2.addUser(user3, { through: { roleId: userRole.id } });
+
+      const cookie = await authenticatedSession(user1, sessionConfig);
+      const response = await request(app)
+        .get('/reports/active-users.csv')
         .set('Cookie', cookie)
         .set('Origin', config.app.adminHostname)
         .expect(200);

--- a/test/api/unit/models/sequelize-hook.test.js
+++ b/test/api/unit/models/sequelize-hook.test.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const { OrganizationRole, Role, User  } = require('../../../../api/models');
+const { OrganizationRole, Role, User } = require('../../../../api/models');
 const orgFactory = require('../../support/factory/organization');
 const createUser = require('../../support/factory/user');
 

--- a/test/api/unit/models/user.test.js
+++ b/test/api/unit/models/user.test.js
@@ -209,6 +209,23 @@ describe('User model', () => {
     });
   });
 
+  describe('havingUAAIdentity', () => {
+    it('includes the UAAIdentity', async () => {
+      const { id: userId } = await createUser();
+      const uaaIdentity = await createUAAIdentity({ userId });
+
+      const user = await User.scope('havingUAAIdentity').findOne({ where: { id: userId } });
+      expect(user.UAAIdentity.id).to.eq(uaaIdentity.id);
+    });
+
+    it('excludes users without a UAAIdentity', async () => {
+      const { id: userId } = await createUser();
+
+      const user = await User.scope('havingUAAIdentity').findOne({ where: { id: userId } });
+      expect(user).to.be.null;
+    });
+  });
+
   describe('byUAAEmail', () => {
     it('filters users by uaa email and includes UAAIdentity', async () => {
       const [user1, user2] = await Promise.all([


### PR DESCRIPTION
Part of #4313

## Changes proposed in this pull request:
- Introduces a new Active Users report which only includes users who have a UAA Identity
- Renames the existing Users report "All Users". 

## security considerations
None. This adds a report visible by admins to conveniently view information admins already have access to. 
