### PR TITLE
Add global Sequelize hook to make count behavior consistent with find

### DIFF
--- a/test/api/unit/models/sequelize-hook.test.js
+++ b/test/api/unit/models/sequelize-hook.test.js
@@ -1,0 +1,51 @@
+const { expect } = require('chai');
+const { OrganizationRole, Role, User  } = require('../../../../api/models');
+const orgFactory = require('../../support/factory/organization');
+const createUser = require('../../support/factory/user');
+
+function clean() {
+  return Promise.all([
+    orgFactory.truncate(),
+    OrganizationRole.truncate({ force: true, cascade: true }),
+    User.truncate({ force: true, cascade: true }),
+  ]);
+}
+
+describe('Sequelize', () => {
+  let userRole;
+  let managerRole;
+
+  before(async () => {
+    await clean();
+    [userRole, managerRole] = await Promise.all([
+      Role.findOne({ where: { name: 'user' } }),
+      Role.findOne({ where: { name: 'manager' } }),
+    ]);
+  });
+
+  afterEach(clean);
+
+  // This test fails without the beforeCount hook in api/models/index.js
+  describe('global beforeCount hook', () => {
+    it('calculates count consistently', async () => {
+      const [user1, user2, org1, org2] = await Promise.all([
+        createUser(),
+        createUser(),
+        orgFactory.create(),
+        orgFactory.create(),
+      ]);
+
+      await Promise.all([
+        org1.addUser(user1, { through: { roleId: managerRole.id } }),
+        org1.addUser(user2, { through: { roleId: userRole.id } }),
+        org2.addUser(user1, { through: { roleId: userRole.id } }),
+      ]);
+
+      const model = User.scope('withOrganizationRoles');
+      const { rows, count } = await model.findAndCountAll();
+
+      expect(rows.length).to.eq(2);
+      expect(rows.length).to.eq(count);
+    });
+  });
+});


### PR DESCRIPTION
In ORM queries incorporating association joins, Sequelize's `count` sometimes reports a larger number than the number of rows that Sequelize returns by the same query. This causes inconsistencies between the actual number of returned results and the number of total results reported, a problem which specifically comes up with some of our reports. 

This PR adds a global `beforeCount` hook that changes Sequelize's default behavior to make `count` consistent. It also introduces a test which fails in the absence of this hook. 

In addition to the test case, the misbehavior can be seen in the admin interface at `/reports/users`:

**Without** the hook a current local development instance will show 14 rows of user data:
<img width="55" alt="Screenshot 2023-12-05 at 2 30 05 PM" src="https://github.com/cloud-gov/pages-core/assets/12150/c5138f77-3f2f-45da-b820-3298f0bb78e2">

but an inconsistent "total results: 17": 
<img width="200" alt="image" src="https://github.com/cloud-gov/pages-core/assets/12150/41cddf44-5eda-489d-a4de-3ea9ada88727">

**With** the hook the total is consistent:
<img width="203" alt="Screenshot 2023-12-05 at 2 30 10 PM" src="https://github.com/cloud-gov/pages-core/assets/12150/c6492571-a88c-49dd-b7e1-744766a8128d">

## Background

In working on #4313 it came to my attention that some of our PaginatedQueryPages were displaying inconsistent information. Specifically, the "total results: _n_" in PaginationBanner differed from the number of rows shown. 

@sknep identified this number as coming from the Sequelize's `count` via the `paginate` function in `api/utils/index.js`, and found other people [reporting](https://stackoverflow.com/questions/64354987/findandcountall-count-gets-a-bigger-number-than-the-actual-returned-data) related issues. 

This led me to https://github.com/sequelize/sequelize/issues/9481 and from there to https://github.com/sequelize/sequelize/issues/10557 where various workarounds are discussed. I experimented with simply adding `distinct: true`, but that caused other things to fail. What _did_ work for me was James M. Greene's [beforeCount hook](https://github.com/sequelize/sequelize/issues/10557#issuecomment-481399247), which I opted to place in `api/models/index.js`.

## Changes proposed in this pull request:
- Adds global Sequelize hook
- Adds unit test for this hook in `test/api/unit/models/sequelize-hook.test.js` — is there a better place for this to live?

## security considerations
None. This change is a bug fix that makes a reported count consistent with the size of the result set it refers to.