### PR TITLE
chore: Upgrade local and CI to Postgres v15

### DIFF
--- a/Dockerfile-db
+++ b/Dockerfile-db
@@ -1,3 +1,3 @@
-FROM postgres:11-alpine
+FROM postgres:15-alpine
 
 COPY scripts/docker-db-setup.sh /docker-entrypoint-initdb.d/10-docker-db-setup.sh

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       CF_API_PASSWORD: deploy_pass
       PROXY_DOMAIN: localhost:1337
   db:
-    image: postgres:11-alpine
+    image: postgres:15-alpine
     environment:
       POSTGRES_PASSWORD: password
   redis:

--- a/ci/pipeline-dev.yml
+++ b/ci/pipeline-dev.yml
@@ -46,7 +46,6 @@ jobs:
         - get: redis
           params: {save: true}
         - get: postgres
-          params: {save: true}
         - get: node
           params: {save: true}
       - task: install-deps-api
@@ -476,10 +475,10 @@ resources:
       tag: 5-alpine
 
   - name: postgres
-    type: docker-image
+    type: registry-image
     source:
       repository: postgres
-      tag: 11-alpine
+      tag: 15-alpine
 
   - name: node
     type: docker-image

--- a/ci/pipeline-production.yml
+++ b/ci/pipeline-production.yml
@@ -14,7 +14,6 @@ test-api: &test-api
     - get: redis
       params: {save: true}
     - get: postgres
-      params: {save: true}
     - get: node
       params: {save: true}
 
@@ -476,10 +475,10 @@ resources:
       tag: 5-alpine
 
   - name: postgres
-    type: docker-image
+    type: registry-image
     source:
       repository: postgres
-      tag: 11-alpine
+      tag: 15-alpine
 
   - name: node
     type: docker-image

--- a/ci/pipeline-staging.yml
+++ b/ci/pipeline-staging.yml
@@ -14,7 +14,6 @@ test-api: &test-api
     - get: redis
       params: {save: true}
     - get: postgres
-      params: {save: true}
     - get: node
       params: {save: true}
 
@@ -583,10 +582,10 @@ resources:
       tag: 5-alpine
 
   - name: postgres
-    type: docker-image
+    type: registry-image
     source:
       repository: postgres
-      tag: 11-alpine
+      tag: 15-alpine
 
   - name: node
     type: docker-image


### PR DESCRIPTION
## Changes proposed in this pull request:
- Upgrades local docker env and CI to Postgres v15
- Switch postgres ci resource to `registry-image`

## security considerations
Upgrades to Postgres v15 via the AWS RDS upgrade
