### PR TITLE
fix: Improve brittle admin user API test

### DIFF
--- a/test/api/admin/requests/user.test.js
+++ b/test/api/admin/requests/user.test.js
@@ -73,10 +73,10 @@ describe('Admin - Users API', () => {
 
     it('returns all users', async () => {
       const user1 = await factory.user();
-      createUAAIdentity({uaaId: 'user_id_1', email: 'user1@example.com', userId: user1.id });
+      await createUAAIdentity({uaaId: 'user_id_1', email: 'user1@example.com', userId: user1.id });
 
       const user2 = await factory.user();
-      createUAAIdentity({uaaId: 'user_id_2', email: 'user2@example.com', userId: user2.id });
+      await createUAAIdentity({uaaId: 'user_id_2', email: 'user2@example.com', userId: user2.id });
 
       const org1 = await factory.organization.create();
       const org2 = await factory.organization.create();
@@ -121,10 +121,10 @@ describe('Admin - Users API', () => {
 
     it('returns all users with UAA identities', async () => {
       const user1 = await factory.user();
-      createUAAIdentity({uaaId: 'user_id_1', email: 'user1@example.com', userId: user1.id });
+      await createUAAIdentity({uaaId: 'user_id_1', email: 'user1@example.com', userId: user1.id });
 
       const user2 = await factory.user();
-      createUAAIdentity({uaaId: 'user_id_2', email: 'user2@example.com', userId: user2.id });
+      await createUAAIdentity({uaaId: 'user_id_2', email: 'user2@example.com', userId: user2.id });
 
       const user3 = await factory.user();
       const user4 = await factory.user();
@@ -166,10 +166,10 @@ describe('Admin - Users API', () => {
 
     it('returns all users with UAA identities', async () => {
       const user1 = await factory.user();
-      createUAAIdentity({uaaId: 'user_id_1', email: 'user1@example.com', userId: user1.id });
+      await createUAAIdentity({uaaId: 'user_id_1', email: 'user1@example.com', userId: user1.id });
 
       const user2 = await factory.user();
-      createUAAIdentity({uaaId: 'user_id_2', email: 'user2@example.com', userId: user2.id });
+      await createUAAIdentity({uaaId: 'user_id_2', email: 'user2@example.com', userId: user2.id });
 
       const user3 = await factory.user();
       const user4 = await factory.user();

--- a/test/api/admin/requests/user.test.js
+++ b/test/api/admin/requests/user.test.js
@@ -26,6 +26,7 @@ describe('Admin - Users API', () => {
       Organization.truncate({ force: true, cascade: true }),
       OrganizationRole.truncate({ force: true, cascade: true }),
       User.truncate({ force: true, cascade: true }),
+      UAAIdentity.truncate({ force: true, cascade: true }),
     ])
   );
 


### PR DESCRIPTION
Changes which I hope will sufficiently remediate #4333 

## Changes proposed in this pull request:
- Explicitly truncate UAAIdentity table after test
-  `await` `createUAAIdentity` calls

## security considerations
None. This is an effort to prevent an unexpected and inconsistent test failure.
