### PR TITLE
fix: Check if buildShaLink args are null on CommitSummary component

### DIFF
--- a/frontend/components/site/CommitSummary.jsx
+++ b/frontend/components/site/CommitSummary.jsx
@@ -9,6 +9,10 @@ import buildActions from '../../actions/buildActions';
 import { timeFrom, dateAndTime } from '../../util/datetime';
 
 function buildShaLink(owner, repo, sha) {
+  if (!owner || !repo || !sha) {
+    return null;
+  }
+
   const BASE = 'https://github.com';
   const baseHref = `${BASE}/${owner}/${repo}`;
   const linkHref = `${baseHref}/commit/${sha}`;


### PR DESCRIPTION
## Changes proposed in this pull request:
- Check if `buildShaLink` function args are null on `CommitSummary` component

## security considerations
none
