### PR TITLE
fix: don't fail the last build log fetch

### DIFF
--- a/api/services/build-logs/build-logs.js
+++ b/api/services/build-logs/build-logs.js
@@ -76,7 +76,7 @@ const BuildLogs = {
 
       return { output, byteLength };
     } catch (error) {
-      if (error.code === 'InvalidRange') {
+      if (error.Code === 'InvalidRange') {
         return { output: null, byteLength: 0 };
       }
       throw error;

--- a/test/api/unit/services/BuildLogs.test.js
+++ b/test/api/unit/services/BuildLogs.test.js
@@ -194,7 +194,7 @@ describe('BuildLogs Service', () => {
 
       const build = { logsS3Key: key };
       const error = new Error('foo');
-      error.code = 'InvalidRange';
+      error.Code = 'InvalidRange';
       getObjectStub.rejects(error);
 
       const { output, byteLength } = await BuildLogs.getBuildLogs(build, 100, 199);


### PR DESCRIPTION
## Changes proposed in this pull request:
- catch the `InvalidRange` error on AWS JS SDK V3
- don't fail the last build log fetch

# Note
This is difficult to test because we don't archive build logs in development or staging. Also S3 is [not currently](#4326) running locally but I did manage to test this successfully on a [branch which begins to implement that feature](https://github.com/cloud-gov/pages-core/tree/chore-localstack)


## security considerations
None