### PR TITLE
fix: don't throw if user isn't present on build

### DIFF
--- a/frontend/components/site/siteBuilds.jsx
+++ b/frontend/components/site/siteBuilds.jsx
@@ -239,7 +239,7 @@ function SiteBuilds() {
                           { branchLink(build) }
                           <div className="commit-info">
                             { shaLink(build) }
-                            <span className="commit-user" title={build.user.email}>
+                            <span className="commit-user" title={build.user?.email}>
                               { build.username }
                             </span>
                             <span className="commit-time" title={dateAndTime(build.createdAt)}>


### PR DESCRIPTION
## Changes proposed in this pull request:
- don't throw if user isn't present on build

## security considerations
None