### PR TITLE
Add queue to delete site builds older than 180 days

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -33,6 +33,15 @@ $ cf run-task pages-<env> --command "yarn migrate-site-repo 1 user@agency.gov ag
 $ cf logs --recent pages-<env>
 ```
 
+## Queues
+
+### Nightly deletion of older builds
+
+This is a job that runs nightly and removes all builds older than 180 days, based on `completedAt` timestamps.
+
+Queue name: `delete-older-builds`
+Queue worker: [`deleteOlderBuilds.js`](./api/workers/jobProcessors/deleteOlderBuilds.js)
+
 ## CI
 
 ### Nightly site bucket key rotations

--- a/api/bull-board/app.js
+++ b/api/bull-board/app.js
@@ -11,6 +11,7 @@ const slowDown = require('express-slow-down');
 const {
   ArchiveBuildLogsQueue,
   BuildTasksQueue,
+  DeleteOlderBuildsQueue,
   DomainQueue,
   FailStuckBuildsQueue,
   MailQueue,
@@ -40,6 +41,7 @@ createBullBoard({
     new BullAdapter(new SiteBuildQueue(connection)),
     new BullMQAdapter(new ArchiveBuildLogsQueue(connection)),
     new BullMQAdapter(new BuildTasksQueue(connection)),
+    new BullMQAdapter(new DeleteOlderBuildsQueue(connection)),
     new BullMQAdapter(new DomainQueue(connection)),
     new BullMQAdapter(new FailStuckBuildsQueue(connection)),
     new BullMQAdapter(new MailQueue(connection)),

--- a/api/models/build.js
+++ b/api/models/build.js
@@ -329,6 +329,7 @@ module.exports = (sequelize, DataTypes) => {
         afterCreate,
         afterUpdate,
       },
+      paranoid: true,
     }
   );
 

--- a/api/queues/DeleteOlderBuildsQueue.js
+++ b/api/queues/DeleteOlderBuildsQueue.js
@@ -1,0 +1,14 @@
+const { Queue } = require('bullmq');
+
+const DeleteOlderBuildsQueueName = 'delete-older-builds';
+
+class DeleteOlderBuildsQueue extends Queue {
+  constructor(connection) {
+    super(DeleteOlderBuildsQueueName, { connection });
+  }
+}
+
+module.exports = {
+  DeleteOlderBuildsQueue,
+  DeleteOlderBuildsQueueName,
+};

--- a/api/queues/index.js
+++ b/api/queues/index.js
@@ -1,4 +1,5 @@
 const { ArchiveBuildLogsQueue, ArchiveBuildLogsQueueName } = require('./ArchiveBuildLogsQueue');
+const { DeleteOlderBuildsQueue, DeleteOlderBuildsQueueName } = require('./DeleteOlderBuildsQueue');
 const { BuildTasksQueue, BuildTasksQueueName } = require('./BuildTasksQueue');
 const { DomainQueue, DomainQueueName } = require('./DomainQueue');
 const { FailStuckBuildsQueue, FailStuckBuildsQueueName } = require('./FailStuckBuildsQueue');
@@ -15,6 +16,8 @@ module.exports = {
   ArchiveBuildLogsQueueName,
   BuildTasksQueue,
   BuildTasksQueueName,
+  DeleteOlderBuildsQueue,
+  DeleteOlderBuildsQueueName,
   DomainQueue,
   DomainQueueName,
   FailStuckBuildsQueue,

--- a/api/workers/index.js
+++ b/api/workers/index.js
@@ -64,6 +64,8 @@ function pagesWorker(connection) {
 
   const buildTasksProcessor = job => Processors.buildTaskRunner(job);
 
+  const deleteOlderBuildsProcessor = job => Processors.deleteOlderBuilds(job);
+
   const failBuildsProcessor = job => Processors.failStuckBuilds(job);
 
   const siteDeletionProcessor = job => Processors.destroySiteInfra(job.data);
@@ -87,8 +89,7 @@ function pagesWorker(connection) {
     new QueueWorker(ArchiveBuildLogsQueueName, connection,
       path.join(__dirname, 'jobProcessors', 'archiveBuildLogsDaily.js')),
     new QueueWorker(BuildTasksQueueName, connection, buildTasksProcessor),
-    new QueueWorker(DeleteOlderBuildsQueueName, connection,
-      path.join(__dirname, 'jobProcessors', 'deleteOlderBuilds.js')),
+    new QueueWorker(DeleteOlderBuildsQueueName, connection, deleteOlderBuildsProcessor),
     new QueueWorker(DomainQueueName, connection, domainJobProcessor),
     new QueueWorker(FailStuckBuildsQueueName, connection, failBuildsProcessor),
     new QueueWorker(MailQueueName, connection, mailJobProcessor),

--- a/api/workers/index.js
+++ b/api/workers/index.js
@@ -117,9 +117,7 @@ function pagesWorker(connection) {
   ];
 
   const jobs = () => Promise.all([
-    appEnv === 'production'
-      ? archiveBuildLogsQueue.add('archiveBuildLogsDaily', {}, nightlyJobConfig)
-      : Promise.resolve(),
+    archiveBuildLogsQueue.add('archiveBuildLogsDaily', {}, nightlyJobConfig),
     deleteOlderBuildsQueue.add('deleteOlderBuilds', {}, nightlyJobConfig),
     failStuckBuildsQueue.add('failStuckBuilds', {}, everyTenMinutesJobConfig),
     nightlyBuildsQueue.add('nightlyBuilds', {}, nightlyJobConfig),

--- a/api/workers/index.js
+++ b/api/workers/index.js
@@ -16,6 +16,8 @@ const {
   ArchiveBuildLogsQueueName,
   BuildTasksQueue,
   BuildTasksQueueName,
+  DeleteOlderBuildsQueue,
+  DeleteOlderBuildsQueueName,
   DomainQueueName,
   FailStuckBuildsQueue,
   FailStuckBuildsQueueName,
@@ -85,6 +87,8 @@ function pagesWorker(connection) {
     new QueueWorker(ArchiveBuildLogsQueueName, connection,
       path.join(__dirname, 'jobProcessors', 'archiveBuildLogsDaily.js')),
     new QueueWorker(BuildTasksQueueName, connection, buildTasksProcessor),
+    new QueueWorker(DeleteOlderBuildsQueueName, connection,
+      path.join(__dirname, 'jobProcessors', 'deleteOlderBuilds.js')),
     new QueueWorker(DomainQueueName, connection, domainJobProcessor),
     new QueueWorker(FailStuckBuildsQueueName, connection, failBuildsProcessor),
     new QueueWorker(MailQueueName, connection, mailJobProcessor),
@@ -97,6 +101,7 @@ function pagesWorker(connection) {
 
   const archiveBuildLogsQueue = new ArchiveBuildLogsQueue(connection);
   const buildTasksQueue = new BuildTasksQueue(connection);
+  const deleteOlderBuildsQueue = new DeleteOlderBuildsQueue(connection);
   const failStuckBuildsQueue = new FailStuckBuildsQueue(connection);
   const nightlyBuildsQueue = new NightlyBuildsQueue(connection);
   const scheduledQueue = new ScheduledQueue(connection);
@@ -104,6 +109,7 @@ function pagesWorker(connection) {
   const queues = [
     archiveBuildLogsQueue,
     buildTasksQueue,
+    deleteOlderBuildsQueue,
     failStuckBuildsQueue,
     nightlyBuildsQueue,
     scheduledQueue,
@@ -114,6 +120,7 @@ function pagesWorker(connection) {
     appEnv === 'production'
       ? archiveBuildLogsQueue.add('archiveBuildLogsDaily', {}, nightlyJobConfig)
       : Promise.resolve(),
+    deleteOlderBuildsQueue.add('deleteOlderBuilds', {}, nightlyJobConfig),
     failStuckBuildsQueue.add('failStuckBuilds', {}, everyTenMinutesJobConfig),
     nightlyBuildsQueue.add('nightlyBuilds', {}, nightlyJobConfig),
     scheduledQueue.add('sandboxNotifications', {}, nightlyJobConfig),

--- a/api/workers/jobProcessors/deleteOlderBuilds.js
+++ b/api/workers/jobProcessors/deleteOlderBuilds.js
@@ -1,0 +1,37 @@
+const moment = require('moment');
+const { Op } = require('sequelize');
+const { Build } = require('../../models');
+const Mailer = require('../../services/mailer');
+const Slacker = require('../../services/slacker');
+const { createJobLogger } = require('./utils');
+
+async function deleteOlderBuilds(job) {
+  const logger = createJobLogger(job);
+  const cutoffDate = moment().subtract(180, 'days').startOf('day');
+
+  logger.log(`Deleting all builds completed before ${cutoffDate}.`);
+
+  try {
+    const numDeleted = await Build.destroy({
+      where: {
+        completedAt: {
+          [Op.lt]: cutoffDate.toDate(),
+        },
+      },
+    });
+    logger.log(`Deleted ${numDeleted} builds.`);
+    await logger.flush();
+    return 'OK';
+  } catch (error) {
+    const errMsg = `Delete builds before ${cutoffDate.format('YYYY-MM-DD')} completed with error`;
+    logger.log(errMsg, error);
+    await logger.flush();
+    Mailer.init();
+    Slacker.init();
+    Mailer.sendAlert(errMsg, error);
+    Slacker.sendAlert(errMsg, error);
+    throw new Error(errMsg);
+  }
+}
+
+module.exports = deleteOlderBuilds;

--- a/api/workers/jobProcessors/index.js
+++ b/api/workers/jobProcessors/index.js
@@ -1,5 +1,6 @@
 const archiveBuildLogsDaily = require('./archiveBuildLogsDaily');
 const buildTaskRunner = require('./buildTaskRunner');
+const deleteOlderBuilds = require('./deleteOlderBuilds');
 const destroySiteInfra = require('./destroySiteInfra');
 const failStuckBuilds = require('./failStuckBuilds');
 const multiJobProcessor = require('./multiJobProcessor');
@@ -11,6 +12,7 @@ const cleanSandboxOrganizations = require('./cleanSandboxOrganizations');
 module.exports = {
   archiveBuildLogsDaily,
   buildTaskRunner,
+  deleteOlderBuilds,
   destroySiteInfra,
   failStuckBuilds,
   multiJobProcessor,

--- a/frontend/components/site/siteBuilds.jsx
+++ b/frontend/components/site/siteBuilds.jsx
@@ -158,7 +158,7 @@ function SiteBuilds() {
   }, []);
 
   if (!builds.isLoading && !builds.data.length) {
-    const header = 'This site does not yet have any builds.';
+    const header = 'This site has not had any builds in the past 180 days.';
     const message = 'If this site was just added, the first build should be available within a few minutes.';
     return (
       <AlertBanner status="info" header={header} message={message}>

--- a/migrations/20240103173046-add-paranoid-to-build.js
+++ b/migrations/20240103173046-add-paranoid-to-build.js
@@ -1,0 +1,9 @@
+const TABLE = 'build';
+
+exports.up = async db => {
+  await db.addColumn(TABLE, 'deletedAt', { type: 'date', allowNull: true });
+};
+
+exports.down = async db => {
+  db.removeColumn(TABLE, 'deletedAt');
+};

--- a/test/frontend/components/site/siteBuilds.test.js
+++ b/test/frontend/components/site/siteBuilds.test.js
@@ -176,7 +176,7 @@ describe('<SiteBuilds/>', () => {
     const wrapper = mountRouter(<SiteBuilds />, '/site/:id/builds', '/site/5/builds', state);
 
     expect(wrapper.find('table')).to.have.length(0);
-    expect(wrapper.find('AlertBanner').prop('header')).to.equal('This site does not yet have any builds.');
+    expect(wrapper.find('AlertBanner').prop('header')).to.equal('This site has not had any builds in the past 180 days.');
     expect(wrapper.find('AlertBanner').prop('message')).to.equal(
       'If this site was just added, the first build should be available within a few minutes.'
     );


### PR DESCRIPTION
Resolves #4336 

## Changes proposed in this pull request:
- Adds a job, queued and run nightly, that deletes builds older than 180 days 
- Changes the language shown in the client for sites which have no builds to reflect that they have had no builds "in the past 180 days" (was "not yet" any builds)

## security considerations
None. The new nightly job will remove build records from the application database for which build logs have already expired and been removed from S3.