### PR TITLE
fix(ci): Run db migrations in CI task container with SSL #4354

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ blob-report/
 playwright/.cache/
 playwright/.auth/*
 !playwright/.auth/.gitkeep 
+database.json

--- a/ci/partials/run-database-migrations.yml
+++ b/ci/partials/run-database-migrations.yml
@@ -1,0 +1,11 @@
+platform: linux
+inputs: [name: src]
+outputs: [name: src]
+run:
+  dir: src
+  path: bash
+  args:
+    - -c
+    - |
+      node --env-file=.env ./ci/tasks/configure-database-migrations.js
+      node node_modules/.bin/db-migrate up --config database.json -e production

--- a/ci/pipeline-dev.yml
+++ b/ci/pipeline-dev.yml
@@ -47,7 +47,6 @@ jobs:
           params: {save: true}
         - get: postgres
         - get: node
-          params: {save: true}
       - task: install-deps-api
         file: src/ci/partials/install-deps-api.yml
         image: node
@@ -88,15 +87,20 @@ jobs:
                   <<: *env-cf
                   CF_APP_NAME: pages-((deploy-env))
 
-          - task: run-database-migrations
-            file: src/ci/partials/run-task.yml
+          - task: get-app-env
+            file: src/ci/partials/get-app-env.yml
             image: cf-image
             params:
               <<: *env-cf
               APP_ENV: ((deploy-env))
-              CF_APP_NAME: pages-((deploy-env))
-              CF_TASK_NAME: run-migrations
-              CF_TASK_COMMAND: 'yarn run migrate:up'
+              CF_APP_NAME: pages-((deploy-env))       
+
+          - task: run-database-migrations
+            file: src/ci/partials/run-database-migrations.yml
+            image: node
+            params:
+              <<: *env-cf
+              APP_ENV: ((deploy-env))
             on_failure:
               in_parallel:
                 - put: gh-status
@@ -481,7 +485,7 @@ resources:
       tag: 15-alpine
 
   - name: node
-    type: docker-image
+    type: registry-image
     source:
       repository: node
       tag: 20.9-bullseye

--- a/ci/pipeline-production.yml
+++ b/ci/pipeline-production.yml
@@ -89,15 +89,34 @@ jobs:
               <<: *env-cf
               CF_APP_NAME: pages-((deploy-env))
 
-      - task: run-database-migrations
-        file: src/ci/partials/run-task.yml
+      - task: get-app-env
+        file: src/ci/partials/get-app-env.yml
         image: cf-image
         params:
           <<: *env-cf
           APP_ENV: ((deploy-env))
-          CF_APP_NAME: pages-((deploy-env))
-          CF_TASK_NAME: run-migrations
-          CF_TASK_COMMAND: 'yarn run migrate:up'
+          CF_APP_NAME: pages-((deploy-env))       
+
+      - task: run-database-migrations
+        file: src/ci/partials/run-database-migrations.yml
+        image: node
+        params:
+          <<: *env-cf
+          APP_ENV: ((deploy-env))
+        on_failure:
+          in_parallel:
+            - put: gh-status
+              inputs: [src]
+              params: {state: failure}
+            - put: slack
+              params:
+                text: |
+                  :x: FAILED: to migrate database for pages ((deploy-env))
+                  <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME?vars.deploy-env="((deploy-env))"|View build details>
+                channel: ((slack-channel))
+                username: ((slack-username))
+                icon_url: ((slack-icon-url))
+
         on_failure:
           in_parallel:
             - put: gh-status
@@ -483,7 +502,7 @@ resources:
       tag: 15-alpine
 
   - name: node
-    type: docker-image
+    type: registry-image
     source:
       repository: node
       tag: 20.9-bullseye

--- a/ci/pipeline-staging.yml
+++ b/ci/pipeline-staging.yml
@@ -194,15 +194,34 @@ jobs:
               <<: *env-cf
               CF_APP_NAME: pages-((deploy-env))
 
-      - task: run-database-migrations
-        file: src/ci/partials/run-task.yml
+      - task: get-app-env
+        file: src/ci/partials/get-app-env.yml
         image: cf-image
         params:
           <<: *env-cf
           APP_ENV: ((deploy-env))
-          CF_APP_NAME: pages-((deploy-env))
-          CF_TASK_NAME: run-migrations
-          CF_TASK_COMMAND: 'yarn run migrate:up'
+          CF_APP_NAME: pages-((deploy-env))    
+
+      - task: run-database-migrations
+        file: src/ci/partials/run-database-migrations.yml
+        image: node
+        params:
+          <<: *env-cf
+          APP_ENV: ((deploy-env))
+        on_failure:
+          in_parallel:
+            - put: gh-status
+              inputs: [src]
+              params: {state: failure}
+            - put: slack
+              params:
+                text: |
+                  :x: FAILED: to migrate database for pages ((deploy-env))
+                  <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME?vars.deploy-env="((deploy-env))"|View build details>
+                channel: ((slack-channel))
+                username: ((slack-username))
+                icon_url: ((slack-icon-url))
+
         on_failure:
           in_parallel:
             - put: gh-status
@@ -655,7 +674,7 @@ resources:
       tag: 15-alpine
 
   - name: node
-    type: docker-image
+    type: registry-image
     source:
       repository: node
       tag: 20.9-bullseye

--- a/ci/tasks/configure-database-migrations.js
+++ b/ci/tasks/configure-database-migrations.js
@@ -1,0 +1,49 @@
+const fs = require('node:fs');
+const cfenv = require('cfenv');
+
+const { APP_ENV } = process.env;
+const fileName = 'database.json';
+
+const baseConfig = {
+  driver: 'pg',
+  port: '5432',
+  ssl: {
+    rejectUnauthorized: false,
+  },
+  schema: 'public',
+};
+
+function main() {
+  try {
+    const appEnv = cfenv.getAppEnv();
+    const creds = appEnv.getServiceCreds(`federalist-${APP_ENV}-rds`);
+
+    const config = {
+      production: {
+        ...baseConfig,
+        user: creds.username,
+        password: creds.password,
+        host: creds.host,
+        database: creds.name,
+        port: creds.port,
+      },
+    };
+
+    const data = JSON.stringify(config);
+
+    fs.writeFileSync(fileName, data);
+
+    // eslint-disable-next-line
+    console.log('\n\nCreated database configuration.\n\n');
+
+    process.exit(0);
+  } catch (error) {
+    // eslint-disable-next-line
+    console.error('\n\n!!! ERROR CONFIGURING DATABASE MIGRATIONS !!!\n\n');
+    // eslint-disable-next-line
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
Closes #4354


## Changes proposed in this pull request:
- Switches CI task to run the db migrations in the CI container
- Uses SSL config to run migraitons

## security considerations
Runs migrations over SSL with update to PG 15
