### PR TITLE
Make Build a paranoid model (enable soft deletion)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -33,6 +33,27 @@ $ cf run-task pages-<env> --command "yarn migrate-site-repo 1 user@agency.gov ag
 $ cf logs --recent pages-<env>
 ```
 
+## Dev and Staging
+
+### Manually running migrations in dev or staging environments
+
+It may necessary at some point to `migrate:down` or `:up` to explore something in the dev or staging environment, or to resolve an earlier failure.
+
+This can be done by first doing a `cf login` and selecting the appropriate org and space.
+
+Then, shell into the environment, e.g. `cf ssh pages-dev`.
+
+From there:
+
+```bash
+$ /tmp/lifecycle/shell
+
+$ node --env-file=.env ./ci/tasks/configure-database-migrations.js
+
+## Example migrate down
+$ node node_modules/.bin/db-migrate down --config database.json -e production
+```
+
 ## CI
 
 ### Nightly site bucket key rotations

--- a/api/models/build.js
+++ b/api/models/build.js
@@ -329,6 +329,7 @@ module.exports = (sequelize, DataTypes) => {
         afterCreate,
         afterUpdate,
       },
+      paranoid: true,
     }
   );
 

--- a/migrations/20240103173046-add-paranoid-to-build.js
+++ b/migrations/20240103173046-add-paranoid-to-build.js
@@ -1,0 +1,9 @@
+const TABLE = 'build';
+
+exports.up = async db => {
+  await db.addColumn(TABLE, 'deletedAt', { type: 'date', allowNull: true });
+};
+
+exports.down = async db => {
+  db.removeColumn(TABLE, 'deletedAt');
+};


### PR DESCRIPTION
Fixes #4366. Extracted from #4352 work on #4336.

## Changes proposed in this pull request:
- Enables soft deletion of Build using Sequelize's paranoid model functionality
- Adds a Dev and Staging section to `OPERATIONS.md` documenting how to manually run migrations in these environments.

## security considerations
None. This provides an (optional but default) extra margin of safety when deleting builds.