### PR TITLE
Run build log archive job in dev and staging

### DIFF
--- a/api/workers/index.js
+++ b/api/workers/index.js
@@ -111,9 +111,7 @@ function pagesWorker(connection) {
   ];
 
   const jobs = () => Promise.all([
-    appEnv === 'production'
-      ? archiveBuildLogsQueue.add('archiveBuildLogsDaily', {}, nightlyJobConfig)
-      : Promise.resolve(),
+    archiveBuildLogsQueue.add('archiveBuildLogsDaily', {}, nightlyJobConfig),
     failStuckBuildsQueue.add('failStuckBuilds', {}, everyTenMinutesJobConfig),
     nightlyBuildsQueue.add('nightlyBuilds', {}, nightlyJobConfig),
     scheduledQueue.add('sandboxNotifications', {}, nightlyJobConfig),


### PR DESCRIPTION
Fixes #4367. Extracted from #4352 work on #4336.

## Changes proposed in this pull request:
- Schedules the archive build logs job in all environments

## security considerations
None. This adds a nightly job in dev and staging that is already present in production.