### PR TITLE
add hardened playwright, registry-image, general-task

### DIFF
--- a/ci/partials/create-test-users.yml
+++ b/ci/partials/create-test-users.yml
@@ -1,0 +1,6 @@
+platform: linux
+inputs: [name: src]
+outputs: [name: src]
+run:
+  dir: src
+  path: ./ci/tasks/create-test-users.sh

--- a/ci/pipeline-dev.yml
+++ b/ci/pipeline-dev.yml
@@ -327,8 +327,9 @@ jobs:
         - test-and-deploy-api-pages
         - test-and-deploy-admin-client-pages
         - deploy-queues-ui-pages
-      - get: node
+      - get: playwright
       - get: cf-image
+      - get: node
       - put: src
         resource: pr-((deploy-env))
         params:
@@ -343,13 +344,19 @@ jobs:
           <<: *env-cf
           APP_ENV: ((deploy-env))
           CF_APP_NAME: pages-((deploy-env))
+      - task: create-test-users
+        file: src/ci/partials/create-test-users.yml
+        image: node
+        params:
+          DOMAIN: ((((deploy-env))-pages-domain))
+          APP_ENV: ((deploy-env))
+          PRODUCT: pages
       - task: run-e2e-tests
         file: src/ci/partials/e2e-test.yml
-        image: node
+        image: playwright
         params:
           APP_ENV: ((deploy-env))
           APP_HOSTNAME: https://((((deploy-env))-pages-domain))
-          DOMAIN: ((((deploy-env))-pages-domain))
           PRODUCT: pages
         ensure:
           do:
@@ -559,9 +566,18 @@ resources:
     source:
       aws_access_key_id: ((ecr-aws-key))
       aws_secret_access_key: ((ecr-aws-secret))
-      repository: harden-concourse-task
+      repository: general-task
       aws_region: us-gov-west-1
-      tag: ((harden-concourse-task-tag))
+      tag: latest
+
+  - name: playwright
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr-aws-key))
+      aws_secret_access_key: ((ecr-aws-secret))
+      repository: harden-playwright
+      aws_region: us-gov-west-1
+      tag: latest
 
   - name: s3
     type: s3-resource
@@ -607,6 +623,15 @@ resource_types:
       aws_region: us-gov-west-1
       tag: latest
 
+  - name: registry-image
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: registry-image-resource
+      aws_region: us-gov-west-1
+      tag: latest
+      
   - name: time
     type: registry-image
     source:
@@ -615,3 +640,5 @@ resource_types:
       repository: time-resource
       aws_region: us-gov-west-1
       tag: latest
+
+  

--- a/ci/pipeline-production.yml
+++ b/ci/pipeline-production.yml
@@ -461,9 +461,9 @@ resources:
     source:
       aws_access_key_id: ((ecr-aws-key))
       aws_secret_access_key: ((ecr-aws-secret))
-      repository: harden-concourse-task
+      repository: general-task
       aws_region: us-gov-west-1
-      tag: ((harden-concourse-task-tag))
+      tag: latest
 
   - name: pages-release
     type: github-release
@@ -501,6 +501,15 @@ resource_types:
       aws_region: us-gov-west-1
       tag: latest
 
+  - name: registry-image
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: registry-image-resource
+      aws_region: us-gov-west-1
+      tag: latest
+      
   - name: time
     type: registry-image
     source:

--- a/ci/pipeline-staging.yml
+++ b/ci/pipeline-staging.yml
@@ -370,8 +370,9 @@ jobs:
         - test-and-deploy-api-pages
         - test-and-deploy-admin-client-pages
         - deploy-queues-ui-pages
-      - get: node
+      - get: playwright
       - get: cf-image
+      - get: node
       - task: get-app-env
         file: src/ci/partials/get-app-env.yml
         image: cf-image
@@ -379,13 +380,19 @@ jobs:
           <<: *env-cf
           APP_ENV: ((deploy-env))
           CF_APP_NAME: pages-((deploy-env))
+      - task: create-test-users
+        file: src/ci/partials/create-test-users.yml
+        image: node
+        params:
+          DOMAIN: ((((deploy-env))-pages-domain))
+          APP_ENV: ((deploy-env))
+          PRODUCT: pages
       - task: run-e2e-tests
         file: src/ci/partials/e2e-test.yml
-        image: node
+        image: playwright
         params:
           APP_ENV: ((deploy-env))
           APP_HOSTNAME: https://((((deploy-env))-pages-domain))
-          DOMAIN: ((((deploy-env))-pages-domain))
           PRODUCT: pages
         ensure:
           do:
@@ -503,9 +510,18 @@ resources:
     source:
       aws_access_key_id: ((ecr-aws-key))
       aws_secret_access_key: ((ecr-aws-secret))
-      repository: harden-concourse-task
+      repository: general-task
       aws_region: us-gov-west-1
-      tag: ((harden-concourse-task-tag))
+      tag: latest
+
+  - name: playwright
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr-aws-key))
+      aws_secret_access_key: ((ecr-aws-secret))
+      repository: harden-playwright
+      aws_region: us-gov-west-1
+      tag: latest
 
   - name: s3
     type: s3-resource
@@ -549,6 +565,15 @@ resource_types:
       aws_access_key_id: ((ecr_aws_key))
       aws_secret_access_key: ((ecr_aws_secret))
       repository: s3-simple-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: registry-image
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: registry-image-resource
       aws_region: us-gov-west-1
       tag: latest
 

--- a/ci/tasks/create-test-users.sh
+++ b/ci/tasks/create-test-users.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+yarn install
+yarn create-test-users

--- a/ci/tasks/e2e-test.sh
+++ b/ci/tasks/e2e-test.sh
@@ -2,12 +2,7 @@
 
 set -e
 
-yarn install
-yarn playwright install-deps
-yarn playwright install
-
 export GIT_COMMIT=`git rev-parse HEAD`
 mkdir -p playwright-report/$APP_ENV/$GIT_COMMIT
 
-yarn create-test-users
-yarn playwright test
+npm exec playwright test

--- a/scripts/create-test-users.js
+++ b/scripts/create-test-users.js
@@ -13,7 +13,7 @@ async function createUsers() {
     path: '/',
     expires: (Number(new Date()) + (24 * 60 * 60 * 1000)) / 1000,
     httpOnly: true,
-    secure: process.env.env === 'production',
+    secure: process.env.APP_ENV === 'production',
     sameSite: 'Lax',
   };
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Use `general-task`, the replacement for `harden-concourse-task`
- Use the hardened `registry-image` in place of the concourse type `registry-image` (identically named)
- Use hardened `playwright` image in place of `node` for end-to-end tests for the convenience/speed of not having to install `playwright` and it's dependencies each run (required separating out `create-test-user` into a separate step)

## security considerations
Replaces images with more updated and/or hardened options.