### PR TITLE
Accessibility improvement: Add row header to published files table

### DIFF
--- a/frontend/components/site/SitePublishedFilesTable.jsx
+++ b/frontend/components/site/SitePublishedFilesTable.jsx
@@ -67,7 +67,7 @@ function renderBranchFileRow(file) {
   }
   return (
     <tr key={viewFileLink}>
-      <td>{file.name}</td>
+      <th scope="row">{file.name}</th>
       <td><a href={viewFileLink} target="_blank" rel="noopener noreferrer">View</a></td>
     </tr>
   );
@@ -86,8 +86,8 @@ function renderPublishedFilesTable(files, name, currentPage, lastPage, setCurren
       <table className="usa-table-borderless table-full-width log-table">
         <thead>
           <tr>
-            <th>File</th>
-            <th>Actions</th>
+            <th scope="col">File</th>
+            <th scope="col">Actions</th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
Fixes #4397

## Changes proposed in this pull request:
- Makes the file cell in the site published files table a row header
- Explicitly assigns `row` and `col` scope to the headers in this table.

## security considerations
None. This is a fix to improve accessibility of a user interface element.