### PR TITLE
chore: vendor node dependencies

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -40,7 +40,7 @@ lib-cov
 *.out
 *.pid
 npm-debug.log
-node_modules/
+# node_modules is purposefully kept for vendoring: https://docs.cloudfoundry.org/buildpacks/node/index.html#vendoring
 
 
 ################################################


### PR DESCRIPTION

https://docs.cloudfoundry.org/buildpacks/node/index.html#vendoring

## Changes proposed in this pull request:
- use the node_modules that are generated in concourse

## security considerations
Uses vendored dependencies generated via CI