### PR TITLE
catch webhook handler errors

### DIFF
--- a/api/controllers/webhook.js
+++ b/api/controllers/webhook.js
@@ -5,7 +5,7 @@ module.exports = wrapHandlers({
   async github(req, res) {
     const { body: payload } = req;
 
-    Webhooks.pushWebhookRequest(payload);
+    await Webhooks.pushWebhookRequest(payload);
 
     res.ok();
   },
@@ -13,7 +13,7 @@ module.exports = wrapHandlers({
   async organization(req, res) {
     const { body: payload } = req;
 
-    Webhooks.organizationWebhookRequest(payload);
+    await Webhooks.organizationWebhookRequest(payload);
 
     res.ok();
   },

--- a/api/models/build.js
+++ b/api/models/build.js
@@ -159,7 +159,7 @@ const afterCreate = async (build) => {
     const buildTasks = await BuildTask
       .byStartsWhen(BuildTaskType.StartsWhens.Build)
       .findAll({ where: { buildId: build.id } });
-    buildTasks.forEach(task => task.enqueue());
+    await Promise.all(buildTasks.map(async task => task.enqueue()));
   } catch (err) {
     console.error(err);
   }
@@ -173,7 +173,7 @@ const afterUpdate = async (build) => {
       const buildTasks = await BuildTask
         .byStartsWhen(BuildTaskType.StartsWhens.Complete)
         .findAll({ where: { buildId: build.id } });
-      buildTasks.forEach(task => task.enqueue());
+      await Promise.all(buildTasks.map(async task => task.enqueue()));
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
## Changes proposed in this pull request:
- await the webhook controller functions
- don't fire/forget the build tasks on build create/update

## security considerations
None