### PR TITLE
Accessibility improvement: Eliminate heading level skips in sites list and user settings page

### DIFF
--- a/frontend/components/siteList/siteListItem.jsx
+++ b/frontend/components/siteList/siteListItem.jsx
@@ -26,7 +26,7 @@ function SiteListItem({ organization, site, user }) {
   return (
     <li className="sites-list-item">
       <div className="sites-list-item-text">
-        <h4 className="site-list-item-title">
+        <h2 className="site-list-item-title">
           {(!site.isActive || (organization && !organization.isActive))
             ? `${getSiteName(site)} (Inactive)`
             : (
@@ -35,12 +35,12 @@ function SiteListItem({ organization, site, user }) {
               </Link>
             )}
           {' '}
-        </h4>
+        </h2>
         {
           organization && (
-            <h5>
+            <h3>
               {`organization - ${organization.name}`}
-            </h5>
+            </h3>
           )
         }
         <RepoLastVerified site={site} userUpdated={user.updatedAt} />

--- a/frontend/components/user/Settings.jsx
+++ b/frontend/components/user/Settings.jsx
@@ -68,7 +68,7 @@ function Settings({
   };
 
   return (
-    <div>
+    <div className="user-settings">
       <div className="page-header usa-grid-full">
         <div className="usa-width-one-half">
           <h1>
@@ -77,14 +77,14 @@ function Settings({
         </div>
       </div>
       <div className="well">
-        <h3>Github Token</h3>
+        <h2>Github Token</h2>
         <GithubAuthButton
           onSuccess={onGithubAuthSuccess}
           onFailure={onGithubAuthFailure}
           text="Reset your Github Access Token."
           revokeFirst
         />
-        <h3>Build Notifications</h3>
+        <h2>Build Notifications</h2>
         <SettingsForm
           initialValues={initialValues}
           organizations={organizations.data}

--- a/frontend/sass/_dashboard.scss
+++ b/frontend/sass/_dashboard.scss
@@ -17,8 +17,6 @@
   }
 }
 
-
-
 .sites-list-item-text,
 .sites-list-item-actions {
   flex-grow: 1;
@@ -37,6 +35,14 @@
   .repo-verification {
     color: red;
   }
+}
+
+h2.site-list-item-title {
+  font-size: $h4-font-size;
+}
+
+.sites-list-item-text h3 {
+  font-size: $h5-font-size;
 }
 
 .sites-list-item-actions {

--- a/frontend/sass/_wells.scss
+++ b/frontend/sass/_wells.scss
@@ -50,3 +50,8 @@
     display: table;
   }
 }
+
+.user-settings .well h2 {
+  font-size: $h3-font-size;
+  color: $body-copy-color;
+}

--- a/test/frontend/components/siteList/siteListItem.test.js
+++ b/test/frontend/components/siteList/siteListItem.test.js
@@ -96,7 +96,7 @@ describe('<SiteListItem />', () => {
     const org = { ...testOrganization, isActive: false };
     wrapper = mountRouter(<SiteListItem site={testSite} user={testUser} organization={org} />);
     expect(wrapper.find(Link)).to.have.length(0);
-    expect(wrapper.find('h4')).to.have.length(1);
+    expect(wrapper.find('h2')).to.have.length(1);
   });
 
   it('no Link if org site is inactive', () => {
@@ -109,17 +109,17 @@ describe('<SiteListItem />', () => {
       />
     );
     expect(wrapper.find(Link)).to.have.length(0);
-    expect(wrapper.find('h4')).to.have.length(1);
+    expect(wrapper.find('h2')).to.have.length(1);
   });
 
   it('no Link if non-org site is inactive', () => {
     const site = { ...testSite, isActive: false };
     wrapper = mountRouter(<SiteListItem site={site} user={testUser} />);
     expect(wrapper.find(Link)).to.have.length(0);
-    expect(wrapper.find('h4')).to.have.length(1);
+    expect(wrapper.find('h2')).to.have.length(1);
   });
 
-  it('outputs an h5 with the site\'s organization', () => {
+  it('outputs an h3 with the site\'s organization', () => {
     const organizationId = testOrganization.id;
     const updatedSite = { ...testSite, organizationId };
     wrapper = mountRouter(
@@ -129,10 +129,10 @@ describe('<SiteListItem />', () => {
         organization={testOrganization}
       />
     );
-    expect(wrapper.find('h5')).to.have.length(1);
+    expect(wrapper.find('h3')).to.have.length(1);
     expect(wrapper.find('p')).to.have.length(0); // is not sandbox
   });
-  it('outputs an h5 with the site\'s sandbox organization', () => {
+  it('outputs an h3 with the site\'s sandbox organization', () => {
     const organizationId = testOrganization.id;
     const updatedSite = { ...testSite, organizationId };
     wrapper = mountRouter(
@@ -143,17 +143,17 @@ describe('<SiteListItem />', () => {
       />
     );
     expect(wrapper.find('p')).to.have.length(1); // is sandbox
-    expect(wrapper.find('h5')).to.have.length(1);
+    expect(wrapper.find('h3')).to.have.length(1);
   });
 
-  it('outputs without an h5 with the site\'s organization', () => {
+  it('outputs without an h3 with the site\'s organization', () => {
     wrapper = mountRouter(
       <SiteListItem
         site={testSite}
         user={testUser}
       />
     );
-    expect(wrapper.find('h5')).to.have.length(0);
+    expect(wrapper.find('h3')).to.have.length(0);
   });
 
   it('outputs a link to the GitHub repo', () => {

--- a/test/frontend/components/user/Settings.test.js
+++ b/test/frontend/components/user/Settings.test.js
@@ -73,7 +73,7 @@ describe('<Settings />', () => {
     const wrapper = shallow(<Settings {...props} />);
 
     expect(wrapper.contains(<h1>User Settings</h1>)).to.be.true;
-    expect(wrapper.contains(<h3>Build Notifications</h3>)).to.be.true;
-    expect(wrapper.contains(<h3>Github Token</h3>)).to.be.true;
+    expect(wrapper.contains(<h2>Build Notifications</h2>)).to.be.true;
+    expect(wrapper.contains(<h2>Github Token</h2>)).to.be.true;
   });
 });


### PR DESCRIPTION
Fixes #4396

## Changes proposed in this pull request:
- Adjusts heading levels in the sites list and user settings pages to eliminate level skips while leaving styling unchanged

## security considerations
None. This is a presentational change.
