### PR TITLE
Prevent restarting build tasks, use enum, add test

### DIFF
--- a/api/controllers/build-task.js
+++ b/api/controllers/build-task.js
@@ -59,13 +59,14 @@ module.exports = wrapHandlers({
   update: async (req, res) => {
     const { params, body } = req;
     const { build_task_id: buildTaskId, token } = params;
+    const { Error, Success } = BuildTask.Statuses;
 
     const task = await BuildTask.findByPk(buildTaskId);
 
     if (!task) {
       return res.notFound();
     }
-    if (task.token !== token || ['success', 'skipped', 'error'].includes(task.status)) {
+    if (task.token !== token || [Error, Success].includes(task.status)) {
       return res.forbidden();
     }
 

--- a/api/models/build-task.js
+++ b/api/models/build-task.js
@@ -116,6 +116,7 @@ module.exports = (sequelize, DataTypes) => {
 
   BuildTask.generateToken = generateToken;
   BuildTask.associate = associate;
+  BuildTask.Statuses = Statuses;
   BuildTask.siteScope = id => ({ method: ['bySite', id] });
   BuildTask.byStartsWhen = startsWhen => BuildTask.scope({ method: ['byStartsWhen', startsWhen] });
   BuildTask.prototype.enqueue = enqueue;

--- a/api/models/build.js
+++ b/api/models/build.js
@@ -172,7 +172,7 @@ const afterUpdate = async (build) => {
     try {
       const buildTasks = await BuildTask
         .byStartsWhen(BuildTaskType.StartsWhens.Complete)
-        .findAll({ where: { buildId: build.id } });
+        .findAll({ where: { buildId: build.id, status: BuildTask.Statuses.Created } });
       await Promise.all(buildTasks.map(async task => task.enqueue()));
     } catch (err) {
       console.error(err);

--- a/api/workers/jobProcessors/buildTaskRunner.js
+++ b/api/workers/jobProcessors/buildTaskRunner.js
@@ -52,7 +52,7 @@ async function buildTaskRunner(job) {
     logger.log(err);
     // TODO: should this hit the update endpoint instead?
     const errorTask = await BuildTask.findByPk(taskId);
-    await errorTask.update({ status: 'error' });
+    await errorTask.update({ status: BuildTask.Statuses.Error });
     return err;
   }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Prevent restarting build tasks
- Use the `BuildTask.Statuses` enum for better error detection
- Add controller test to confirm tasks aren't updatable after completion

## security considerations
None