### PR TITLE
Add build scan priority

### DIFF
--- a/api/services/BuildTaskQueue.js
+++ b/api/services/BuildTaskQueue.js
@@ -67,11 +67,11 @@ const BuildTaskQueue = {
 
 BuildTaskQueue.messageBodyForBuild = buildTask => buildContainerEnvironment(buildTask);
 
-BuildTaskQueue.sendTaskMessage = async (buildTask) => {
+BuildTaskQueue.sendTaskMessage = async (buildTask, priority) => {
   const message = await BuildTaskQueue.messageBodyForBuild(buildTask);
   await setupBucket(buildTask.Build);
 
-  return BuildTaskQueue.bullClient.add('sendTaskMessage', message);
+  return BuildTaskQueue.bullClient.add('sendTaskMessage', message, { priority });
 };
 
 module.exports = BuildTaskQueue;

--- a/test/api/unit/models/build-task.test.js
+++ b/test/api/unit/models/build-task.test.js
@@ -1,0 +1,78 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const { DatabaseError, ValidationError } = require('sequelize');
+const BuildTaskQueue = require('../../../../api/services/BuildTaskQueue');
+const factory = require('../../support/factory');
+const { Build, Site, BuildTask } = require('../../../../api/models');
+const config = require('../../../../config');
+
+describe('Build Task model', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('enqueue', () => {
+    it('should send a new build task message', async () => {
+      const sendMessageStub = sinon.stub(BuildTaskQueue, 'sendTaskMessage');
+      sendMessageStub.resolves();
+
+      const site = await factory.site();
+      const build = await factory.build({ site });
+      const buildTaskType = await factory.buildTaskType();
+      const buildTask = await factory.buildTask({ build, buildTaskTypeId: buildTaskType.id})
+      await buildTask.enqueue();
+      await buildTask.reload();
+
+      const [queuedTask, priority] = sendMessageStub.getCall(0).args;
+
+      // called with the right things
+      expect(sendMessageStub.called).to.be.true;
+      expect(queuedTask.id).to.equal(buildTask.id);
+      expect(priority).to.equal(1);
+
+      // reloaded task is queued
+      expect(buildTask.status).to.equal(BuildTask.Statuses.Queued);
+
+      // The task should include the site
+      expect(queuedTask.Build.Site).to.be.an.instanceof(Site);
+      expect(queuedTask.Build.Site.id).to.eq(site.id);
+    });
+
+    it('can receive a higher priority', async () => {
+      const sendMessageStub = sinon.stub(BuildTaskQueue, 'sendTaskMessage');
+      sendMessageStub.resolves();
+
+      const site = await factory.site();
+      let build = await factory.build({ site });
+      const buildTaskType = await factory.buildTaskType();
+      const buildTask = await factory.buildTask({ build, buildTaskTypeId: buildTaskType.id})
+
+      // add N extra for the same site
+      const N = 5;
+      // eslint-disable-next-line no-unused-vars
+      await Promise.all(Array(N).fill(0).map(async (_) => {
+        build = await factory.build({ site });
+        return factory.buildTask({ build, buildTaskTypeId: buildTaskType.id });
+      }));
+
+      // add two complete task to check our math (they shouldn't count in priority)
+      build = await factory.build({ site });
+      const successfulTask = await factory.buildTask({ build, buildTaskTypeId: buildTaskType.id });
+      successfulTask.update({ status: BuildTask.Statuses.Success });
+
+      build = await factory.build({ site });
+      const errorTask = await factory.buildTask({ build, buildTaskTypeId: buildTaskType.id });
+      errorTask.update({ status: BuildTask.Statuses.Error });
+
+      await buildTask.enqueue();
+      await buildTask.reload();
+
+      const [queuedTask, priority] = sendMessageStub.getCall(0).args;
+
+      // called with higher priority
+      expect(sendMessageStub.called).to.be.true;
+      expect(queuedTask.id).to.equal(buildTask.id);
+      expect(priority).to.equal(N + 1);
+    });
+  });
+});


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add build scan priority
- Close #4476 


## Notes
For a scan to be queued: adds queue priority equivalent to the number of non-completed tasks for the site. This has the nice effect of a sites 10th in a row scan being prioritized behind others second. It also ensures everything has a priority assigned, which allows some operator flexibility in adding non-prioritized jobs if necessary (as they would bypass all others)

## security considerations
None 