### PR TITLE
Send sandbox reminders to UAA email address 

### DIFF
--- a/api/services/SandboxHelper.js
+++ b/api/services/SandboxHelper.js
@@ -5,7 +5,7 @@ const {
 const PromisePool = require('@supercharge/promise-pool');
 const Mailer = require('./mailer');
 const {
-  User, Organization, Site, Role,
+  User, Organization, Site, Role, UAAIdentity,
 } = require('../models');
 const SiteDestroyer = require('./SiteDestroyer');
 const { sandboxDays } = require('../../config').app;
@@ -29,6 +29,7 @@ const notifyOrganizations = async (cleaningDate) => {
             roleId: managerRole.id,
           },
         },
+        include: UAAIdentity,
       },
       {
         model: Site,

--- a/test/api/unit/services/SandboxHelper.test.js
+++ b/test/api/unit/services/SandboxHelper.test.js
@@ -65,6 +65,23 @@ describe('notifyOrganizations', () => {
       .to.eql(o.Sites.map(v => v.id)));
   };
 
+  it('includes UAA identities for users who have them', async () => {
+    let org;
+    const orgsToNotify = [];
+    org = await createSandboxOrgDaysRemaining();
+    const user = org.Users[0];
+    await factory.uaaIdentity({ userId: user.id });
+
+    orgsToNotify.push(org.id);
+
+    await notifyOrganizations(moment().toDate());
+
+    expect(mailerSpy.callCount).to.equal(1);
+    expect(mailerSpy.args[0][0].Users.length).to.equal(1);
+    expect(mailerSpy.args[0][0].Users[0].id).to.equal(user.id);
+    expect(mailerSpy.args[0][0].Users[0]).to.haveOwnProperty('UAAIdentity');
+  });
+
   it('notifies agencies with schedule date', async () => {
     let org;
     const orgsToNotify = [];


### PR DESCRIPTION
## Changes proposed in this pull request:
- Use UAA email address as the destination for Sandbox reminder emails

## security considerations
None. This change switches to a more appropriate and more reliably-present email address to receive these notifications. 