### PR TITLE
chore: Refactor site build queue and worker

### DIFF
--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -50,6 +50,7 @@ applications:
       CF_DOMAIN_WITH_CDN_PLAN_GUID: 440cce96-8989-428b-a60e-91c1393bf3f2
       NEW_RELIC_ERROR_COLLECTOR_ENABLED: false
       QUEUES_BUILD_TASKS_CONCURRENCY: ((queues_build_tasks_concurrency))
+      QUEUES_SITE_BUILDS_CONCURRENCY: ((queues_site_builds_concurrency))
   - name: pages-admin((env_postfix))
     buildpack: staticfile_buildpack
     path: ../admin-client

--- a/.cloudgov/vars/pages-dev.yml
+++ b/.cloudgov/vars/pages-dev.yml
@@ -14,4 +14,5 @@ new_relic_app_name: web-pages-dev
 proxy_domain: sites.pages-dev.cloud.gov
 cf_cdn_space_name: sites-dev
 node_env: development
-queues_build_tasks_concurrency: 20
+queues_build_tasks_concurrency: 2
+queues_site_builds_concurrency: 3

--- a/.cloudgov/vars/pages-production.yml
+++ b/.cloudgov/vars/pages-production.yml
@@ -14,4 +14,5 @@ new_relic_app_name: web-pages-production
 proxy_domain: sites.pages.cloud.gov
 cf_cdn_space_name: sites
 node_env: production
-queues_build_tasks_concurrency: 20
+queues_build_tasks_concurrency: 2
+queues_site_builds_concurrency: 3

--- a/.cloudgov/vars/pages-staging.yml
+++ b/.cloudgov/vars/pages-staging.yml
@@ -15,3 +15,4 @@ proxy_domain: sites.pages-staging.cloud.gov
 cf_cdn_space_name: sites-staging
 node_env: production
 queues_build_tasks_concurrency: 10
+queues_site_builds_concurrency: 10

--- a/api/bull-board/app.js
+++ b/api/bull-board/app.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const { createBullBoard } = require('@bull-board/api');
-const { BullAdapter } = require('@bull-board/api/bullAdapter');
 const { BullMQAdapter } = require('@bull-board/api/bullMQAdapter');
 const { ExpressAdapter } = require('@bull-board/express');
 const IORedis = require('ioredis');
@@ -15,6 +14,7 @@ const {
   FailStuckBuildsQueue,
   MailQueue,
   NightlyBuildsQueue,
+  SiteBuildsQueue,
   SiteBuildQueue,
   SiteDeletionQueue,
   ScheduledQueue,
@@ -37,7 +37,8 @@ const serverAdapter = new ExpressAdapter();
 
 createBullBoard({
   queues: [
-    new BullAdapter(new SiteBuildQueue(connection)),
+    new BullMQAdapter(new SiteBuildQueue(connection)),
+    new BullMQAdapter(new SiteBuildsQueue(connection)),
     new BullMQAdapter(new ArchiveBuildLogsQueue(connection)),
     new BullMQAdapter(new BuildTasksQueue(connection)),
     new BullMQAdapter(new DomainQueue(connection)),

--- a/api/queue-jobs/index.js
+++ b/api/queue-jobs/index.js
@@ -1,0 +1,37 @@
+const IORedis = require('ioredis');
+const { SiteBuildsQueue } = require('../queues');
+const { truncateString } = require('../utils');
+const { redis } = require('../../config');
+
+const connection = new IORedis(redis.url, {
+  tls: redis.tls,
+  maxRetriesPerRequest: null,
+});
+
+const siteBuildsQueue = new SiteBuildsQueue(connection);
+
+const QueueJobs = {};
+
+/**
+* Adds a site build job to the Site Builds Queue
+* The build's branch, site owner, and site repository attributes
+* are used to creat the name of the job added to the queue
+* @async
+* @method startSiteBuild
+* @param {Object} build - An instance of the model Build
+* @param {number} build.id - The build primary key
+* @param {string} build.branch - The git branch for the site build
+* @param {Object} build.Site - The build instance's related site
+* @param {string} build.Site.owner - The site's owner
+* @param {string} build.Site.repository - The site's repository
+* @return {Promise<{Object}>} The bullmq's queue add job response
+*/
+QueueJobs.startSiteBuild = async (build, priority) => {
+  const { branch, id: buildId, Site } = build;
+  const { owner, repository } = Site;
+  const jobName = `${owner}/${repository}: ${truncateString(branch)}`;
+
+  return siteBuildsQueue.add(jobName, { buildId }, { priority });
+};
+
+module.exports = QueueJobs;

--- a/api/queues/SiteBuildsQueue.js
+++ b/api/queues/SiteBuildsQueue.js
@@ -1,0 +1,19 @@
+const { Queue } = require('bullmq');
+
+const SiteBuildsQueueName = 'site-builds';
+
+class SiteBuildsQueue extends Queue {
+  constructor(connection, { attempts = 1 } = {}) {
+    super(SiteBuildsQueueName, {
+      connection,
+      defaultJobOptions: {
+        attempts,
+      },
+    });
+  }
+}
+
+module.exports = {
+  SiteBuildsQueue,
+  SiteBuildsQueueName,
+};

--- a/api/queues/index.js
+++ b/api/queues/index.js
@@ -6,6 +6,7 @@ const { MailQueue, MailQueueName } = require('./MailQueue');
 const { NightlyBuildsQueue, NightlyBuildsQueueName } = require('./NightlyBuildsQueue');
 const { ScheduledQueue, ScheduledQueueName } = require('./ScheduledQueue');
 const { SiteBuildQueue, SiteBuildQueueName } = require('./SiteBuildQueue');
+const { SiteBuildsQueue, SiteBuildsQueueName } = require('./SiteBuildsQueue');
 const { SiteDeletionQueue, SiteDeletionQueueName } = require('./SiteDeletionQueue');
 const { SlackQueue, SlackQueueName } = require('./SlackQueue');
 const { TimeoutBuildTasksQueue, TimeoutBuildTasksQueueName } = require('./TimeoutBuildTasksQueue');
@@ -23,12 +24,14 @@ module.exports = {
   MailQueueName,
   NightlyBuildsQueue,
   NightlyBuildsQueueName,
-  SiteBuildQueue,
-  SiteBuildQueueName,
-  SiteDeletionQueue,
-  SiteDeletionQueueName,
   ScheduledQueue,
   ScheduledQueueName,
+  SiteBuildQueue,
+  SiteBuildQueueName,
+  SiteBuildsQueue,
+  SiteBuildsQueueName,
+  SiteDeletionQueue,
+  SiteDeletionQueueName,
   SlackQueue,
   SlackQueueName,
   TimeoutBuildTasksQueue,

--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -243,6 +243,14 @@ function defaultContext(req, res) {
   };
 }
 
+function truncateString(s, characters = 30) {
+  if (s.length > characters) {
+    return `${s.substring(0, characters)}...`;
+  }
+
+  return s;
+}
+
 const DEFAULT_BUILD_TASK_PARAMS = "-p '{ \"STATUS_CALLBACK\": \"{{job.data.STATUS_CALLBACK}}\", \"TASK_ID\": {{job.data.TASK_ID}}, \"AWS_DEFAULT_REGION\": \"{{job.data.AWS_DEFAULT_REGION}}\", \"AWS_ACCESS_KEY_ID\": \"{{job.data.AWS_ACCESS_KEY_ID}}\", \"AWS_SECRET_ACCESS_KEY\": \"{{job.data.AWS_SECRET_ACCESS_KEY}}\", \"BUCKET\": \"{{job.data.BUCKET}}\" }'";
 
 module.exports = {
@@ -263,6 +271,7 @@ module.exports = {
   shouldIncludeTracking,
   toInt,
   toSubdomainPart,
+  truncateString,
   wait,
   wrapHandler,
   wrapHandlers,

--- a/api/workers/index.js
+++ b/api/workers/index.js
@@ -26,6 +26,8 @@ const {
   ScheduledQueue,
   ScheduledQueueName,
   SlackQueueName,
+  SiteBuildsQueue,
+  SiteBuildsQueueName,
   SiteDeletionQueueName,
   TimeoutBuildTasksQueue,
   TimeoutBuildTasksQueueName,
@@ -62,7 +64,7 @@ function pagesWorker(connection) {
   };
 
   const buildTasksProcessor = job => Processors.buildTaskRunner(job);
-
+  const siteBuildProcessor = job => Processors.siteBuildRunner(job);
   const failBuildsProcessor = job => Processors.failStuckBuilds(job);
 
   const siteDeletionProcessor = job => Processors.destroySiteInfra(job.data);
@@ -96,6 +98,12 @@ function pagesWorker(connection) {
     new QueueWorker(MailQueueName, connection, mailJobProcessor),
     new QueueWorker(NightlyBuildsQueueName, connection, nightlyBuildsProcessor),
     new QueueWorker(ScheduledQueueName, connection, scheduledJobProcessor),
+    new QueueWorker(
+      SiteBuildsQueueName,
+      connection,
+      siteBuildProcessor,
+      { concurrency: queuesConfig.siteBuildsConcurrency }
+    ),
     new QueueWorker(SiteDeletionQueueName, connection, siteDeletionProcessor),
     new QueueWorker(SlackQueueName, connection, slackJobProcessor),
     new QueueWorker(TimeoutBuildTasksQueueName, connection, timeoutBuildsProcessor),
@@ -106,6 +114,7 @@ function pagesWorker(connection) {
   const failStuckBuildsQueue = new FailStuckBuildsQueue(connection);
   const nightlyBuildsQueue = new NightlyBuildsQueue(connection);
   const scheduledQueue = new ScheduledQueue(connection);
+  const siteBuildsQueue = new SiteBuildsQueue(connection);
   const timeoutBuildTasksQueue = new TimeoutBuildTasksQueue(connection);
   const queues = [
     archiveBuildLogsQueue,
@@ -113,6 +122,7 @@ function pagesWorker(connection) {
     failStuckBuildsQueue,
     nightlyBuildsQueue,
     scheduledQueue,
+    siteBuildsQueue,
     timeoutBuildTasksQueue,
   ];
 

--- a/api/workers/jobProcessors/index.js
+++ b/api/workers/jobProcessors/index.js
@@ -1,21 +1,23 @@
 const archiveBuildLogsDaily = require('./archiveBuildLogsDaily');
 const buildTaskRunner = require('./buildTaskRunner');
+const cleanSandboxOrganizations = require('./cleanSandboxOrganizations');
 const destroySiteInfra = require('./destroySiteInfra');
 const failStuckBuilds = require('./failStuckBuilds');
 const multiJobProcessor = require('./multiJobProcessor');
 const nightlyBuilds = require('./nightlyBuilds');
-const timeoutBuilds = require('./timeoutBuilds');
 const sandboxNotifications = require('./sandboxNotifications');
-const cleanSandboxOrganizations = require('./cleanSandboxOrganizations');
+const siteBuildRunner = require('./siteBuildRunner');
+const timeoutBuilds = require('./timeoutBuilds');
 
 module.exports = {
   archiveBuildLogsDaily,
   buildTaskRunner,
+  cleanSandboxOrganizations,
   destroySiteInfra,
   failStuckBuilds,
   multiJobProcessor,
   nightlyBuilds,
-  timeoutBuilds,
   sandboxNotifications,
-  cleanSandboxOrganizations,
+  siteBuildRunner,
+  timeoutBuilds,
 };

--- a/api/workers/jobProcessors/siteBuildRunner.js
+++ b/api/workers/jobProcessors/siteBuildRunner.js
@@ -1,0 +1,95 @@
+const { Build } = require('../../models');
+const SiteBuildQueueService = require('../../services/SiteBuildQueue');
+const { createJobLogger } = require('./utils');
+const CloudFoundryAPIClient = require('../../utils/cfApiClient');
+
+const apiClient = new CloudFoundryAPIClient();
+
+// Add CF Task (startBuildTask method) call to retry sleep interval to 1 second
+// If it is in test environment set to 0 seconds
+const sleepInterval = process.env.NODE_ENV === 'test' ? 0 : 1000;
+
+/**
+ * The Site Builds Queue job processor
+ * to start a CF Task to build the site's branch
+ * @async
+ * @method siteBuildRunner
+ * @param {Object} job - The bullmq job object
+ * @param {object} job.data - The job data object
+ * @param {string} job.data.buildId - The buildId for the site build job
+ * @param {Object} options - The options for polling.
+ * @param {number} [options.totalAttempts=180] - The total number of attempts
+ * @param {number} [options.sleepNumber=15000] - The milliseconds
+ * @return {Promise<{Object}>} The bullmq's queue add job response
+ */
+async function siteBuildRunner(
+  job,
+  { sleepNumber = 15000, totalAttempts = 180 } = {}
+) {
+  const logger = createJobLogger(job);
+  const { buildId } = job.data;
+
+  logger.log(`Running site build: ${buildId}`);
+  try {
+    const { build, message } = await SiteBuildQueueService.setupTaskEnv(
+      buildId
+    );
+
+    const {
+      branch,
+      Site: { owner, repository },
+    } = build;
+
+    logger.log(
+      `Starting site build for ${owner}/${repository} on branch ${branch}`
+    );
+
+    const cfResponse = await apiClient.startSiteBuildTask(message, job.id, {
+      sleepInterval,
+    });
+
+    if (cfResponse.state === 'FAILED') {
+      const errorMessage = `CF task failed for site build ${buildId}`;
+      logger.log(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    logger.log('The site build started successfully.');
+
+    logger.log('Waiting for build status update.');
+    const hasCompleted = await apiClient.pollTaskStatus(cfResponse.guid, {
+      sleepInterval: sleepNumber,
+      totalAttempts,
+    });
+
+    // reload instance
+    await build.reload();
+
+    if (
+      hasCompleted.state === 'FAILED'
+      && [
+        Build.States.Processing,
+        Build.States.Queued,
+        Build.States.Created,
+        Build.States.Tasked,
+      ].includes(build.state)
+    ) {
+      await build.update({ state: Build.States.Error });
+    }
+
+    logger.log(`Site build completed with ${build.state}`);
+
+    return true;
+  } catch (err) {
+    const message = `Error site build ${buildId}: ${err?.message}`;
+    logger.log(message);
+    const errorTask = await Build.findByPk(buildId);
+    await errorTask.update({
+      state: Build.States.Error,
+      error: err?.message,
+    });
+    throw new Error(message);
+  }
+}
+
+module.exports = siteBuildRunner;

--- a/config/queues.js
+++ b/config/queues.js
@@ -2,6 +2,11 @@ const buildTasksConcurrency = process.env.QUEUES_BUILD_TASKS_CONCURRENCY
   ? parseInt(process.env.QUEUES_BUILD_TASKS_CONCURRENCY, 10)
   : 5;
 
+const siteBuildsConcurrency = process.env.QUEUES_SITE_BUILDS_CONCURRENCY
+  ? parseInt(process.env.QUEUES_SITE_BUILDS_CONCURRENCY, 10)
+  : 5;
+
 module.exports = {
   buildTasksConcurrency,
+  siteBuildsConcurrency,
 };

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -554,3 +554,17 @@ The frontend UI should be structured to improve consistency and developer experi
 - Custom hooks using React hooks should be used in pages and dynamic components to define the specific data and actions related to their corresponding pages and dynamic components. Custom hooks should be defined in a file in the [`./frontend/hooks](../frontend/hooks/) directory. ie:
   - The `useBuildLogs` hook would define the state and effects associated with the build logs dynamic component.
   - The `useSiteBuilds` hook would define the state and effects for a site's build history
+
+## Event Driven Queueing
+
+### Queues
+
+Queues are the different event streams that accept jobs, process them, and are kept in the [./api/queues](../api/queues) directory.
+
+### Queue Jobs
+
+Queue jobs are actions that add a job to a queue and are kept in the [./api/queue-jobs](../api/queue-jobs) directory.
+
+### Workers
+
+Workers are the processors that handle a job in a queue and are kept in the [./api/workers](../api/workers) directory.

--- a/test/api/requests/build.test.js
+++ b/test/api/requests/build.test.js
@@ -3,7 +3,7 @@ const nock = require('nock');
 const request = require('supertest');
 const sinon = require('sinon');
 const app = require('../../../app');
-const SiteBuildQueue = require('../../../api/services/SiteBuildQueue');
+const queueJobs = require('../../../api/queue-jobs');
 const GithubBuildHelper = require('../../../api/services/GithubBuildHelper');
 const EventCreator = require('../../../api/services/EventCreator');
 const factory = require('../support/factory');
@@ -17,9 +17,8 @@ const requestedCommitSha = 'a172b66c31e19d456a448041a5b3c2a70c32d8b7';
 const clonedCommitSha = '7b8d23c07a2c3b5a140844a654d91e13c66b271a';
 
 describe('Build API', () => {
-
   beforeEach(() => {
-    sinon.stub(SiteBuildQueue, 'sendBuildMessage').resolves();
+    sinon.stub(queueJobs, 'startSiteBuild').resolves();
     sinon.stub(EventCreator, 'audit').resolves();
     sinon.stub(EventCreator, 'error').resolves();
   });

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -27,7 +27,7 @@ const {
 } = require('../../../api/models');
 const SiteDestroyer = require('../../../api/services/SiteDestroyer');
 const siteErrors = require('../../../api/responses/siteErrors');
-const SiteBuildQueue = require('../../../api/services/SiteBuildQueue');
+const queueJobs = require('../../../api/queue-jobs');
 const EventCreator = require('../../../api/services/EventCreator');
 const DomainService = require('../../../api/services/Domain');
 
@@ -36,7 +36,7 @@ const authErrorMessage =
 
 describe('Site API', () => {
   beforeEach(() => {
-    sinon.stub(SiteBuildQueue, 'sendBuildMessage').resolves();
+    sinon.stub(queueJobs, 'startSiteBuild').resolves();
     sinon.stub(EventCreator, 'error').resolves();
 
     return factory.organization.truncate();

--- a/test/api/support/queues.js
+++ b/test/api/support/queues.js
@@ -1,0 +1,16 @@
+function promisedQueueEvents(queueEvents, event) {
+  return new Promise((resolve) => {
+    queueEvents.on(event, resolve);
+  });
+}
+
+function promisedQueueAnyEvents(queueEvents, events) {
+  return new Promise((resolve) => {
+    events.forEach(event => queueEvents.on(event, resolve));
+  });
+}
+
+module.exports = {
+  promisedQueueEvents,
+  promisedQueueAnyEvents,
+};

--- a/test/api/unit/jobs/index.test.js
+++ b/test/api/unit/jobs/index.test.js
@@ -1,0 +1,67 @@
+const { expect } = require('chai');
+const { QueueEvents } = require('bullmq');
+const IORedis = require('ioredis');
+const { startSiteBuild } = require('../../../../api/queue-jobs');
+const {
+  SiteBuildsQueue,
+  SiteBuildsQueueName,
+} = require('../../../../api/queues');
+const {
+  Build,
+  Site,
+} = require('../../../../api/models');
+const { redis: redisConfig } = require('../../../../config');
+const factory = require('../../support/factory');
+const { promisedQueueEvents, promisedQueueAnyEvents } = require('../../support/queues');
+
+const connection = new IORedis(redisConfig.url, {
+  tls: redisConfig.tls,
+  maxRetriesPerRequest: null,
+});
+
+async function cleanDb() {
+  return Promise.all([
+    Build.truncate(),
+    Site.truncate({ force: true, cascade: true }),
+  ]);
+}
+
+describe('queue-jobs', () => {
+  describe('.startSiteBuild', () => {
+    const queue = new SiteBuildsQueue(connection);
+    const queueEvents = new QueueEvents(SiteBuildsQueueName, { connection });
+
+    after(async () => {
+      await queueEvents.close();
+      await queue.close();
+    });
+
+    afterEach(async () => {
+      await queue.obliterate({ force: true });
+      await cleanDb();
+    });
+
+    it('should start a site build successfully', async () => {
+      const factoryBuild = await factory.build();
+      const build = await Build.findByPk(factoryBuild.id, { include: [Site] });
+      const jobname = `${build.Site.owner}/${build.Site.repository}: ${build.branch}`;
+
+      const response = await startSiteBuild(build);
+      const job = await promisedQueueEvents(queueEvents, 'active');
+      expect(response.id).to.eq(job.jobId);
+      expect(response.name).to.eq(jobname);
+    });
+
+    it('should start a site build successfully and truncat long branch name', async () => {
+      const branch = Array(100).fill('b').join('');
+      const factoryBuild = await factory.build({ branch });
+      const build = await Build.findByPk(factoryBuild.id, { include: [Site] });
+      const jobname = `${build.Site.owner}/${build.Site.repository}: ${build.branch.substring(0, 30)}...`;
+
+      const response = await startSiteBuild(build);
+      const job = await promisedQueueAnyEvents(queueEvents, ['active', 'waiting']);
+      expect(response.id).to.eq(job.jobId);
+      expect(response.name).to.eq(jobname);
+    });
+  });
+});

--- a/test/api/unit/services/NightlyBuildsHelper.test.js
+++ b/test/api/unit/services/NightlyBuildsHelper.test.js
@@ -8,13 +8,13 @@ const {
   User,
 } = require('../../../../api/models');
 const NightlyBuildsHelper = require('../../../../api/services/NightlyBuildsHelper');
-const SiteBuildQueue = require('../../../../api/services/SiteBuildQueue');
+const queueJobs = require('../../../../api/queue-jobs');
 
 describe('NightlyBuildsHelper', () => {
   const nightlyConfig = { schedule: 'nightly' };
 
   before(async () => {
-    sinon.stub(SiteBuildQueue, 'sendBuildMessage').resolves();
+    sinon.stub(queueJobs, 'startSiteBuild').resolves();
     await factory.user({ username: process.env.USER_AUDITOR });
   });
 

--- a/test/api/unit/services/SiteCreator.test.js
+++ b/test/api/unit/services/SiteCreator.test.js
@@ -15,11 +15,11 @@ const {
   User,
   SiteBranchConfig,
 } = require('../../../../api/models');
-const SiteBuildQueue = require('../../../../api/services/SiteBuildQueue');
+const queueJobs = require('../../../../api/queue-jobs');
 
 describe('SiteCreator', () => {
   beforeEach(() => {
-    sinon.stub(SiteBuildQueue, 'sendBuildMessage').resolves();
+    sinon.stub(queueJobs, 'startSiteBuild').resolves();
   });
 
   afterEach(() => {
@@ -601,13 +601,13 @@ describe('SiteCreator', () => {
           const secretAccessKey = crypto.randomBytes(10).toString('hex');
           const region = 'us-gov-other-1';
           const bucket = 'testing-bucket';
-  
+
           const instanceRequestBody = { name, service_plan_guid: planGuid };
           const keyRequestBody = {
             name: keyName,
             serviceInstanceGuid: bucketGuid,
           };
-  
+
           const planResponses = factory.createCFAPIResourceList({
             resources: [
               factory.createCFAPIResource({ guid: planGuid, name: planName }),
@@ -617,12 +617,12 @@ describe('SiteCreator', () => {
             guid: bucketGuid,
             name,
           });
-  
+
           const keyResponse = factory.createCFAPIResource({
             name: keyName,
             serviceInstanceGuid: bucketGuid,
           });
-  
+
           const keyCredentials = factory.responses.credentials({
             access_key_id: accessKeyId,
             secret_access_key: secretAccessKey,
@@ -638,7 +638,7 @@ describe('SiteCreator', () => {
               }),
             ],
           });
-  
+
           const buildResponses = factory.createCFAPIResourceList({
             resources: [
               factory.createCFAPIResource({
@@ -647,7 +647,7 @@ describe('SiteCreator', () => {
               }),
             ],
           });
-  
+
           mockTokenRequest();
           apiNocks.mockFetchS3ServicePlanGUID(planResponses, planName);
           apiNocks.mockCreateS3ServiceInstance(

--- a/test/api/unit/services/Webhooks.test.js
+++ b/test/api/unit/services/Webhooks.test.js
@@ -2,10 +2,8 @@ const crypto = require('crypto');
 const { expect } = require('chai');
 const nock = require('nock');
 const sinon = require('sinon');
-const request = require('supertest');
-const app = require('../../../../app');
-const { Build, Site, User, Event } = require('../../../../api/models');
-const SiteBuildQueue = require('../../../../api/services/SiteBuildQueue');
+const { Build, User, Event } = require('../../../../api/models');
+const queueJobs = require('../../../../api/queue-jobs');
 const EventCreator = require('../../../../api/services/EventCreator');
 const GithubBuildHelper = require('../../../../api/services/GithubBuildHelper');
 
@@ -52,7 +50,7 @@ describe('Webhooks Service', () => {
       nock.cleanAll();
       githubAPINocks.status();
       githubAPINocks.repo({ response: [201, { permissions: { admin: true, push: true } }] });
-      sinon.stub(SiteBuildQueue, 'sendBuildMessage').resolves();
+      sinon.stub(queueJobs, 'startSiteBuild').resolves();
     });
 
     it('should create a new site build for the sender', async () => {

--- a/test/api/unit/utils/cfApiClient.tasks.test.js
+++ b/test/api/unit/utils/cfApiClient.tasks.test.js
@@ -1,0 +1,138 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const CloudFoundryAPIClient = require('../../../../api/utils/cfApiClient');
+
+describe('CloudFoundryAPIClient', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('.startSiteBuildTask', () => {
+    const apiClient = new CloudFoundryAPIClient();
+
+    it('should start a site build cf task with default settings', async () => {
+      const guid = 123;
+      const jobId = 456;
+      const state = 'SUCCEEDED';
+      const appName = 'pages-build-container-development';
+      const message = {
+        environment: [
+          {
+            name: 'BUILD',
+            value: '1',
+          },
+        ],
+      };
+      const method = 'POST';
+      const path = `/v3/apps/${guid}/tasks`;
+      const commandParam = message.environment[0];
+      const taskParams = {
+        disk_in_mb: 4 * 1024,
+        memory_in_mb: 2 * 1024,
+        name: `build-${jobId}`,
+        command: `cd app && python main.py -p '${JSON.stringify({
+          [commandParam.name]: commandParam.value,
+        })}'`,
+        metadata: { labels: { type: 'build-task' } },
+      };
+
+      const stubFetchTaskAppGUID = sinon.stub(CloudFoundryAPIClient.prototype, 'fetchTaskAppGUID');
+      stubFetchTaskAppGUID.resolves(guid);
+
+      const stubAuthRequest = sinon.stub(CloudFoundryAPIClient.prototype, 'authRequest');
+      stubAuthRequest.resolves({ state });
+
+      const res = await apiClient.startSiteBuildTask(message, jobId);
+
+      expect(res.state).to.equal('SUCCEEDED');
+      sinon.assert.calledOnceWithExactly(stubFetchTaskAppGUID, appName);
+      sinon.assert.calledOnceWithExactly(stubAuthRequest, method, path, taskParams);
+    });
+
+    it('should start a site build cf task with containerSize large settings', async () => {
+      const guid = 123;
+      const jobId = 456;
+      const state = 'SUCCEEDED';
+      const appName = 'pages-build-container-development';
+      const message = {
+        environment: [
+          {
+            name: 'BUILD',
+            value: '1',
+          },
+        ],
+        containerSize: 'large',
+      };
+      const method = 'POST';
+      const path = `/v3/apps/${guid}/tasks`;
+      const commandParam = message.environment[0];
+      const taskParams = {
+        disk_in_mb: 6 * 1024,
+        memory_in_mb: 2 * 1024,
+        name: `build-${jobId}`,
+        command: `cd app && python main.py -p '${JSON.stringify({
+          [commandParam.name]: commandParam.value,
+        })}'`,
+        metadata: { labels: { type: 'build-task' } },
+      };
+
+      const stubFetchTaskAppGUID = sinon.stub(CloudFoundryAPIClient.prototype, 'fetchTaskAppGUID');
+      stubFetchTaskAppGUID.resolves(guid);
+
+      const stubAuthRequest = sinon.stub(CloudFoundryAPIClient.prototype, 'authRequest');
+      stubAuthRequest.resolves({ state });
+
+      const res = await apiClient.startSiteBuildTask(message, jobId);
+
+      expect(res.state).to.equal('SUCCEEDED');
+      sinon.assert.calledOnceWithExactly(stubFetchTaskAppGUID, appName);
+      sinon.assert.calledOnceWithExactly(stubAuthRequest, method, path, taskParams);
+    });
+
+    it('should start a site build cf task on the third retry', async () => {
+      const guid = 123;
+      const jobId = 456;
+      const state = 'SUCCEEDED';
+      const appName = 'pages-build-container-development';
+      const message = {
+        environment: [
+          {
+            name: 'BUILD',
+            value: '1',
+          },
+        ],
+      };
+      const method = 'POST';
+      const path = `/v3/apps/${guid}/tasks`;
+      const commandParam = message.environment[0];
+      const taskParams = {
+        disk_in_mb: 4 * 1024,
+        memory_in_mb: 2 * 1024,
+        name: `build-${jobId}`,
+        command: `cd app && python main.py -p '${JSON.stringify({
+          [commandParam.name]: commandParam.value,
+        })}'`,
+        metadata: { labels: { type: 'build-task' } },
+      };
+
+      const stubFetchTaskAppGUID = sinon.stub(CloudFoundryAPIClient.prototype, 'fetchTaskAppGUID');
+      stubFetchTaskAppGUID.resolves(guid);
+
+      const stubAuthRequest = sinon.stub(CloudFoundryAPIClient.prototype, 'authRequest');
+      stubAuthRequest
+        .onFirstCall()
+        .rejects()
+        .onSecondCall()
+        .rejects()
+        .onThirdCall()
+        .resolves({ state });
+
+      const res = await apiClient.startSiteBuildTask(message, jobId, { sleepInterval: 0 });
+
+      expect(res.state).to.equal('SUCCEEDED');
+      expect(stubAuthRequest.callCount).to.equal(3);
+      sinon.assert.calledWithExactly(stubFetchTaskAppGUID, appName);
+      sinon.assert.calledWithExactly(stubAuthRequest, method, path, taskParams);
+    });
+  });
+});

--- a/test/api/workers/jobProcessors/siteBuildRunner.test.js
+++ b/test/api/workers/jobProcessors/siteBuildRunner.test.js
@@ -1,0 +1,274 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const IORedis = require('ioredis');
+const { QueueEvents } = require('bullmq');
+const QueueWorker = require('../../../../api/workers/QueueWorker');
+const {
+  Build,
+  BuildTask,
+  Domain,
+  Site,
+  SiteBranchConfig,
+  User,
+} = require('../../../../api/models');
+const CloudFoundryAPIClient = require('../../../../api/utils/cfApiClient');
+const SiteBuildQueue = require('../../../../api/services/SiteBuildQueue');
+const {
+  SiteBuildsQueue,
+  SiteBuildsQueueName,
+} = require('../../../../api/queues');
+const jobProcessors = require('../../../../api/workers/jobProcessors');
+const SiteBuildQueueService = require('../../../../api/services/SiteBuildQueue');
+const { redis: redisConfig } = require('../../../../config');
+const factory = require('../../support/factory');
+const { promisedQueueEvents } = require('../../support/queues');
+
+const buildIncludeOptions = {
+  include: [
+    {
+      model: Site,
+      required: true,
+      include: [SiteBranchConfig, Domain],
+    },
+    User,
+  ],
+};
+
+const taskMessage = buildId => ({
+  environment: [
+    {
+      name: 'STATUS_CALLBACK',
+      value: `http://localhost:1337/v0/build/${buildId}/status/abcd-123`,
+    },
+    { name: 'BRANCH', value: 'test-branch' },
+    { name: 'BUILD_ID', value: buildId },
+    { name: 'BUCKET', value: 'cg-123456789' },
+  ],
+  containerName: undefined,
+  containerSize: undefined,
+});
+
+const testJobOptions = { sleepNumber: 0, totalAttempts: 240 };
+
+const connection = new IORedis(redisConfig.url, {
+  tls: redisConfig.tls,
+  maxRetriesPerRequest: null,
+});
+
+async function cleanDb() {
+  return Promise.all([
+    BuildTask.truncate(),
+    Build.truncate(),
+    Site.truncate({ force: true, cascade: true }),
+  ]);
+}
+
+describe('siteBuildRunner', () => {
+  after(async () => {
+    await cleanDb();
+  });
+
+  describe('Expected Worker Output', () => {
+    const worker = new QueueWorker(
+      SiteBuildsQueueName,
+      connection,
+      job => jobProcessors.siteBuildRunner(job, testJobOptions)
+    );
+
+    // Set the queue to only attempt jobs once for testing
+    const queue = new SiteBuildsQueue(connection);
+    const queueEvents = new QueueEvents(SiteBuildsQueueName, { connection });
+
+    after(async () => {
+      await worker.close();
+      await queueEvents.close();
+      await queue.close();
+    });
+
+    afterEach(async () => {
+      await queue.obliterate({ force: true });
+      await cleanDb();
+      await sinon.restore();
+    });
+
+    it('should fail the job when unable to setupTaskEnv', async () => {
+      const errorResponse = new Error('It errored');
+      const build = await factory.build();
+      const stubBuildFindByPk = sinon.stub(Build, 'findByPk').resolves(build);
+      const stubSiteBuildQueueService = sinon
+        .stub(SiteBuildQueueService, 'setupTaskEnv')
+        .rejects(errorResponse);
+      const job = await queue.add('message', { buildId: build.id });
+      const result = await promisedQueueEvents(queueEvents, 'failed');
+      const expectedReason = `Error site build ${build.id}: ${errorResponse.message}`;
+
+      await build.reload();
+
+      expect(result.jobId).to.equal(job.id);
+      expect(result.failedReason).to.equal(expectedReason);
+      expect(build.state).to.equal(Build.States.Error);
+      sinon.assert.calledOnceWithExactly(stubBuildFindByPk, build.id);
+      sinon.assert.calledOnceWithExactly(stubSiteBuildQueueService, build.id);
+    });
+
+    it('should fail the job when CF task call fails', async () => {
+      const cfTaskError = new Error('Unable to connect');
+      const stubTaskEnv = sinon.stub(SiteBuildQueue, 'setupTaskEnv');
+      sinon
+        .stub(CloudFoundryAPIClient.prototype, 'startSiteBuildTask')
+        .rejects(cfTaskError);
+
+      const factoryBuild = await factory.build();
+      const build = await Build.findByPk(factoryBuild.id, buildIncludeOptions);
+      const message = taskMessage(build.id);
+      stubTaskEnv.resolves({ build, message });
+      const job = await queue.add('message', { buildId: build.id });
+      expect(build.state).to.equal(Build.States.Created);
+
+      const result = await promisedQueueEvents(queueEvents, 'failed');
+      const expectedReason = `Error site build ${build.id}: ${cfTaskError.message}`;
+      await build.reload();
+
+      expect(build.state).to.equal(Build.States.Error);
+      expect(result.jobId).to.equal(job.id);
+      expect(result.failedReason).to.equal(expectedReason);
+    });
+
+    it('should fail the job and build when CF tasks status goes beyond the max number of attempts', async () => {
+      const guid = 'task-guid';
+      const taskState = 'PENDING';
+
+      sinon
+        .stub(CloudFoundryAPIClient.prototype, 'startSiteBuildTask')
+        .resolves({ guid, state: taskState });
+
+      const fb = await factory.build();
+      const build = await Build.findByPk(fb.id, buildIncludeOptions);
+      const message = taskMessage(build.id);
+      sinon.stub(SiteBuildQueue, 'setupTaskEnv')
+        .resolves({ build, message });
+      const stubStatus = sinon.stub(CloudFoundryAPIClient.prototype, 'fetchTaskByGuid');
+      stubStatus.resolves({ state: taskState });
+
+      const stubCancelTask = sinon.stub(CloudFoundryAPIClient.prototype, 'cancelTask');
+      stubCancelTask.resolves();
+
+      expect(build.state).to.equal(Build.States.Created);
+
+      const job = await queue.add('message', { buildId: build.id });
+      const result = await promisedQueueEvents(queueEvents, 'failed');
+      const expectedReason = `Error site build ${build.id}: Task timed out after 0 minutes`;
+      await build.reload();
+
+      expect(build.state).to.equal(Build.States.Error);
+      expect(result.jobId).to.equal(job.id);
+      expect(result.failedReason).to.equal(expectedReason);
+      // Default number of attempts to poll status. Every 15 seconds for an hour.
+      expect(stubStatus.callCount).to.equal(240);
+      sinon.assert.calledWith(stubStatus, guid);
+      sinon.assert.calledOnceWithExactly(stubCancelTask, guid);
+    });
+
+    it('should have a successfull build', async () => {
+      const guid = 'task-guid';
+      const taskState = 'SUCCEEDED';
+
+      const stubStartSiteBuildTask = sinon
+        .stub(CloudFoundryAPIClient.prototype, 'startSiteBuildTask');
+      stubStartSiteBuildTask.resolves({ guid, state: taskState });
+
+      const fb = await factory.build();
+      const build = await Build.findByPk(fb.id, buildIncludeOptions);
+      const message = taskMessage(build.id);
+      const stubSetupTaskEnv = sinon.stub(SiteBuildQueue, 'setupTaskEnv');
+      stubSetupTaskEnv.resolves({ build, message });
+
+      const stubTaskStatus = sinon.stub(CloudFoundryAPIClient.prototype, 'fetchTaskByGuid');
+      stubTaskStatus.resolves({ state: taskState });
+
+      const job = await queue.add('sendTaskMessage', { buildId: build.id });
+      const result = await promisedQueueEvents(queueEvents, 'completed');
+      expect(result.jobId).to.equal(job.id);
+      sinon.assert.calledOnceWithExactly(
+        stubStartSiteBuildTask,
+        message,
+        job.id,
+        { sleepInterval: 0 }
+      );
+      sinon.assert.calledOnceWithExactly(stubSetupTaskEnv, build.id);
+      sinon.assert.calledWith(stubTaskStatus, guid);
+    });
+
+    it('should verify or set build state error if CF Task fails', async () => {
+      const guid = 'task-guid';
+      const taskState = 'SUCCEEDED';
+      const taskFinishedState = 'FAILED';
+
+      const stubStartSiteBuildTask = sinon
+        .stub(CloudFoundryAPIClient.prototype, 'startSiteBuildTask');
+      stubStartSiteBuildTask.resolves({ guid, state: taskState });
+
+      const fb = await factory.build();
+      const build = await Build.findByPk(fb.id, buildIncludeOptions);
+      const message = taskMessage(build.id);
+      const stubSetupTaskEnv = sinon.stub(SiteBuildQueue, 'setupTaskEnv');
+      stubSetupTaskEnv.resolves({ build, message });
+
+      const stubTaskStatus = sinon.stub(CloudFoundryAPIClient.prototype, 'fetchTaskByGuid');
+      stubTaskStatus.resolves({ state: taskFinishedState });
+
+      expect(build.state).to.equal(Build.States.Created);
+
+      const job = await queue.add('sendTaskMessage', { buildId: build.id });
+      const result = await promisedQueueEvents(queueEvents, 'completed');
+
+      await build.reload();
+
+      expect(build.state).to.equal(Build.States.Error);
+      expect(result.jobId).to.equal(job.id);
+      sinon.assert.calledOnceWithExactly(
+        stubStartSiteBuildTask,
+        message,
+        job.id,
+        { sleepInterval: 0 }
+      );
+      sinon.assert.calledOnceWithExactly(stubSetupTaskEnv, build.id);
+      sinon.assert.calledWith(stubTaskStatus, guid);
+    });
+
+    it('should have a successfull build with a retry on creating CF Task', async () => {
+      const guid = 'task-guid';
+      const startTaskResponse = { guid, state: 'PENDING' };
+      const taskState = 'SUCCEEDED';
+
+      sinon.stub(CloudFoundryAPIClient.prototype, 'fetchTaskAppGUID')
+        .resolves('123');
+
+      const cfTaskStub = sinon
+        .stub(CloudFoundryAPIClient.prototype, 'authRequest');
+
+      cfTaskStub.onFirstCall()
+        .rejects()
+        .onSecondCall()
+        .rejects()
+        .onThirdCall()
+        .resolves(startTaskResponse);
+
+      const fb = await factory.build();
+      const build = await Build.findByPk(fb.id, buildIncludeOptions);
+      const message = taskMessage(build.id);
+      const stubSetupTaskEnv = sinon.stub(SiteBuildQueue, 'setupTaskEnv');
+      stubSetupTaskEnv.resolves({ build, message });
+
+      const stubTaskStatus = sinon.stub(CloudFoundryAPIClient.prototype, 'fetchTaskByGuid');
+      stubTaskStatus.resolves({ state: taskState });
+
+      const job = await queue.add('sendTaskMessage', { buildId: build.id });
+      const result = await promisedQueueEvents(queueEvents, 'completed');
+      expect(result.jobId).to.equal(job.id);
+      expect(cfTaskStub.callCount).to.equal(3);
+      sinon.assert.calledOnceWithExactly(stubSetupTaskEnv, build.id);
+      sinon.assert.calledWith(stubTaskStatus, guid);
+    });
+  });
+});


### PR DESCRIPTION
closes #4456


## Changes proposed in this pull request:
- Creates a new `SiteBuildsQueue` to manage site build jobs from the bullmq queue worker
- Allows the current `SiteBuildQueue` (singular) to be deprecated in a following update along with the pages-builder app
- Refactor the site build job to just include the build id and allows the worker to setup the CF task command and manage the task


## security considerations
None
