### PR TITLE
chore: Increase prod queue concurrencies to max 10

### DIFF
--- a/.cloudgov/vars/pages-production.yml
+++ b/.cloudgov/vars/pages-production.yml
@@ -14,5 +14,5 @@ new_relic_app_name: web-pages-production
 proxy_domain: sites.pages.cloud.gov
 cf_cdn_space_name: sites
 node_env: production
-queues_build_tasks_concurrency: 2
-queues_site_builds_concurrency: 3
+queues_build_tasks_concurrency: 10
+queues_site_builds_concurrency: 10

--- a/.cloudgov/vars/pages-staging.yml
+++ b/.cloudgov/vars/pages-staging.yml
@@ -14,5 +14,5 @@ new_relic_app_name: web-pages-staging
 proxy_domain: sites.pages-staging.cloud.gov
 cf_cdn_space_name: sites-staging
 node_env: production
-queues_build_tasks_concurrency: 10
-queues_site_builds_concurrency: 10
+queues_build_tasks_concurrency: 4
+queues_site_builds_concurrency: 4


### PR DESCRIPTION
## Changes proposed in this pull request:
- Increase production queue concurrencies for build tasks and site builds to max out at 10
- Reduce staging queue concurrencies to 4

## security considerations
None
