### PR TITLE
wait for db port on ci tests

### DIFF
--- a/ci/tasks/test-api.sh
+++ b/ci/tasks/test-api.sh
@@ -3,6 +3,6 @@ set -euo pipefail
 
 cd app
 
-yarn test:cover; status=$?
+./scripts/wait-for-it.sh db:5432 -- yarn test:cover; status=$?
 
 exit $status


### PR DESCRIPTION
## Changes proposed in this pull request:
- wait for db port on ci tests

## security considerations
None 