### PR TITLE
send 401 response for bad auth callback

### DIFF
--- a/api/services/uaaStrategy.js
+++ b/api/services/uaaStrategy.js
@@ -39,7 +39,6 @@ function createUAAStrategy(options, verify) {
 
 async function verifyUAAUser(accessToken, refreshToken, profile, uaaGroups) {
   const { user_id: uaaId, email } = profile;
-
   const client = new UAAClient();
   const isVerified = await client.verifyUserGroup(uaaId, uaaGroups);
 

--- a/test/api/requests/auth.test.js
+++ b/test/api/requests/auth.test.js
@@ -160,10 +160,24 @@ describe('Authentication requests', () => {
               .expect(302);
 
             const session = await sessionForCookie(cookie);
-
             expect(session.flash.error.length).to.equal(1);
             expect(session.flash.error[0]).to.equal(flashMessage);
             expect(eventAuditStub.called).to.equal(true);
+          });
+        });
+
+        context('when the callback code does not match', () => {
+          it('should return 401', async () => {
+            const oauthState = 'state-123abc';
+            const code = 'code';
+            cfUAANocks.mockFailedExchange(code)
+
+            const cookie = await unauthenticatedSession({ oauthState });
+
+            await request(app)
+              .get(`/auth/uaa/callback?code=${code}&state=${oauthState}`)
+              .set('Cookie', cookie)
+              .expect(401);
           });
         });
       });

--- a/test/api/support/cfUAANock.js
+++ b/test/api/support/cfUAANock.js
@@ -176,6 +176,22 @@ function mockExchangeToken(code, accessToken) {
     });
 }
 
+function mockFailedExchange(code) {
+  const url = new URL(uaaConfig.tokenURL);
+
+  return nock(url.origin)
+    .post(url.pathname, body => (
+      body.code === code
+      && body.grant_type === 'authorization_code'
+      && body.client_id === uaaConfig.clientID
+      && body.client_secret === uaaConfig.clientSecret
+    ))
+    .reply(401, {
+      error: 'unauthorized',
+      error_description: 'An Authentication object was not found in the SecurityContext'
+    });
+}
+
 /**
  *
  * Flows that require multiple mocks
@@ -233,6 +249,7 @@ function mockServerErrorStatus(status, path, message, accessToken, method = 'get
 module.exports = {
   mockAddUserToGroup,
   mockUAAAuth,
+  mockFailedExchange,
   mockFetchClientToken,
   mockFetchGroupId,
   mockFetchGroupMembers,


### PR DESCRIPTION
## Changes proposed in this pull request:
- send 401 response for bad auth callback
- close #4512

## security considerations
Change to our OAuth callback flow. In theory it implements the same pattern as before but with additional error handling