### PR TITLE
Show UAAIdentity ID in Admin User page

### DIFF
--- a/admin-client/src/pages/user/Show.svelte
+++ b/admin-client/src/pages/user/Show.svelte
@@ -85,7 +85,7 @@
     <div class="grid-row">
       {#if user.UAAIdentity}
         <div class="tablet:grid-col-fill padding-bottom-1">
-          <LabeledItem label="uaa user id" value={user.UAAIdentity.userId} />
+          <LabeledItem label="uaa identity id" value={user.UAAIdentity.id} />
           <LabeledItem label="uaa id" value={user.UAAIdentity.uaaId} />
           <LabeledItem label="uaa origin" value={user.UAAIdentity.origin} />
           <LabeledItem label="uaa email" value={user.UAAIdentity.email} />

--- a/api/serializers/uaa-identity.js
+++ b/api/serializers/uaa-identity.js
@@ -7,6 +7,7 @@ const attributes = {
 };
 
 const adminAttributes = {
+  id: '',
   uaaId: '',
   userId: '',
   origin: '',

--- a/test/api/unit/serializers/uaa-identity.test.js
+++ b/test/api/unit/serializers/uaa-identity.test.js
@@ -15,6 +15,7 @@ describe('UAAIdentitySerializer', () => {
       const result = validateJSONSchema(uaaIdentityJson, uaaIdentitySchema);
       expect(result.errors).to.be.empty;
 
+      expect(uaaIdentityJson.id).to.be.undefined;
       expect(uaaIdentityJson.uaaId).to.be.undefined;
     });
 
@@ -26,6 +27,7 @@ describe('UAAIdentitySerializer', () => {
       const result = validateJSONSchema(uaaIdentityJson, uaaIdentitySchema);
       expect(result.errors).to.be.empty;
 
+      expect(uaaIdentityJson.id).to.eq(uaaIdentity.id);
       expect(uaaIdentityJson.uaaId).to.eq(uaaIdentity.uaaId);
     });
   });


### PR DESCRIPTION
Fixes #4501 

## Changes proposed in this pull request:
- Show UAA Identity ID in UAA Info section of Admin User page instead of showing User ID a second time

## security considerations
None. The change makes a primary key field visible in the user interface and through the API to authenticated admin users who already have access to that information through other means.
