### PR TITLE
fix: Only encrypt site build param values based on defined keys

### DIFF
--- a/api/services/Encryptor.js
+++ b/api/services/Encryptor.js
@@ -3,9 +3,9 @@ const _ = require('underscore');
 
 const ALGORITHM = 'aes-256-gcm';
 
-function encrypt(value, key, { hintSize = 4 } = {}) {
+function encrypt(value, encryptionKey, { hintSize = 4 } = {}) {
   // Create a 32 byte hash from the secret key
-  const hashedKey = Crypto.createHash('sha256').update(key).digest();
+  const hashedKey = Crypto.createHash('sha256').update(encryptionKey).digest();
 
   // Generate a random 16 byte initialization vector
   const iv = Crypto.randomBytes(16);
@@ -33,30 +33,63 @@ function encrypt(value, key, { hintSize = 4 } = {}) {
   return { ciphertext, hint };
 }
 
-function encryptObjectValues(obj, key, { hintSize = 4 } = {}) {
-  return _.mapObject(obj, (value) => {
-    if (_.isArray(value) || _.isFunction(value)) {
+function encryptObjectValues(
+  obj,
+  encryptionKey,
+  { hintSize = 4, onlyEncryptKeys = [] } = {}
+) {
+  const returnEncrypted = (item, shouldEncrypt = true) => {
+    if (_.isString(item) && shouldEncrypt) {
+      return encrypt(item, encryptionKey, { hintSize }).ciphertext;
+    }
+
+    if (_.isNumber(item) && shouldEncrypt) {
+      return encrypt(item.toString(), encryptionKey, { hintSize })
+        .ciphertext;
+    }
+
+    return item;
+  };
+
+  const encryptAll = onlyEncryptKeys.length === 0;
+
+  return _.mapObject(obj, (value, key) => {
+    const shouldEncrypt = encryptAll || onlyEncryptKeys.includes(key);
+
+    if (_.isFunction(value)) {
       return value;
     }
 
+    if (_.isArray(value) && shouldEncrypt) {
+      return _.map(value, (item) => {
+        if (_.isFunction(item)) {
+          return item;
+        }
+
+        if (_.isObject(item)) {
+          return encryptObjectValues(item, encryptionKey, {
+            hintSize,
+            onlyEncryptKeys,
+          });
+        }
+
+        return returnEncrypted(item);
+      });
+    }
+
     if (_.isObject(value)) {
-      return encryptObjectValues(value, key, { hintSize });
+      return encryptObjectValues(value, encryptionKey, {
+        hintSize,
+        onlyEncryptKeys,
+      });
     }
 
-    if (_.isString(value)) {
-      return encrypt(value, key, { hintSize }).ciphertext;
-    }
-
-    if (_.isNumber(value)) {
-      return encrypt(value.toString(), key, { hintSize }).ciphertext;
-    }
-
-    return value;
+    return returnEncrypted(value, shouldEncrypt);
   });
 }
 
-function decrypt(ciphertext, key) {
-  const hashedKey = Crypto.createHash('sha256').update(key).digest();
+function decrypt(ciphertext, encryptionKey) {
+  const hashedKey = Crypto.createHash('sha256').update(encryptionKey).digest();
   const [authTagHex, ivHex, encrypted] = ciphertext.split(':');
 
   const iv = Buffer.from(ivHex, 'hex');

--- a/test/api/unit/services/Encryptor.test.js
+++ b/test/api/unit/services/Encryptor.test.js
@@ -37,7 +37,7 @@ describe('Encryptor', () => {
   });
 
   describe('.encryptObjectValues', () => {
-    it('should only encrypt string and number values', () => {
+    it('should only encrypt string, numbers, and array values', () => {
       const key = 'encrypt-key';
       const data = {
         id: 123,
@@ -53,12 +53,49 @@ describe('Encryptor', () => {
 
       expect(decryptedId).to.equal(data.id.toString());
       expect(decryptedName).to.equal(data.name);
-      expect(output.numberlist).to.equal(data.numberlist);
-      expect(output.stringList).to.equal(data.stringList);
+      output.numberlist.map((enc, idx) => expect(
+        Encryptor.decrypt(enc, key)).to.equal(data.numberlist[idx].toString())
+      );
+      output.stringList.map((enc, idx) => expect(
+        Encryptor.decrypt(enc, key)).to.equal(data.stringList[idx])
+      );
       expect(typeof output.getFunction).to.equal('function');
     });
 
-    it('should only encrypt nested string and number values', () => {
+    it('should only encrypt key values when defined in options', () => {
+      const key = 'encrypt-key';
+      const id = 123;
+      const name = 'this-test-object';
+      const describe = 'The testing object';
+      const secret = 'A secret to encrypt';
+      const password = 'Apassword2encrypt';
+      const pin = 8772274669;
+      const onlyEncryptKeys = ['secret', 'password', 'pin'];
+      const data = {
+        id,
+        name,
+        describe,
+        secret,
+        password,
+        pin,
+      };
+
+      const output = Encryptor.encryptObjectValues(data, key, {
+        onlyEncryptKeys,
+      });
+      const decryptedSecret = Encryptor.decrypt(output.secret, key);
+      const decryptedPassword = Encryptor.decrypt(output.password, key);
+      const decryptedPin = Encryptor.decrypt(output.pin, key);
+
+      expect(decryptedSecret).to.equal(secret);
+      expect(decryptedPassword).to.equal(password);
+      expect(decryptedPin).to.equal(pin.toString());
+      expect(output.id).to.equal(id);
+      expect(output.name).to.equal(name);
+      expect(output.describe).to.equal(describe);
+    });
+
+    it('should only encrypt nested string, number, and array values', () => {
       const key = 'encrypt-key';
       const data = {
         id: 123,
@@ -101,7 +138,9 @@ describe('Encryptor', () => {
       expect(decryptedMetadataName).to.equal(data.metadata.name);
       expect(decryptedMetadataType).to.equal(data.metadata.type);
       expect(decryptedMetadataMetaName).to.equal(data.metadata.meta.name);
-      expect(output.metadata.meta.list).to.equal(data.metadata.meta.list);
+      output.metadata.meta.list.map((enc, idx) => expect(
+        Encryptor.decrypt(enc, key)).to.equal(data.metadata.meta.list[idx].toString())
+      );
       expect(decryptedAttributesTotal).to.equal(
         data.attributes.total.toString()
       );


### PR DESCRIPTION
## Changes proposed in this pull request:


- Switches to just encrypt values for predefined keys sent to the CF task as a parameter
- This work is related to the `4096` character cap on the command passed to a CF task

## security considerations
None
