### PR TITLE
Unvendor the node modules

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -40,7 +40,9 @@ lib-cov
 *.out
 *.pid
 npm-debug.log
-# node_modules is purposefully kept for vendoring: https://docs.cloudfoundry.org/buildpacks/node/index.html#vendoring
+node_modules
+# https://docs.cloudfoundry.org/buildpacks/node/index.html#vendoring
+# Vendoring is suggested during the build but empirically slows down deployment
 
 
 ################################################


### PR DESCRIPTION
## Changes proposed in this pull request:
- Unvendor the node modules
- https://docs.cloudfoundry.org/buildpacks/node/index.html#vendoring
- Vendoring is recommended but empirically it seems like the associated file hash checks, packaging, and upload slow down the build rather than speeding it up

## security considerations
None