### PR TITLE
feat(admin): Add runDay input to manage build tasks

### DIFF
--- a/admin-client/src/components/Nav.svelte
+++ b/admin-client/src/components/Nav.svelte
@@ -97,6 +97,11 @@
             </a>
           </li>
           <li class="usa-nav__primary-item">
+            <a class="usa-nav__link"  class:usa-current={currentPath === '/tasks'} href="/tasks">
+              <span>Tasks</span>
+            </a>
+          </li>
+          <li class="usa-nav__primary-item">
             <a class="usa-nav__link"  class:usa-current={currentPath === '/users'} href="/users">
               <span>Users</span>
             </a>

--- a/admin-client/src/components/NumberInput.svelte
+++ b/admin-client/src/components/NumberInput.svelte
@@ -1,0 +1,34 @@
+<script>
+  export let error;
+  export let hint;
+  export let id;
+  export let label;
+  export let name;
+  export let required = false;
+  export let value;
+  export let min;
+  export let max;
+
+  $: idValue = id ?? name;
+  $: errorMessageId = `${idValue}-error-message`;
+</script>
+
+<label class="usa-label" for={idValue}>
+  {label}{#if required}<abbr title="required" class="usa-hint usa-hint--required">*</abbr>{/if}
+</label>
+{#if hint}
+  <span class="usa-hint">{hint}</span>
+{/if}
+{#if error}
+  <span id={errorMessageId} class="usa-error-message">{error}</span>
+{/if}
+<input
+  class="usa-select"
+  name={name}
+  id={idValue}
+  type="number"
+  min={min}
+  max={max}
+  {required}
+  bind:value={value}
+/>

--- a/admin-client/src/components/SiteFormBuildTaskType.svelte
+++ b/admin-client/src/components/SiteFormBuildTaskType.svelte
@@ -3,7 +3,7 @@
   import NumberInput from './NumberInput.svelte';
   import SelectInput from './SelectInput.svelte';
 
-  export let buildTaskTypes;
+  export let buildTaskTypes = [];
   export let site;
   export let onSubmit;
   export let onSuccess;

--- a/admin-client/src/components/SiteFormBuildTaskType.svelte
+++ b/admin-client/src/components/SiteFormBuildTaskType.svelte
@@ -1,5 +1,6 @@
 <script>
   import Form from './Form.svelte';
+  import NumberInput from './NumberInput.svelte';
   import SelectInput from './SelectInput.svelte';
 
   export let buildTaskTypes;
@@ -21,13 +22,14 @@
 
   $: value = undefined;
   $: branch = undefined;
+  $: runDay = undefined;
 </script>
 
 <div class="grid-row">
   <div class="grid-col-8 grid-offset-4">
     <Form
       action="Add"
-      onSubmit={() => onSubmit(value, branch)}
+      onSubmit={() => onSubmit(value, branch, runDay)}
       {onSuccess}
       {onFailure}
       let:errors
@@ -39,6 +41,7 @@
           name="build-task-types"
           label='Build Task Types'
           options={options}
+          required
           bind:value={value}
         />
         <SelectInput
@@ -48,7 +51,14 @@
           options={branches}
           bind:value={branch}
         />
-
+        <NumberInput
+          error={errors.isActive}
+          name="runDay"
+          label='Runs On'
+          min={1}
+          max={27}
+          bind:value={runDay}
+        />
       </fieldset>
     </Form>
   </div>

--- a/admin-client/src/components/SiteFormUpdateBuildTaskType.svelte
+++ b/admin-client/src/components/SiteFormUpdateBuildTaskType.svelte
@@ -1,0 +1,54 @@
+<script>
+  import Form from './Form.svelte';
+  import Modal from './Modal.svelte';
+  import NumberInput from './NumberInput.svelte';
+
+  export let branch;
+  export let buildTaskName;
+  export let id;
+  export let initialRunDay;
+  export let runDay;
+  export let closeModal;
+  export let onSubmit;
+  export let onSuccess;
+  export let onFailure;
+</script>
+
+
+{#if buildTaskName && id}
+  <Modal>
+    <div class="display-flex flex-column flex-align-end">
+      <button
+        class="usa-button usa-button--base"
+        on:click|preventDefault={() => closeModal()}
+      >
+        Close
+      </button>
+    </div>
+    <Form
+      action="Edit"
+      disabled={initialRunDay === runDay}
+      onSubmit={() => onSubmit(id, runDay)}
+      {onSuccess}
+      {onFailure}
+      let:errors
+    >
+      <fieldset class="usa-fieldset">
+        <p class="font-sans-lg">
+          Edit the <span class="text-bold">{buildTaskName}</span>
+          running on the
+          <span class="font-code-lg bg-base-lightest padding-x-1">{branch}</span> branch.
+        </p>
+        <NumberInput
+          error={errors.isActive}
+          name="run-day"
+          label="Select day of the month to run report. (Choose a number
+          from 1 to 27)"
+          min={1}
+          max={27}
+          bind:value={runDay}
+        />
+      </fieldset>
+    </Form>
+  </Modal>
+  {/if}

--- a/admin-client/src/components/index.js
+++ b/admin-client/src/components/index.js
@@ -16,7 +16,7 @@ export { default as LabeledItem } from './LabeledItem.svelte';
 export { default as Modal } from './Modal.svelte';
 export { default as Nav } from './Nav.svelte';
 export { default as NavButton } from './NavButton.svelte';
-export { default as NumberInput } from './NumberInput.svelte'
+export { default as NumberInput } from './NumberInput.svelte';
 export { default as PageTitle } from './PageTitle.svelte';
 export { default as PaginatedQueryPage } from './PaginatedQueryPage.svelte';
 export { default as PaginationBanner } from './PaginationBanner.svelte';

--- a/admin-client/src/components/index.js
+++ b/admin-client/src/components/index.js
@@ -16,6 +16,7 @@ export { default as LabeledItem } from './LabeledItem.svelte';
 export { default as Modal } from './Modal.svelte';
 export { default as Nav } from './Nav.svelte';
 export { default as NavButton } from './NavButton.svelte';
+export { default as NumberInput } from './NumberInput.svelte'
 export { default as PageTitle } from './PageTitle.svelte';
 export { default as PaginatedQueryPage } from './PaginatedQueryPage.svelte';
 export { default as PaginationBanner } from './PaginationBanner.svelte';

--- a/admin-client/src/lib/api.js
+++ b/admin-client/src/lib/api.js
@@ -318,12 +318,17 @@ async function addSiteBuildTask(id, params) {
   return post(`/sites/${id}/tasks`, params);
 }
 
+async function updateSiteBuildTask(id, params) {
+  return put(`/site-build-tasks/${id}`, params);
+}
+
 async function removeBuildTask(id) {
   return destroy(`/site-build-tasks/${id}`);
 }
 
 export {
   addSiteBuildTask,
+  updateSiteBuildTask,
   removeBuildTask,
   destroySite,
   fetchMe,

--- a/admin-client/src/pages/Site.svelte
+++ b/admin-client/src/pages/Site.svelte
@@ -78,8 +78,8 @@
     notification.setError(`Site webhook create error: ${error.message}`);
   }
 
-  async function handleSiteBuildTaskSubmit(buildTaskTypeId, branch) {
-    return addSiteBuildTask(id, { buildTaskTypeId, branch });
+  async function handleSiteBuildTaskSubmit(buildTaskTypeId, branch, runDay = null) {
+    return addSiteBuildTask(id, { buildTaskTypeId, branch, runDay });
   }
 
   async function handleSiteBuildTaskSuccess() {

--- a/admin-client/src/pages/Site.svelte
+++ b/admin-client/src/pages/Site.svelte
@@ -12,6 +12,7 @@
     fetchUsers,
     updateSite,
     addSiteBuildTask,
+    updateSiteBuildTask,
     removeBuildTask,
   } from '../lib/api';
   import {
@@ -33,6 +34,7 @@
   import { destroySite } from '../flows';
   import { selectSiteDomains, stateColor } from '../lib/utils';
   import SiteFormBuildTaskType from '../components/SiteFormBuildTaskType.svelte';
+  import SiteFormUpdateBuildTaskType from '../components/SiteFormUpdateBuildTaskType.svelte';
 
   const { id } = $router.params;
   $: sitePromise = fetchSite(id);
@@ -43,6 +45,14 @@
   $: orgsPromise = fetchOrganizations({ limit: 100 });
   $: usersPromise = fetchUsers({ site: id });
   $: uevsPromise = fetchUserEnvironmentVariables({ site: id });
+
+  const initEditedBuildTask = {
+    isEditing: false,
+    initialRunDay: null,
+    data: null,
+  };
+
+  let editedBuildTask = initEditedBuildTask;
 
   async function handleOrganizationSubmit(organizationId) {
     return updateSite(id, { organizationId });
@@ -78,7 +88,11 @@
     notification.setError(`Site webhook create error: ${error.message}`);
   }
 
-  async function handleSiteBuildTaskSubmit(buildTaskTypeId, branch, runDay = null) {
+  async function handleSiteBuildTaskSubmit(
+    buildTaskTypeId,
+    branch,
+    runDay = null
+  ) {
     return addSiteBuildTask(id, { buildTaskTypeId, branch, runDay });
   }
 
@@ -89,6 +103,28 @@
 
   async function handleSiteBuildTaskFailure() {
     notification.setError('Build task update error');
+  }
+
+  async function handleCloseEditSiteBuildTask() {
+    editedBuildTask = initEditedBuildTask;
+  }
+
+  async function handleOpenEditSiteBuildTask(data) {
+    editedBuildTask = {
+      isEditing: true,
+      initialRunDay: data?.metadata?.runDay,
+      data,
+    };
+  }
+
+  async function handleEditSiteBuildTaskSubmit(sbtId, runDay = null) {
+    return updateSiteBuildTask(sbtId, { runDay });
+  }
+
+  async function handleEditSiteBuildTaskSuccess() {
+    sitePromise = fetchSite(id);
+    notification.setSuccess('Build task edited successfully');
+    editedBuildTask = initEditedBuildTask;
   }
 
   async function handleRemoveBuildTask(sbt) {
@@ -166,10 +202,7 @@
         </Await>
       </AccordionContent>
       <AccordionContent title="Domains">
-        <DataTable
-          data={selectSiteDomains(site)}
-          borderless={true}
-        >
+        <DataTable data={selectSiteDomains(site)} borderless={true}>
           <tr slot="header">
             <th>Domain Names</th>
             <th>Context</th>
@@ -236,8 +269,10 @@
             <th>Build Task Type</th>
             <th>Type Id</th>
             <th>Branch</th>
-            <th>Metadata</th>
+            <th>Run Day</th>
+            <th>Rules</th>
             <th>Created At</th>
+            <th>Edit</th>
             <th>Remove</th>
           </tr>
           <tr slot="item" let:item={sbt}>
@@ -245,14 +280,27 @@
             <td>{sbt.BuildTaskType.name}</td>
             <td>{sbt.buildTaskTypeId}</td>
             <td>{sbt.branch}</td>
-            <td>{JSON.stringify(sbt.metadata)}</td>
+            <td>
+              {sbt.metadata?.runDay}
+            </td>
+            <td>{JSON.stringify(sbt.metadata?.rules)}</td>
             <td>{sbt.createdAt}</td>
+            <td>
+              <input
+                class="usa-button"
+                type="button"
+                value="Edit"
+                on:click|preventDefault={() => handleOpenEditSiteBuildTask(sbt)}
+              />
+            </td>
             <td>
               <input
                 class="usa-button usa-button--base"
                 type="reset"
                 value="Remove"
-                on:click|preventDefault={() => handleRemoveBuildTask(sbt)} /></td>
+                on:click|preventDefault={() => handleRemoveBuildTask(sbt)}
+              />
+            </td>
           </tr>
           <p slot="empty">No build tasks registered</p>
         </DataTable>
@@ -271,3 +319,18 @@
     </Accordion>
   </Await>
 </GridContainer>
+
+{#if editedBuildTask.isEditing}
+  <SiteFormUpdateBuildTaskType
+    isEditing={editedBuildTask.site}
+    branch={editedBuildTask.data?.branch}
+    buildTaskName={editedBuildTask?.data?.BuildTaskType?.name}
+    id={editedBuildTask?.data?.id}
+    initialRunDay={editedBuildTask.initialRunDay}
+    runDay={editedBuildTask.data?.metadata?.runDay}
+    closeModal={handleCloseEditSiteBuildTask}
+    onSubmit={handleEditSiteBuildTaskSubmit}
+    onSuccess={handleEditSiteBuildTaskSuccess}
+    onFailure={handleSiteBuildTaskFailure}
+  />
+{/if}

--- a/admin-client/src/pages/Site.svelte
+++ b/admin-client/src/pages/Site.svelte
@@ -91,7 +91,7 @@
   async function handleSiteBuildTaskSubmit(
     buildTaskTypeId,
     branch,
-    runDay = null
+    runDay = null,
   ) {
     return addSiteBuildTask(id, { buildTaskTypeId, branch, runDay });
   }

--- a/api/admin/controllers/task.js
+++ b/api/admin/controllers/task.js
@@ -70,6 +70,17 @@ module.exports = wrapHandlers({
     return res.json({});
   },
 
+  async updateSiteBuildTask(req, res) {
+    const { id } = req.params;
+    const { runDay } = req.body;
+
+    const sbt = await SiteBuildTask.findByPk(id);
+
+    await sbt.update({ metadata: { ...sbt.metadata, runDay } });
+
+    return res.json({});
+  },
+
   async removeSiteBuiltTask(req, res) {
     const { id } = req.params;
 

--- a/api/admin/controllers/task.js
+++ b/api/admin/controllers/task.js
@@ -57,11 +57,14 @@ module.exports = wrapHandlers({
   },
 
   async addSiteBuildTask(req, res) {
+    const { branch, runDay } = req.body;
+    const metadata = runDay ? { runDay } : {};
+
     await SiteBuildTask.create({
       buildTaskTypeId: req.body.buildTaskTypeId,
       siteId: req.params.id,
-      branch: req.body.branch,
-      metadata: {},
+      branch,
+      metadata,
     });
 
     return res.json({});

--- a/api/admin/routers/api.js
+++ b/api/admin/routers/api.js
@@ -56,6 +56,7 @@ apiRouter.post('/sites/:id/tasks', AdminControllers.Task.addSiteBuildTask);
 apiRouter.get('/tasks', AdminControllers.Task.list);
 apiRouter.get('/tasks/types', AdminControllers.Task.listTypes);
 apiRouter.delete('/site-build-tasks/:id', authorize(['pages.admin']), AdminControllers.Task.removeSiteBuiltTask);
+apiRouter.put('/site-build-tasks/:id', AdminControllers.Task.updateSiteBuildTask);
 apiRouter.get('/me', AdminControllers.User.me);
 apiRouter.get('/user-environment-variables', AdminControllers.UserEnvironmentVariable.list);
 apiRouter.get('/users', AdminControllers.User.list);

--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -304,7 +304,7 @@ module.exports = wrapHandlers({
       body,
     } = req;
 
-    const { metadata } = body;
+    const { metadata: { rules } } = body;
 
     // check Site for authorizer's sake
     const site = await Site.findByPk(siteId);
@@ -321,7 +321,9 @@ module.exports = wrapHandlers({
       return res.notFound();
     }
 
-    await siteBuildTask.update({ metadata });
+    const { metadata } = siteBuildTask.dataValues;
+
+    await siteBuildTask.update({ metadata: { ...metadata, rules } });
 
     return res.ok({});
   },

--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -41,7 +41,7 @@ module.exports = wrapHandlers({
     const { user } = req;
 
     const sites = await Site.forUser(user).findAll({
-      include: [Domain, SiteBranchConfig],
+      include: [Domain, SiteBranchConfig, SiteBuildTask],
     });
 
     if (!sites) {

--- a/frontend/components/site/SiteSettings/index.jsx
+++ b/frontend/components/site/SiteSettings/index.jsx
@@ -80,7 +80,9 @@ function SiteSettings() {
       />
 
       <EnvironmentVariables siteId={site.id} />
-      <ReportConfigs siteId={site.id} />
+      {site.SiteBuildTasks.length > 0 && (
+        <ReportConfigs siteId={site.id} />
+      )}
     </div>
   );
 }

--- a/frontend/components/site/siteBuilds.jsx
+++ b/frontend/components/site/siteBuilds.jsx
@@ -30,8 +30,9 @@ function latestBuildByBranch(builds) {
   });
   return maxBuilds;
 }
-function siteHasBuildTasks({ data, isLoading }) {
-  return process.env.FEATURE_BUILD_TASKS === 'active' && !isLoading && data.some(build => build.BuildTasks?.length);
+
+function siteHasBuildTasks(SiteBuildTasks = []) {
+  return SiteBuildTasks.length > 0;
 }
 
 function SiteBuilds() {
@@ -104,7 +105,7 @@ function SiteBuilds() {
                 <tr>
                   <th scope="col">Build</th>
                   <th scope="col">Branch</th>
-                  { siteHasBuildTasks(builds) && (
+                  { siteHasBuildTasks(site.SiteBuildTasks) && (
                     <th scope="col">
                       Reports
                       {' '}
@@ -121,7 +122,7 @@ function SiteBuilds() {
                 {builds.data.map(build => (
                   <SiteBuildsBuild
                     build={build}
-                    showBuildTasks={siteHasBuildTasks(builds)}
+                    showBuildTasks={siteHasBuildTasks(site.SiteBuildTasks)}
                     previewBuilds={previewBuilds}
                     site={site}
                     key={build.id}

--- a/frontend/components/siteContainer.jsx
+++ b/frontend/components/siteContainer.jsx
@@ -132,10 +132,13 @@ export function SiteContainer(props) {
   }
 
   const pageTitle = getPageTitle(location.pathname, buildId);
+  const navConig = SITE_NAVIGATION_CONFIG.filter(navItem => !(
+    navItem.route === 'reports' && site.SiteBuildTasks.length === 0
+  ));
 
   return (
     <div className="usa-grid site">
-      <SideNav siteId={site.id} config={SITE_NAVIGATION_CONFIG} />
+      <SideNav siteId={site.id} config={navConig} />
       <div className="usa-width-five-sixths site-main" id="pages-container" role="main">
 
         <AlertBanner

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@supercharge/promise-pool": "^1.5.0",
     "@uswds/uswds": "^3.8.1",
     "ajv": "^8.12.0",
-    "axios": "^1.3.1",
+    "axios": "^1.7.5",
     "bullmq": "^5.7.0",
     "cfenv": "^1.2.3",
     "connect-flash": "^0.1.1",

--- a/test/frontend/components/site/SiteSettings/SiteSettings.test.jsx
+++ b/test/frontend/components/site/SiteSettings/SiteSettings.test.jsx
@@ -38,6 +38,7 @@ describe('<SiteSettings/>', () => {
           engine: 'jekyll',
           basicAuth: {},
           organizationId: 1,
+          SiteBuildTasks: [],
         },
       ],
     },

--- a/test/frontend/components/siteContainer.test.js
+++ b/test/frontend/components/siteContainer.test.js
@@ -27,6 +27,7 @@ const site = {
   repository: 'test-repo',
   organizationId: 1,
   isActive: true,
+  SiteBuildTasks: [],
 };
 const organization = {
   id: 1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3729,10 +3729,10 @@ axe-core@^4.9.1:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.0.tgz#d9e56ab0147278272739a000880196cdfe113b59"
   integrity sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==
 
-axios@^1.3.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.3.tgz#a1125f2faf702bc8e8f2104ec3a76fab40257d85"
-  integrity sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==
+axios@^1.7.5:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.5.tgz#21eed340eb5daf47d29b6e002424b3e88c8c54b1"
+  integrity sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"


### PR DESCRIPTION
Closes https://github.com/cloud-gov/pages-core/issues/4581

## Changes proposed in this pull request:
- Admin adds the ability to add a site build tasks recurring `runDay`
- Admin adds the ability to edit a site build tasks `runDay`
- Adds logic to only show site report links and actions on sites that have reports enabled
- Fixes site build tasks update API to only update a site build tasks metadata field's `rules` JSON key
- Updates dependency axios to v1.7.5

## security considerations
None
