### PR TITLE
chore: swap experiment icon for report icon in report button

### DIFF
--- a/frontend/components/site/siteBuildsBuild.jsx
+++ b/frontend/components/site/siteBuildsBuild.jsx
@@ -23,7 +23,7 @@ import {
   IconSpinner,
   IconX,
   IconRebuild,
-  IconExperiment,
+  IconReport,
 } from '../icons';
 
 function BuildLogsLink({ buildId, siteId }) {
@@ -212,7 +212,7 @@ export const SiteBuildsBuild = ({
                 </>
               ) : (
                 <>
-                  <IconExperiment />
+                  <IconReport />
                   Get report
                 </>
               )}


### PR DESCRIPTION
## Changes proposed in this pull request:
Changes button to use Reports icon instead of Experiment beaker icon

## security considerations
None - swaps SVG only
