### PR TITLE
Update rule suppression language

### DIFF
--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -262,17 +262,21 @@ function truncateString(s, characters = 30) {
 
 const DEFAULT_BUILD_TASK_PARAMS = '-p \'{ "STATUS_CALLBACK": "{{job.data.STATUS_CALLBACK}}", "TASK_ID": {{job.data.TASK_ID}}, "AWS_DEFAULT_REGION": "{{job.data.AWS_DEFAULT_REGION}}", "AWS_ACCESS_KEY_ID": "{{job.data.AWS_ACCESS_KEY_ID}}", "AWS_SECRET_ACCESS_KEY": "{{job.data.AWS_SECRET_ACCESS_KEY}}", "BUCKET": "{{job.data.BUCKET}}" }\'';
 
+const ZAP_SCAN_RULES = [
+  { id: '10038' },
+  { id: '10045' },
+  { id: '10063' },
+  { id: '10098' },
+  { id: '10099' },
+  { id: '90004' },
+  { id: '10017', match: ['https://dap.digitalgov.gov/', 'https://search.usa.gov/'] },
+  { id: '10202', match: ['search_form'] },
+  { id: '10097', match: ['/assets/styles'] },
+  { id: '90003', match: ['https://dap.digital.gov/'] },
+];
+
 const DEFAULT_SCAN_RULES = {
-  'owasp-zap': [
-    { id: '10038', source: 'Pages' },
-    { id: '10045', source: 'Pages' },
-    { id: '10063', source: 'Pages' },
-    { id: '10098', source: 'Pages' },
-    { id: '10099', source: 'Pages' },
-    { id: '90004', source: 'Pages' },
-    { id: '10202', match: ['search_form'], source: 'Pages' },
-    { id: '10097', match: ['/assets/styles'], source: 'Pages' },
-  ],
+  'owasp-zap': ZAP_SCAN_RULES.map(rule => ({ ...rule, source: 'Pages' })),
   a11y: [],
 };
 

--- a/frontend/components/Reports/ScanFinding.jsx
+++ b/frontend/components/Reports/ScanFinding.jsx
@@ -151,7 +151,7 @@ const FindingDescription = ({
     {ignore && (
       <div className="usa-prose font-serif-xs">
         <p className="text-italic">
-          {`(Note: This finding has been suppressed by ${ignoreSource || 'an existing report configuration'}. This is common for results that have been previously identified as a false positive. You can review the report rules and criteria that are suppressed during report generation in your `}
+          {`(Note: This finding has been suppressed by ${ignoreSource || 'an existing report configuration'}. You can review the report rules and criteria that are suppressed during report generation in your `}
           <Link reloadDocument to={`/sites/${siteId}/settings`} className="usa-link">Site Settings Report Configuration</Link>
           {'.) '}
         </p>

--- a/frontend/components/Reports/about.jsx
+++ b/frontend/components/Reports/about.jsx
@@ -14,9 +14,9 @@ export default function About({ scanType, siteId, children }) {
         <h3>Suppressed results</h3>
         <p>
           Pages may automatically suppress certain results
-          which are irrelevant for statically hosted websites or frequently produce “false
-          positives” for our customers.  While still visible in the report, the suppressed
-          results don’t count towards your total issue count. Customers can specify additional
+          which are irrelevant for statically hosted websites, based on unconfigurable server settings,
+          or frequently produce “false positives” for our customers.  While still visible in the report,
+          the suppressed results don’t count towards your total issue count. Customers can specify additional
           criteria to be suppressed in future reports for this site in your Pages
           {' '}
           <Link reloadDocument to={`/sites/${siteId}/settings`} className="usa-link">Site Settings</Link>

--- a/frontend/components/site/SiteSettings/ReportConfigs.jsx
+++ b/frontend/components/site/SiteSettings/ReportConfigs.jsx
@@ -173,10 +173,10 @@ function ReportConfigs({ siteId: id }) {
           {sbt.name}
           {' '}
           produced by cloud.gov Pages will automatically suppress certain findings
-          which are irrelevant for statically hosted websites or frequently produce ‘false
-          positive’ findings for our customers. You can specify additional findings to be
-          suppressed for this site by adding the rule and any matching criteria to the ignore
-          list below.
+          which are irrelevant for statically hosted websites, based on unconfigurable
+          server settings, or frequently produce ‘false positive’ findings for our customers.
+          You can specify additional findings to be suppressed for this site by adding the rule
+          and any matching criteria to the ignore list below.
           {' '}
           <b>
             While still visible in the report, the suppressed findings don’t count towards your
@@ -250,7 +250,7 @@ function ReportConfigs({ siteId: id }) {
             >
               documentation
             </a>
-            . If you’d like to suggest a rule to be suppressed due to “false positives”,
+            . If you’d like to suggest a rule to be suppressed for all sites,
             {' '}
             <a href="mailto:pages-support@cloud.gov" target="_blank" rel="noopener noreferrer" title="Email Pages Support at pages-support@cloud.gov">let us know</a>
             .


### PR DESCRIPTION
## Changes proposed in this pull request:
- This broadens the suppression language to indicate that these aren't all false positives
- As an example, adding a search.gov input will create a finding for lack of CSRF tokens. There isn't really risk associated with this (it's not a form submission) but the finding itself is valid even if the implementation is required. 
- Another example is CSP Headers: these aren't able to be set by end users, so a ZAP scan will flag this as a vulnerability. Users have no control over this particular setting but can gain CSP protection by adding `meta` tags with CSP rules.

## security considerations
Noted above
