### PR TITLE
Release 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.11.1 (2024-09-09)
+
+### Fixed
+
+- Site builds polling to use doc visibilityState #4591
+- use serialized site reponse to fix build preview link
+- restore the ability to rebuild failed latest branches
+
 ## 0.11.0 (2024-09-04)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pages-core",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "",
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
## :robot: This is an automated release PR

chore: release 0.11.1
tag to create: 0.11.1
increment detected: PATCH

## 0.11.1 (2024-09-09)

### Fixed

- Site builds polling to use doc visibilityState #4591
- use serialized site reponse to fix build preview link
- restore the ability to rebuild failed latest branches
## security considerations
Noted in individual PRs
