### PR TITLE
Fix build preview link

### DIFF
--- a/frontend/components/site/siteBuildsBuild.jsx
+++ b/frontend/components/site/siteBuildsBuild.jsx
@@ -234,7 +234,7 @@ export const SiteBuildsBuild = ({
           <p className="site-link">
             <BranchViewLink
               branchName={build.branch}
-              site={build.site}
+              site={site}
               showIcon
               completedAt={build.completedAt}
             />


### PR DESCRIPTION
## Changes proposed in this pull request:
- The site serializer returns some lowercase models (e.g. `Domain` -> `domain`) and this serialization is not repeated on the build serializer.
- On the build history page, send `site` rather than `build.site` to the `BranchViewLink` so it can correctly capture the domain information

## Todo
- Ponder how to deduplicate this logic (as well as https://github.com/cloud-gov/pages-core/issues/4323)

## security considerations
None