### PR TITLE
fix: Site builds polling to use doc visibilityState #4591

### DIFF
--- a/frontend/components/site/siteBuilds.jsx
+++ b/frontend/components/site/siteBuilds.jsx
@@ -51,7 +51,7 @@ function SiteBuilds() {
     buildActions.fetchBuilds({ id });
 
     const intervalHandle = setInterval(() => {
-      if (document.hasFocus()) {
+      if (document.visibilityState === 'visible') {
         buildActions.refetchBuilds({ id });
       }
     }, REFRESH_INTERVAL);


### PR DESCRIPTION
Closes #4591 

## Changes proposed in this pull request:
- Fixes site builds data auto update to use the document `visibilityState` to not poll the API when a user navigates to another browser tab or window.

## security considerations
None