### PR TITLE
Chore asr punchlist

### DIFF
--- a/frontend/components/Reports/A11yScanChildLayout.jsx
+++ b/frontend/components/Reports/A11yScanChildLayout.jsx
@@ -82,7 +82,7 @@ export default function A11yScanChild({ data, siteId, buildId }) {
         <div className="tablet:grid-col tablet:margin-left-4">
           <div className="margin-bottom-2 margin-top-4">
             <section
-              className={`usa-alert usa-alert--${unsuppressed.length > 0 ? 'error' : 'success'}`}
+              className={`usa-alert usa-alert--${unsuppressed.length > 0 ? 'warning' : 'success'}`}
             >
               <div className="usa-alert__body">
                 <p className="usa-alert__text">

--- a/frontend/components/Reports/A11yScanChildLayout.jsx
+++ b/frontend/components/Reports/A11yScanChildLayout.jsx
@@ -53,7 +53,15 @@ export default function A11yScanChild({ data, siteId, buildId }) {
           Accessibility report for
           {' '}
           <br />
-          <span className="font-code-lg text-normal text-primary-darker bg-accent-cool-lighter padding-x-05r narrow-mono">{data.url}</span>
+          <span className="font-code-lg text-normal text-primary-darker bg-accent-cool-lighter padding-x-05r narrow-mono break-anywhere">{data.url}</span>
+          <span className="font-sans-lg text-normal margin-left-1">
+            <a className="usa-link font-body-xs text-no-wrap margin-x-2" target="_blank" aria-label="open scanned page in a new window," title="open scanned page in a new window" href={data.url} rel="noreferrer">
+              open page
+              <svg className="usa-icon text-ttop" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+                <path fill="currentColor" d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z" />
+              </svg>
+            </a>
+          </span>
         </h1>
         <span className="grid-col-auto inline-block margin-y-4">
           <a id="pages-logo" href="https://cloud.gov/pages" target="_blank" title="link to Pages homepage" rel="noreferrer">

--- a/frontend/components/Reports/A11yScanChildLayout.jsx
+++ b/frontend/components/Reports/A11yScanChildLayout.jsx
@@ -170,16 +170,20 @@ const A11yPassed = ({ passes = [] }) => (
       <table className="usa-table usa-table--striped usa-table--compact usa-table--borderless font-body-xs width-full">
         <thead>
           <tr>
-            <th>Description</th>
-            <th className="text-right">Places found</th>
+            <th scope="col">Description</th>
+            <th scope="col">Criteria</th>
+            <th scope="col" className="text-right">Places found</th>
           </tr>
         </thead>
         <tbody>
           {passes.map(check => (
             <tr key={check.help}>
-              <td>
+              <th scope="row">
                 {check.help}
                 .
+              </th>
+              <td className="font-body-xs">
+                {utils.getSuccessCriteria(check).map(c => c.short).join(', ')}
               </td>
               <td className="font-mono-sm text-tabular text-right">{check.nodes.length}</td>
             </tr>

--- a/frontend/components/Reports/A11yScanChildLayout.jsx
+++ b/frontend/components/Reports/A11yScanChildLayout.jsx
@@ -123,7 +123,7 @@ export default function A11yScanChild({ data, siteId, buildId }) {
             <A11yPassed passes={data.passes} />
             <hr />
             <About scanType="a11y" siteId={siteId}>
-              <p className="font-body-xs line-height-body-3">
+              <p className="font-body-xs line-height-sans-3">
                 This report was generated for
                 {' '}
                 <code className="narrow-mono font-mono-2xs bg-accent-cool-lighter">{data.url}</code>

--- a/frontend/components/Reports/A11yScanIndexLayout.jsx
+++ b/frontend/components/Reports/A11yScanIndexLayout.jsx
@@ -53,7 +53,7 @@ export default function A11yScanIndex({ data, siteId, buildId }) {
       <div className="grid-row">
         <div className="grid-col border-top-1px">
           <section
-            className={`margin-top-4 usa-alert usa-alert--${unsuppressed.length > 0 ? 'error' : 'success'}`}
+            className={`margin-top-4 usa-alert usa-alert--${unsuppressed.length > 0 ? 'warning' : 'success'}`}
           >
             <div className="usa-alert__body">
               <p className="usa-alert__text">
@@ -63,10 +63,14 @@ export default function A11yScanIndex({ data, siteId, buildId }) {
                     ${unsuppressed.length} ${utils.plural(unsuppressed.length, 'unsuppressed result')}
                   `}
                 </b>
-                and
-                <b>
-                  {` ${suppressed.length} ${utils.plural(suppressed.length, 'suppressed or informational result')} `}
-                </b>
+                {suppressed.length > 0 && (
+                  <>
+                    and
+                    <b>
+                      {` ${suppressed.length} ${utils.plural(suppressed.length, 'suppressed or informational result')} `}
+                    </b>
+                  </>
+                )}
                 for this site.  View each page report below for specific details.
               </p>
             </div>
@@ -98,7 +102,7 @@ export default function A11yScanIndex({ data, siteId, buildId }) {
       <div className="grid-row">
         <div className="grid-col">
           <h2 className="font-heading-xl grid-col padding-right-2 margin-bottom-0 margin-top-1">
-            All reports
+            All pages
             {' '}
             <span className="font-body-lg text-accent-cool-darker">
               (

--- a/frontend/components/Reports/A11yScanIndexLayout.jsx
+++ b/frontend/components/Reports/A11yScanIndexLayout.jsx
@@ -38,7 +38,7 @@ export default function A11yScanIndex({ data, siteId, buildId }) {
           Accessibility reports for
           {' '}
           <br />
-          <span className="font-code-lg text-normal text-primary-darker bg-accent-cool-lighter padding-x-05r narrow-mono">
+          <span className="font-code-lg text-normal text-primary-darker bg-accent-cool-lighter padding-x-05r narrow-mono break-anywhere">
             {data.baseurl}
             {' '}
           </span>

--- a/frontend/components/Reports/ScanFinding.jsx
+++ b/frontend/components/Reports/ScanFinding.jsx
@@ -178,6 +178,14 @@ const FindingDescription = ({
                 <Link reloadDocument to={`/sites/${siteId}/settings`} className="usa-link">Site Settings Report Configuration</Link>
                 .
               </p>
+              <p>
+                For a full list of what Pages excludes from your results, review the
+                {' '}
+                <Link to="https://cloud.gov/pages/documentation/automated-site-reports/" className="usa-link">
+                  Automated Site Reports documentation
+                </Link>
+                .
+              </p>
             </details>
           </div>
         </div>

--- a/frontend/components/Reports/ScanFinding.jsx
+++ b/frontend/components/Reports/ScanFinding.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Highlight from 'react-highlight';
 import { Link, useLocation } from 'react-router-dom';
 
-import { plural } from '../../util/reports';
+import { plural, getSuccessCriteria } from '../../util/reports';
 
 const ScanFinding = ({
   finding, groupColor, groupLabel, scanType = 'zap', siteId,
@@ -18,6 +18,7 @@ const ScanFinding = ({
   let solution = '';
   let references = [];
   let locations = [];
+  let criteria = [];
 
   if (scanType === 'zap') {
     ({
@@ -38,7 +39,8 @@ const ScanFinding = ({
     description = `${finding.description}.`;
     locations = finding.nodes || [];
     solution = finding.nodes[0]?.failureSummary || [];
-    references = [finding.helpUrl];
+    criteria = getSuccessCriteria(finding);
+    references = [finding.helpUrl, ...criteria.map(c => c.url)];
   }
 
   useEffect(() => {
@@ -61,6 +63,7 @@ const ScanFinding = ({
         references={references}
         scanType={scanType}
         anchor={anchor}
+        criteria={criteria.map(c => c.short)}
       />
       <div className="maxw-tablet-lg">
         <FindingDescription
@@ -93,21 +96,30 @@ const FindingTitle = ({
   groupLabel,
   groupColor,
   count,
-  references = [],
+  criteria = [],
   scanType,
   anchor,
 }) => (
   <div className="bg-white padding-top-05 sticky">
-    <h3 className="font-heading-lg margin-y-105">
+    <h3 className="font-heading-lg margin-y-105 break-balance line-height-serif-3">
       {title}
       <a href={`#${anchor}`} className="usa-link target-highlight anchor-indicator">#</a>
     </h3>
-    <p className="font-body-md padding-bottom-2 border-bottom-2px line-height-body-2">
+    <p className="font-body-md padding-bottom-2 border-bottom-2px line-height-sans-4 break-balance">
       <span className={`usa-tag bg-${groupColor} radius-pill`}>
         {groupLabel}
       </span>
       {' '}
-      finding identified in
+      finding
+      {' '}
+      {scanType === 'a11y' && criteria.length > 0 && (
+        <>
+          that violates&nbsp;
+          <b>{ new Intl.ListFormat('en-US').format(criteria)}</b>
+        </>
+      )}
+      {' '}
+      was identified in
       {' '}
       <b>
         {count}
@@ -115,15 +127,6 @@ const FindingTitle = ({
         {plural(count, 'place')}
       </b>
       {'. '}
-      {scanType === 'a11y' && references.length > 0 && (
-      <a href={references[0]} target="_blank" className="usa-link font-body-sm" aria-label="Learn more about this rule" rel="noreferrer">
-        Learn more
-        {' '}
-        <svg className="usa-icon" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
-          <path fill="currentColor" d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z" />
-        </svg>
-      </a>
-      )}
     </p>
   </div>
 );
@@ -134,7 +137,7 @@ FindingTitle.propTypes = {
   groupColor: PropTypes.string.isRequired,
   count: PropTypes.number,
   // eslint-disable-next-line react/forbid-prop-types
-  references: PropTypes.array,
+  criteria: PropTypes.array,
   scanType: PropTypes.string.isRequired,
   anchor: PropTypes.string.isRequired,
 
@@ -250,7 +253,7 @@ FindingReferences.propTypes = {
 
 const FindingReference = ({ url }) => (
   <li className="font-body-2xs">
-    <a className="usa-link" href={url}>{url}</a>
+    <a target="_blank" rel="noreferrer" className="usa-link" href={url}>{url}</a>
   </li>
 );
 

--- a/frontend/components/Reports/ScanFindingsSummary.jsx
+++ b/frontend/components/Reports/ScanFindingsSummary.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/forbid-prop-types */
 import React from 'react';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { relPath, plural } from '../../util/reports';
 import ScanPagePathAndReportLink from './ScanPagePathReportLink';
@@ -22,7 +23,7 @@ function ScanFindingsSummaryTable({
         </tr>
       </thead>
       <tbody>
-        {findings.map(finding => (
+        {findings.map((finding, fi) => (
           <tr key={finding.alertRef || finding.id}>
             <td data-label="Severity Risk level" className="font-body-xs text-no-wrap">
               <b className="usa-sr-only">
@@ -39,7 +40,7 @@ function ScanFindingsSummaryTable({
                 <br />
               </b>
               {!finding.anchor && (
-                <details>
+                <details open={(fi === 0)}>
                   <summary>
                     <b>{finding.name}</b>
                     {' on '}
@@ -48,7 +49,7 @@ function ScanFindingsSummaryTable({
                   </summary>
                   <ol className="font-mono-3xs">
                     {finding.urls?.map((url, i) => (
-                      <li key={url} className="margin-bottom-1">
+                      <li key={url} className="margin-bottom-1 report-item">
                         <ScanPagePathAndReportLink
                           pagePath={relPath(url, baseurl)}
                           reportLink={`${finding.reports[i]}#finding-${finding.id}`}
@@ -94,17 +95,59 @@ ScanFindingsSummaryTable.propTypes = {
 
 const ScanFindingsSummary = ({ suppressedFindings = [], unsuppressedFindings = [], baseurl }) => (
   <>
-    <h3>⚠️ Unsuppressed results</h3>
-    <ScanFindingsSummaryTable
-      baseurl={baseurl}
-      findings={unsuppressedFindings}
-    />
-    <h3>🔕  Suppressed or informational results</h3>
-    <ScanFindingsSummaryTable
-      baseurl={baseurl}
-      findings={suppressedFindings}
-      hasSuppressColumn
-    />
+    {unsuppressedFindings.length > 0 && (
+      <>
+        <h3 className="font-heading-lg margin-bottom-1 padding-top-2 margin-y-2">
+          ⚠️ Unsuppressed results
+          <span className="font-body-lg padding-left-1 text-secondary-vivid">
+            (
+            {unsuppressedFindings.length}
+            )
+          </span>
+        </h3>
+        <ScanFindingsSummaryTable
+          baseurl={baseurl}
+          findings={unsuppressedFindings}
+        />
+      </>
+    )}
+    {suppressedFindings.length > 0 && (
+      <>
+        <h3 className="font-heading-lg margin-bottom-1 padding-top-2 margin-y-2">
+          🔕  Suppressed or informational results
+          <span className="font-body-lg padding-left-1 text-accent-cool-darker">
+            (
+            {suppressedFindings.length}
+            )
+          </span>
+        </h3>
+        <section className="usa-alert usa-alert--info margin-top-3">
+          <div className="usa-alert__body">
+            <p className="usa-alert__text">
+              <b>
+                This report contains
+                {' '}
+                <a className="usa-link" href="#about-suppressed">
+                  suppressed results
+                </a>
+              </b>
+              , which don’t count towards your total issues.
+              For more information about excluded results and suppression rules, review the
+              {' '}
+              <Link to="https://cloud.gov/pages/documentation/automated-site-reports/" className="usa-link">
+                Automated Site Reports documentation
+              </Link>
+              .
+            </p>
+          </div>
+        </section>
+        <ScanFindingsSummaryTable
+          baseurl={baseurl}
+          findings={suppressedFindings}
+          hasSuppressColumn
+        />
+      </>
+    )}
   </>
 );
 

--- a/frontend/components/Reports/ScanFindingsSummary.jsx
+++ b/frontend/components/Reports/ScanFindingsSummary.jsx
@@ -94,7 +94,7 @@ ScanFindingsSummaryTable.propTypes = {
 
 const ScanFindingsSummary = ({ suppressedFindings = [], unsuppressedFindings = [], baseurl }) => (
   <>
-    <h3>⚠️ Unsuppressed Results</h3>
+    <h3>⚠️ Unsuppressed results</h3>
     <ScanFindingsSummaryTable
       baseurl={baseurl}
       findings={unsuppressedFindings}

--- a/frontend/components/Reports/ScanPagePathReportLink.jsx
+++ b/frontend/components/Reports/ScanPagePathReportLink.jsx
@@ -6,18 +6,18 @@ const ScanPagePathAndReportLink = ({ pagePath, pageURL = false, reportLink }) =>
   <div className="grid-row flex-align-center">
     <span className="grid-col-12 tablet:grid-col-fill font-mono-2xs margin-right-1 break-anywhere">
       {pagePath}
-    </span>
 
-    {pageURL && (
-      <span className="grid-col-12 tablet:grid-col-auto flex-align-self-start">
-        <a className="usa-link font-body-3xs text-no-wrap margin-x-2" target="_blank" aria-label="open scanned page in a new window," title="open scanned page in a new window" href={pageURL} rel="noreferrer">
-          open page
-          <svg className="usa-icon text-ttop" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
-            <path fill="currentColor" d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z" />
-          </svg>
-        </a>
-      </span>
-    )}
+      {pageURL && (
+        <span className="grid-col-12 tablet:grid-col-auto flex-align-self-start">
+          <a className="usa-link font-body-3xs text-no-wrap margin-x-2" target="_blank" aria-label="open scanned page in a new window," title="open scanned page in a new window" href={pageURL} rel="noreferrer">
+            open page
+            <svg className="usa-icon text-ttop" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+              <path fill="currentColor" d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z" />
+            </svg>
+          </a>
+        </span>
+      )}
+    </span>
     <span className="grid-col-12 tablet:grid-col-auto flex-align-self-start margin-y-1 tablet:margin-y-0">
       <Link className="usa-link font-body-2xs text-bold text-no-wrap" to={reportLink} path="relative" title={`Full results for ${pagePath}`}>
         View report

--- a/frontend/components/Reports/ScanPagePathReportLink.jsx
+++ b/frontend/components/Reports/ScanPagePathReportLink.jsx
@@ -4,13 +4,13 @@ import PropTypes from 'prop-types';
 
 const ScanPagePathAndReportLink = ({ pagePath, pageURL = false, reportLink }) => (
   <div className="grid-row flex-align-center">
-    <span className="grid-col-12 tablet:grid-col-auto font-mono-2xs margin-right-1">
+    <span className="grid-col-12 tablet:grid-col-fill font-mono-2xs margin-right-1 break-anywhere">
       {pagePath}
     </span>
 
     {pageURL && (
-      <span className="grid-col-12 tablet:grid-col-fill">
-        <a className="usa-link font-body-3xs text-no-wrap margin-right-1" target="_blank" aria-label="open scanned page in a new window," title="open scanned page in a new window" href={pageURL} rel="noreferrer">
+      <span className="grid-col-12 tablet:grid-col-auto flex-align-self-start">
+        <a className="usa-link font-body-3xs text-no-wrap margin-x-2" target="_blank" aria-label="open scanned page in a new window," title="open scanned page in a new window" href={pageURL} rel="noreferrer">
           open page
           <svg className="usa-icon text-ttop" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
             <path fill="currentColor" d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z" />
@@ -18,7 +18,7 @@ const ScanPagePathAndReportLink = ({ pagePath, pageURL = false, reportLink }) =>
         </a>
       </span>
     )}
-    <span className="grid-col-12 tablet:grid-col-auto flex-align-self-end margin-y-1 tablet:margin-y-0">
+    <span className="grid-col-12 tablet:grid-col-auto flex-align-self-start margin-y-1 tablet:margin-y-0">
       <Link className="usa-link font-body-2xs text-bold text-no-wrap" to={reportLink} path="relative" title={`Full results for ${pagePath}`}>
         View report
       </Link>

--- a/frontend/components/Reports/Zap.jsx
+++ b/frontend/components/Reports/Zap.jsx
@@ -86,9 +86,10 @@ export default function Zap({ data, buildId, siteId }) {
           />
         </section>
         <div className="tablet:grid-col tablet:margin-left-4">
-          <div className="margin-top-4">
+          <h2 className="usa-sr-only">Summary of results</h2>
+          <div className="margin-y-4">
             <section
-              className={`usa-alert usa-alert--${unsuppressed.length > 0 ? 'error' : 'success'}`}
+              className={`usa-alert usa-alert--${unsuppressed.length > 0 ? 'warning' : 'success'} margin-bottom-3`}
             >
               <div className="usa-alert__body">
                 <p className="usa-alert__text">

--- a/frontend/components/Reports/Zap.jsx
+++ b/frontend/components/Reports/Zap.jsx
@@ -55,7 +55,7 @@ export default function Zap({ data, buildId, siteId }) {
           {scanTitle}
           {' report for '}
           <br />
-          <span className="font-code-lg text-normal text-primary-darker bg-accent-cool-lighter padding-x-05r narrow-mono">
+          <span className="font-code-lg text-normal text-primary-darker bg-accent-cool-lighter padding-x-05r narrow-mono break-anywhere">
             {data.site['@name']}
           </span>
           <span className="text-italic font-sans-lg text-normal margin-left-2">(all pages)</span>

--- a/frontend/components/Reports/about.jsx
+++ b/frontend/components/Reports/about.jsx
@@ -11,7 +11,7 @@ export default function About({ scanType, siteId, children }) {
       </h2>
       <div className="font-body-md line-height-body-5">
         { scanType === 'zap' ? <ZapAbout /> : <A11yAbout /> }
-        <h3>Suppressed results</h3>
+        <h3 id="about-suppressed">Suppressed results</h3>
         <p>
           Pages may automatically suppress certain results
           which are irrelevant for statically hosted websites, based on unconfigurable server settings,
@@ -20,6 +20,14 @@ export default function About({ scanType, siteId, children }) {
           criteria to be suppressed in future reports for this site in your Pages
           {' '}
           <Link reloadDocument to={`/sites/${siteId}/settings`} className="usa-link">Site Settings</Link>
+          .
+        </p>
+        <p>
+          For a full list of what Pages excludes from your results, review the
+          {' '}
+          <Link to="https://cloud.gov/pages/documentation/automated-site-reports/" className="usa-link">
+            Automated Site Reports documentation
+          </Link>
           .
         </p>
         <hr />

--- a/frontend/components/site/SiteReports.jsx
+++ b/frontend/components/site/SiteReports.jsx
@@ -20,6 +20,8 @@ import { currentSite } from '../../selectors/site';
 import { getOrgById } from '../../selectors/organization';
 import ReportResultsSummary from '../ReportResultsSummary';
 import FilterIndicator from '../FilterIndicator';
+import ExpandableArea from '../ExpandableArea';
+import { IconX } from '../icons';
 
 const {
   setDate, isBefore, startOfToday, addMonths,
@@ -70,46 +72,13 @@ function SiteReports() {
             <div>
               <p>
                 {/* eslint-disable-next-line max-len */}
-                Pages is now offering automated monthly quality reports for customer production sites. These reports examine your Pages site for common website issues and provide guidance and resources for remediation. Pages Reports are part of a larger effort to help our customers comply with OMB Memo 23-22 and ATO requirements.
-              </p>
-              { siteBuildTasks.length > 0 && !buildIdToFilterBy && (
-                <table id="scheduled" className="usa-table table-full-width usa-table-borderless site-reports-table">
-                  <thead>
-                    <tr>
-                      <th scope="col">Report</th>
-                      <th scope="col" className="nowrap">Next report on</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    { siteBuildTasks.map(task => (
-                      <tr key={task.id}>
-                        <th scope="row">
-                          <h3>{task.name}</h3>
-                          <p>
-                            {`${task.description} For more information, refer to the `}
-                            <Link to={task.url}>documentation</Link>
-                            .
-                          </p>
-                        </th>
-                        <td>
-                          {dateOnly(nextScanDate(task))}
-                          {' on '}
-                          <b>{branchToBeScanned}</b>
-                        </td>
-                      </tr>
-                    ))}
-
-                  </tbody>
-                </table>
-              )}
-              <p>
-                You can request an immediate report for any recent site branch from
+                Pages is now offering monthly Automated Site Reports, which examine your Pages site for common website issues and provide guidance and resources for remediation. You can request an immediate report for any recent site branch from
                 {' '}
                 <Link to={`/sites/${id}/builds`}>Build history</Link>
                 . You can also customize your report results in
                 {' '}
                 <Link to={`/sites/${id}/settings`}>Site settings</Link>
-                . For more information on Pages Reports, check out the
+                . For more information on Pages Automated Site Reports, check out the
                 {' '}
                 <a
                   target="_blank"
@@ -121,13 +90,54 @@ function SiteReports() {
                 </a>
                 .
               </p>
+              { siteBuildTasks.length > 0 && (
+                <>
+                  <h3>
+                    Available report types (
+                    {siteBuildTasks.length}
+                    )
+                  </h3>
+                  { siteBuildTasks.map(task => (
+                    <ExpandableArea
+                      bordered
+                      title={task.name}
+                      key={task.id}
+                    >
+                      <div className="well">
+                        <p>
+                          Next scheduled for&nbsp;
+                          <b>{dateOnly(nextScanDate(task))}</b>
+                          &nbsp;on&nbsp;
+                          <b>{branchToBeScanned}</b>
+                        </p>
+                        <p>
+                          {`${task.description} For more information, refer to the `}
+                          <Link to={task.url}>documentation</Link>
+                          .
+                        </p>
+                      </div>
+                    </ExpandableArea>
+                  ))}
+                </>
+              )}
+
             </div>
+            <br />
+            <h3>
+              Generated reports (
+              {scans.length}
+              )
+            </h3>
             <FilterIndicator criteria={buildIdToFilterBy ? `build #${buildIdToFilterBy}` : null} count={filteredScans.length} noun="report">
               <>
                 {' '}
-                <a href="#list" role="button" tabIndex="0" className="usa-link" onClick={clearParams}>Clear filters</a>
+                <a href="#list" role="button" tabIndex="0" className="usa-link" onClick={clearParams}>
+                  Show all reports
+                  <span className="filter-close-button" title="close filter">
+                    <IconX />
+                  </span>
+                </a>
                 {' '}
-                to show all reports.
               </>
             </FilterIndicator>
             <div className="table-container">

--- a/frontend/components/site/SiteSettings/ReportConfigs.jsx
+++ b/frontend/components/site/SiteSettings/ReportConfigs.jsx
@@ -110,7 +110,7 @@ function ReportConfigs({ siteId: id }) {
     const isPagesRule = rule?.source === 'Pages';
     const customPlaceholder = '/assets class="ignore"';
     function pagesPlaceholder() {
-      if (rule.match) {
+      if (rule.match && Array.isArray(rule.match)) {
         return rule.match.map(match => (
           <code className="pages-suppressed-string" key="match">
             {match}

--- a/frontend/components/site/SiteSettings/ReportConfigs.jsx
+++ b/frontend/components/site/SiteSettings/ReportConfigs.jsx
@@ -108,7 +108,17 @@ function ReportConfigs({ siteId: id }) {
 
   function ruleRender(rule) {
     const isPagesRule = rule?.source === 'Pages';
-    const placeholder = (rule.match?.join(', ') || '') + (isPagesRule ? ' (not editable - suppressed by Pages)' : '/assets class="ignore"');
+    const customPlaceholder = '/assets class="ignore"';
+    function pagesPlaceholder() {
+      if (rule.match) {
+        return rule.match.map(match => (
+          <code className="pages-suppressed-string" key="match">
+            {match}
+          </code>
+        ));
+      }
+      return 'Pages suppresses all results for this rule';
+    }
     return (
       (
         <tr key={rule.id} aria-labelledby={`rule-${rule.id}`} className={`rule-source--${rule.source}`}>
@@ -141,42 +151,45 @@ function ReportConfigs({ siteId: id }) {
               )}
 
           </td>
-          <td>
-            { /* eslint-disable-next-line jsx-a11y/label-has-associated-control */ }
-            <label className="usa-sr-only" htmlFor={`${rule.id}-criteria`}>Criteria to match:</label>
-            <input
-              id={`${rule.id}-criteria`}
-              type="text"
-              placeholder={placeholder}
-              disabled={isPagesRule}
-              onChange={event => updateRule(event, rule.id, 'match')}
-              value={isPagesRule ? '' : rule.match?.join(', ')}
-            />
-          </td>
-          <td>
-            { /* eslint-disable-next-line jsx-a11y/label-has-associated-control */ }
-            <label className="usa-sr-only" htmlFor={`${rule.id}-delete`}>Delete this rule</label>
-            <button id={`${rule.id}-delete`} className="button-delete" disabled={isPagesRule} aria-label={isPagesRule ? 'Cannot delete this rule' : 'Delete this rule'} type="button" onClick={() => deleteRule(rule)}>
-              <IconTrash className="icon-delete" aria-hidden />
-            </button>
-          </td>
+          {!isPagesRule && (
+            <>
+              <td>
+                { /* eslint-disable-next-line jsx-a11y/label-has-associated-control */ }
+                <label className="usa-sr-only" htmlFor={`${rule.id}-criteria`}>Criteria to match:</label>
+                <input
+                  id={`${rule.id}-criteria`}
+                  type="text"
+                  placeholder={customPlaceholder}
+                  disabled={isPagesRule}
+                  onChange={event => updateRule(event, rule.id, 'match')}
+                  value={isPagesRule ? '' : rule.match?.join(', ')}
+                />
+              </td>
+              <td className="has-button">
+                { /* eslint-disable-next-line jsx-a11y/label-has-associated-control */ }
+                <label className="usa-sr-only" htmlFor={`${rule.id}-delete`}>Delete this rule</label>
+                <button id={`${rule.id}-delete`} className="button-delete" aria-label={isPagesRule ? 'Cannot delete this rule' : 'Delete this rule'} type="button" onClick={() => deleteRule(rule)}>
+                  <IconTrash className="icon-delete" aria-hidden />
+                </button>
+              </td>
+            </>
+          )}
+          {isPagesRule && (
+            <td colSpan="2">
+              {pagesPlaceholder()}
+            </td>
+          )}
         </tr>
       )
     );
   }
-  function helperText(sbt) {
+  function helperText() {
     return (
       <>
         <p>
-          The
-          {' '}
-          {sbt.name}
-          {' '}
-          produced by cloud.gov Pages will automatically suppress certain findings
+          For some reports, Pages Automated Site Reports already exclude certain findings
           which are irrelevant for statically hosted websites, based on unconfigurable
           server settings, or frequently produce ‘false positive’ findings for our customers.
-          You can specify additional findings to be suppressed for this site by adding the rule
-          and any matching criteria to the ignore list below.
           {' '}
           <b>
             While still visible in the report, the suppressed findings don’t count towards your
@@ -184,21 +197,24 @@ function ReportConfigs({ siteId: id }) {
           </b>
         </p>
         <p>
-          Specifying match criteria will limit the suppression of findings to any partial string
-          match in:
+          You can specify additional results to be suppressed for this site by adding the
+          related rules and any matching criteria to the exclusion list below.
+          <ul>
+            <li>
+              <b>Specify match criteria</b>
+              {' '}
+              to make sure you’re only suppressing results where the
+              evidence contains that criteria you want to exclude.
+            </li>
+            <li>
+              <b>Leave the criteria field empty</b>
+              {' '}
+              to suppress all results for that rule.
+            </li>
+          </ul>
         </p>
-        <ul>
-          <li>
-            the HTML of the finding (such as an
-            {' '}
-            <code>id</code>
-            )
-          </li>
-          <li>the URL of the page where the finding is discovered</li>
-          <li>the URL of a specific resource to be ignored</li>
-        </ul>
         <p>
-          Try to
+          Remember to
           {' '}
           <b>be as specific as possible</b>
           {' '}
@@ -216,7 +232,7 @@ function ReportConfigs({ siteId: id }) {
         key={sbt.sbtId}
       >
         <div className="well">
-          {helperText(sbt)}
+          {helperText()}
           <table className="usa-table usa-table-borderless scan-config-table">
             <thead>
               <tr>
@@ -239,6 +255,9 @@ function ReportConfigs({ siteId: id }) {
           >
             Save all rules
           </button>
+          {!rulesSynced && (
+            <span className="save-reminder">Make sure to save these changes.</span>
+          )}
           <p className="post-scan-config-table-info">
             For more information on reports and rulesets, check out the
             {' '}
@@ -246,7 +265,7 @@ function ReportConfigs({ siteId: id }) {
               target="_blank"
               rel="noopener noreferrer"
               title="Pages documentation on site reports"
-              href="https://cloud.gov/pages/documentation/build-scans/"
+              href="https://cloud.gov/pages/documentation/automated-site-reports/#configuration"
             >
               documentation
             </a>

--- a/frontend/sass/_icons.scss
+++ b/frontend/sass/_icons.scss
@@ -75,3 +75,19 @@
     margin-bottom: 2px;
   }
 }
+.filter-close-button {
+  svg {
+    color: currentColor;
+    margin-left: 0.6rem;
+    stroke-width: 0;
+    vertical-align: middle;
+    width: 18px;
+    height: 18px;
+    background: currentColor;
+    border-radius: 100%;
+    border: 1px solid currentColor;
+    path {
+      fill: #e1f3f8;
+    }
+  }
+}

--- a/frontend/sass/_tables.scss
+++ b/frontend/sass/_tables.scss
@@ -403,6 +403,12 @@
   .rule-source--Pages {
     td {
       vertical-align: middle;
+      &[colspan] {
+        font-size: 16px;
+        code {
+          font-size: 14px;
+        }
+      }
     }
   }
   tr th {
@@ -411,9 +417,8 @@
   }
   td:first-child {
     padding-left: 0;
-    max-width: 50ch;
   }
-  td:last-child {
+  td.has-button{
     padding-right: 0;
     padding-left: 0;
     width: 10ch;
@@ -423,11 +428,7 @@
   .button-delete {
     background-color: transparent;
     padding: 0 1em;
-    margin: 0;
-    &:disabled {
-      opacity: .4;
-      cursor: not-allowed;
-    }
+    margin: 0 0 1em;
   }
   .icon-delete {
     width: 1.25em;
@@ -445,6 +446,18 @@
     border: none;
     color: #757575;
   }
+  .pages-suppressed-string {
+    background: #f1f1f1;
+    padding: 3px;
+    margin: 2px 0;
+    display: inline-block;
+  }
+}
+.save-reminder {
+  background: #fff1d2;
+  padding: .5em .75em;
+  font-size: 16px;
+  font-weight: bold;
 }
 .post-scan-config-table-info {
   margin-top: 1em;

--- a/frontend/util/reports.js
+++ b/frontend/util/reports.js
@@ -92,7 +92,7 @@ export function relPath(url, baseurl) {
   return url.split(baseurl)[1];
 }
 
-export function getSuccessCriteria({ tags, id }) {
+export function getSuccessCriteria({ tags = [], id = '' }) {
   const criteria = tags.map((tag) => {
     if (tag.startsWith('wcag')) {
       switch (tag) {

--- a/frontend/util/reports.js
+++ b/frontend/util/reports.js
@@ -91,3 +91,39 @@ export function plural(count, name) {
 export function relPath(url, baseurl) {
   return url.split(baseurl)[1];
 }
+
+export function getSuccessCriteria({ tags, id }) {
+  const criteria = tags.map((tag) => {
+    if (tag.startsWith('wcag')) {
+      switch (tag) {
+        case 'wcag2a':
+        case 'wcag2aa':
+        case 'wcag2aaa':
+        case 'wcag21a':
+        case 'wcag21aa':
+        case 'wcag22aa':
+        case 'wcag2a-obsolete':
+          break;
+        default:
+          return {
+            // turn wcag111 into "WCAG SC 1.1.1"
+            short: `WCAG Success Criteria ${tag.split('wcag')[1].split('').join('.')}`,
+            url: `https://www.w3.org/TR/WCAG22/#:~:text=Success%20Criterion%20${tag.split('wcag')[1].split('').join('.')}`,
+          };
+      }
+    } else if ((tag.startsWith('TT')) && tag !== 'TTv5') {
+      return {
+        // turn TT1.1a into "Trusted Tester 1.1A"
+        short: `${tag.toUpperCase().split('TT').join('Trusted Tester ')}`,
+        url: 'https://section508coordinators.github.io/TrustedTester/appendixc.html',
+      };
+    } else if (tag === 'ACT') {
+      return {
+        short: 'ACT',
+        url: `https://www.access-board.gov/search/?query=wcag+sc+baseline+${id}`,
+      };
+    }
+    return undefined;
+  });
+  return criteria.filter(n => n);
+}

--- a/frontend/util/reports.js
+++ b/frontend/util/reports.js
@@ -107,14 +107,14 @@ export function getSuccessCriteria({ tags, id }) {
         default:
           return {
             // turn wcag111 into "WCAG SC 1.1.1"
-            short: `WCAG Success Criteria ${tag.split('wcag')[1].split('').join('.')}`,
+            short: `WCAG SC ${tag.split('wcag')[1].split('').join('.')}`,
             url: `https://www.w3.org/TR/WCAG22/#:~:text=Success%20Criterion%20${tag.split('wcag')[1].split('').join('.')}`,
           };
       }
     } else if ((tag.startsWith('TT')) && tag !== 'TTv5') {
       return {
         // turn TT1.1a into "Trusted Tester 1.1A"
-        short: `${tag.toUpperCase().split('TT').join('Trusted Tester ')}`,
+        short: `${tag.toUpperCase().split('TT').join('TT ')}`,
         url: 'https://section508coordinators.github.io/TrustedTester/appendixc.html',
       };
     } else if (tag === 'ACT') {

--- a/public/styles/report.css
+++ b/public/styles/report.css
@@ -54,8 +54,12 @@ ol li::marker {
   font-family: 'Roboto Mono Web', 'Bitstream Vera Sans Mono',Consolas,Courier,monospace;
 }
 .break-anywhere {
-  line-break: anywhere;
+  word-break: break-all;
 }
+.break-balance {
+  text-wrap: balance;
+}
+
 summary {
   cursor: pointer;
 }
@@ -79,8 +83,8 @@ summary b:hover {
 }
 .anchor-indicator {
   text-decoration: none;
-  margin: .25em;
-  padding: .125em;
+  margin: 0 .25em;
+  padding: 0 .125em;
   font-weight: normal;
   font-variant-position: super;
   display: inline-block;

--- a/public/styles/report.css
+++ b/public/styles/report.css
@@ -53,6 +53,13 @@ hr {
 ol li::marker {
   font-family: 'Roboto Mono Web', 'Bitstream Vera Sans Mono',Consolas,Courier,monospace;
 }
+
+ol li.report-item:hover,
+ol li.report-item:focus {
+  background: #92ddf24f;
+  outline: 3px solid #92ddf24f;
+  border-radius: 2px;
+}
 .break-anywhere {
   word-break: break-all;
 }

--- a/public/styles/report.css
+++ b/public/styles/report.css
@@ -58,6 +58,7 @@ ol li::marker {
 }
 .break-balance {
   text-wrap: balance;
+  text-wrap: pretty;
 }
 
 summary {
@@ -66,6 +67,12 @@ summary {
 summary b:hover {
   text-decoration: underline;
 }
+
+.finding-description > p:first-child {
+  font-size: 20px;
+  margin: 1em 0;
+}
+
 .usa-table--compact th,
 .usa-table--compact td {
   vertical-align: top;


### PR DESCRIPTION
Closes https://github.com/cloud-gov/pages-core/issues/4598

## Changes proposed in this pull request:

**General UX/design:**
- [x] Rework the info introducing the types of scans and their run days on the /sites/id/reports page, making sure it doesn't hide when a build filter is applied to the page
- [x] Wrap or truncate long paths on the a11y index page in the dropdowns
- [x] Make the page URL in the a11y single page header a link
- [x] Try to get the specific WCAG success criteria ("4.1.2") in the accessibility findings somewhere
- [x] Fix steps are buried under all of the evidence; bring it up further and style the additional info better

**Rule Suppression:**
- [x] Indicate whether a finding is suppressed more obviously; the italics aren't cutting it
- [x] Add a "what's this" or some kind of link to the suppression criteria section from the suppressed list so people can find out what that means
- [x] See about making the disabled trash can icon buttons less clicky looking / confusing
- [x] Alert the user they must save their changes to ruleset suppressions, especially if deleting a rule... or make that send to the backend right away?


## security considerations
None
