### PR TITLE
Release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 0.12.0 (2024-09-25)
+
+### Added
+
+- add success criteria to a11y findings
+
+### Fixed
+
+- wrong instance count on zap alert titles
+- separate anchors between suppressed and unsuppressed
+- usability improvements to the report result content display
+- make urls wrap in report headers
+- URLs should wrap on the report index page
+- show report types even when filtered
+
+### Maintenance
+
+- regenerate lockfile, remove some overrides
+- don't audit devDependencies
+- add more references to a11y scan findings using ACT ids
+- add act id mapping
+- UX improvements for findings with multiple match criteria
+- update rule suppression related to search.gov and dap
+- usability improvements to reports
+- improve display of pages-suppressed rules in report config settings
+
 ## 0.11.1 (2024-09-09)
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pages-core",
   "private": true,
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "",
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
## :robot: This is an automated release PR
chore: release 0.12.0
tag to create: 0.12.0
increment detected: MINOR

## 0.12.0 (2024-09-25)

### Added

- add success criteria to a11y findings

### Fixed

- wrong instance count on zap alert titles
- separate anchors between suppressed and unsuppressed
- usability improvements to the report result content display
- make urls wrap in report headers
- URLs should wrap on the report index page
- show report types even when filtered

### Maintenance

- regenerate lockfile, remove some overrides
- don't audit devDependencies
- add more references to a11y scan findings using ACT ids
- add act id mapping
- UX improvements for findings with multiple match criteria
- update rule suppression related to search.gov and dap
- usability improvements to reports
- improve display of pages-suppressed rules in report config settings

## security considerations
Noted in individual PRs
