### PR TITLE
chore: remove extra quotes from cron definition

### DIFF
--- a/api/workers/index.js
+++ b/api/workers/index.js
@@ -41,7 +41,7 @@ const everyTenMinutesJobConfig = {
 };
 
 const makeNightlyJobConfig = (minute = 0, hour = 5) => ({
-  repeat: { cron: `'${minute} ${hour} * * *'` },
+  repeat: { cron: `${minute} ${hour} * * *` },
   priority: 10,
 });
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- remove extra quotes from cron definition

## security considerations
None