### PR TITLE
Release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 0.14.0 (2024-11-20)
+
+### Added
+
+- allow rules to be suppressed from reports
+
+### Fixed
+
+- Site build polling and latest build branch
+- use single build url upon creation (#4323)
+
+### Maintenance
+
+- don't fail the scheduled worker with missing sites
+- Enable eslint-plugin-import for frontend and tests
+- add pr code coverage to ci (#4643)
+- Decouple local app frontend build #4649
+- start rtl transition (#4635)
+- Run prettier formatting on codebase
+- Update linting and formatting
+
 ## 0.13.2 (2024-10-28)
 
 ### Maintenance

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pages-core",
   "private": true,
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "",
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
## :robot: This is an automated release PR
chore: release 0.14.0
tag to create: 0.14.0
increment detected: MINOR

## 0.14.0 (2024-11-20)

### Added

- allow rules to be suppressed from reports

### Fixed

- Site build polling and latest build branch
- use single build url upon creation (#4323)

### Maintenance

- don't fail the scheduled worker with missing sites
- Enable eslint-plugin-import for frontend and tests
- add pr code coverage to ci (#4643)
- Decouple local app frontend build #4649
- start rtl transition (#4635)
- Run prettier formatting on codebase
- Update linting and formatting

## security considerations
Noted in individual PRs
