### PR TITLE
fix: use single build url upon creation (#4323)

### DIFF
--- a/admin-client/src/pages/Build.svelte
+++ b/admin-client/src/pages/Build.svelte
@@ -77,7 +77,7 @@
           <LabeledItem label="completed at" value={formatDateTime(build.completedAt, true)} title={formatDateTime(build.completedAt)} />
           <LabeledItem label="source" value={build.source} />
           <div>
-            <ExternalLink href={build.viewLink}>Live</ExternalLink>
+            <ExternalLink href={build.url}>Live</ExternalLink>
             <ExternalLink
               icon="github"
               href="https://github.com/{build.site.owner}/{build.site.repository}">

--- a/api/serializers/build.js
+++ b/api/serializers/build.js
@@ -7,7 +7,6 @@ const {
   BuildTask,
   BuildTaskType,
 } = require('../models');
-const { buildViewLink } = require('../utils/build');
 const siteSerializer = require('./site');
 const userSerializer = require('./user');
 
@@ -25,17 +24,12 @@ const toJSON = (build) => {
     object.startedAt = object.startedAt.toISOString();
   }
 
-  if (build.Site) {
-    object.viewLink = buildViewLink(build, build.Site);
-  }
-
   Object.keys(object).forEach((key) => {
     if (object[key] === null) {
       delete object[key];
     }
   });
   delete object.token;
-  delete object.url;
   delete object.logsS3Key;
   // only return first 80 chars in case it's long
   if (object.error) {

--- a/api/services/GithubBuildHelper.js
+++ b/api/services/GithubBuildHelper.js
@@ -1,7 +1,6 @@
 const url = require('url');
 const GitHub = require('./GitHub');
 const config = require('../../config');
-const { buildViewLink } = require('../utils/build');
 
 // Loops through supplied list of users, until it
 // finds a user with a valid access token
@@ -109,7 +108,7 @@ const reportBuildStatus = async (build) => {
     options.description = 'The build is running.';
   } else if (build.state === 'success') {
     options.state = 'success';
-    options.target_url = buildViewLink(build, site);
+    options.target_url = build.url;
     options.description = 'The build is complete!';
   } else if (build.state === 'error') {
     options.state = 'error';

--- a/api/services/SiteBuildQueue.js
+++ b/api/services/SiteBuildQueue.js
@@ -9,7 +9,7 @@ const {
 } = require('../models');
 const config = require('../../config');
 const CloudFoundryAPIClient = require('../utils/cfApiClient');
-const { buildViewLink, buildUrl } = require('../utils/build');
+const { sitePrefix, buildUrl } = require('../utils/build');
 const GithubBuildHelper = require('./GithubBuildHelper');
 const S3Helper = require('./S3Helper');
 
@@ -24,13 +24,8 @@ const siteConfig = (build, siteBranchConfigs = []) => {
   return configRecord?.config || {};
 };
 
-const baseURLForDomain = (rawDomain) => url.parse(rawDomain).path.replace(/(\/)+$/, '');
-
-const sitePrefixForBuild = (rawDomain) =>
-  baseURLForDomain(rawDomain).replace(/^(\/)+/, '');
-
 const baseURLForBuild = (build) => {
-  const link = buildViewLink(build, build.Site);
+  const link = buildUrl(build, build.Site);
   const urlObject = new URL(link);
   return urlObject.pathname.replace(/(\/)+$/, '');
 };
@@ -61,7 +56,7 @@ const generateDefaultCredentials = async (build) => {
     CONFIG: JSON.stringify(siteConfig(build, SiteBranchConfigs)),
     REPOSITORY: repository,
     OWNER: owner,
-    SITE_PREFIX: sitePrefixForBuild(buildUrl(build, build.Site)),
+    SITE_PREFIX: sitePrefix(build, build.Site),
     GITHUB_TOKEN: (build.User || {}).githubAccessToken, // temp hot-fix
     GENERATOR: engine,
     BUILD_ID: build.id,

--- a/frontend/pages/sites/$siteId/builds/Build.jsx
+++ b/frontend/pages/sites/$siteId/builds/Build.jsx
@@ -8,7 +8,7 @@ import buildActions from '@actions/buildActions';
 
 import GithubBuildBranchLink from '@shared/GithubBuildBranchLink';
 import GithubBuildShaLink from '@shared/GithubBuildShaLink';
-import BranchViewLink from '@shared/BranchViewLink';
+import { IconView } from '@shared/icons';
 import {
   IconCheckCircle,
   IconClock,
@@ -207,12 +207,15 @@ const Build = ({ build, latestForBranch, showBuildTasks = false, site }) => {
       <td data-title="Results" className="table-actions">
         {latestForBranch && build.state === 'success' && (
           <p className="site-link">
-            <BranchViewLink
-              branchName={build.branch}
-              site={site}
-              showIcon
-              completedAt={build.completedAt}
-            />
+            <a
+              href={build.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={'view-site-link'}
+            >
+              <IconView />
+              View site preview
+            </a>
           </p>
         )}
         {latestForBranch && ['error', 'success'].includes(build.state) && (

--- a/frontend/pages/sites/$siteId/published/BranchRow.jsx
+++ b/frontend/pages/sites/$siteId/published/BranchRow.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 
-import BranchViewLink from '@shared/BranchViewLink';
+import BranchViewLink from './BranchViewLink';
 
 import { SITE } from '@propTypes';
 

--- a/frontend/pages/sites/$siteId/published/BranchViewLink.jsx
+++ b/frontend/pages/sites/$siteId/published/BranchViewLink.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { SITE } from '../propTypes';
-import { IconView } from './icons';
-import globals from '../globals';
+import { SITE } from '@propTypes';
+import globals from '@globals';
 
 // Based on the site's related site branch configs and domains
 // This function determines the link for a built branch
@@ -32,17 +30,11 @@ const getViewLink = (branch, site) => {
   return `https://${domain.names.split(',')[0]}`;
 };
 
-export const BranchViewLink = ({ branchName, site, showIcon }) => {
+export const BranchViewLink = ({ branchName, site }) => {
   const domain = getViewLink(branchName, site);
 
   return (
-    <a
-      href={domain}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={showIcon ? 'view-site-link' : ''}
-    >
-      {showIcon && <IconView />}
+    <a href={domain} target="_blank" rel="noopener noreferrer">
       View site preview
     </a>
   );
@@ -51,11 +43,5 @@ export const BranchViewLink = ({ branchName, site, showIcon }) => {
 BranchViewLink.propTypes = {
   branchName: PropTypes.string.isRequired,
   site: SITE.isRequired,
-  showIcon: PropTypes.bool,
 };
-
-BranchViewLink.defaultProps = {
-  showIcon: false,
-};
-
-export default connect()(BranchViewLink);
+export default BranchViewLink;

--- a/test/api/unit/models/build.test.js
+++ b/test/api/unit/models/build.test.js
@@ -296,7 +296,7 @@ describe('Build model', () => {
           expect(build.completedAt.getTime()).to.eql(site.publishedAt.getTime());
           const url = [
             `https://${site.awsBucketName}.${config.app.proxyDomain}`,
-            `/preview/${site.owner}/${site.repository}/${build.branch}`,
+            `/preview/${site.owner}/${site.repository}/${build.branch}/`,
           ].join('');
           expect(build.url).to.eql(url);
         });

--- a/test/api/unit/services/GithubBuildHelper.test.js
+++ b/test/api/unit/services/GithubBuildHelper.test.js
@@ -5,7 +5,7 @@ const config = require('../../../../config');
 const { Domain, Site, SiteBranchConfig, User } = require('../../../../api/models');
 const factory = require('../../support/factory');
 const githubAPINocks = require('../../support/githubAPINocks');
-const { buildViewLink } = require('../../../../api/utils/build');
+const { buildUrl } = require('../../../../api/utils/build');
 const GitHub = require('../../../../api/services/GitHub');
 const GithubBuildHelper = require('../../../../api/services/GithubBuildHelper');
 
@@ -770,6 +770,14 @@ describe('GithubBuildHelper', () => {
         await build.update({
           branch: 'preview-branch',
         });
+
+        await build.reload();
+
+        // this depends on branch so we update twice
+        await build.update({
+          url: buildUrl(build, site),
+        });
+
         const repoNock = githubAPINocks.repo({
           accessToken: user.githubAccessToken,
           owner: site.owner,
@@ -780,7 +788,7 @@ describe('GithubBuildHelper', () => {
           owner: site.owner,
           repo: site.repository,
           sha: clonedCommitSha,
-          targetURL: buildViewLink(build, site),
+          targetURL: buildUrl(build, site),
         });
 
         await build.reload({
@@ -791,6 +799,7 @@ describe('GithubBuildHelper', () => {
             },
           ],
         });
+
         await GithubBuildHelper.reportBuildStatus(build);
         expect(repoNock.isDone()).to.be.true;
         expect(statusNock.isDone()).to.be.true;

--- a/test/api/workers/jobProcessors/buildTaskRunner.test.js
+++ b/test/api/workers/jobProcessors/buildTaskRunner.test.js
@@ -250,7 +250,7 @@ describe('buildTaskRunner', () => {
         branch: siteBranchConfig.branch,
       });
       const task = await factory.buildTask({ build });
-      const domain = await factory.domain.create({
+      await factory.domain.create({
         siteId: site.id,
         siteBranchConfigId: siteBranchConfig.id,
         state: 'provisioned',
@@ -259,7 +259,6 @@ describe('buildTaskRunner', () => {
       const rawTask = taskWithIncludes.get({
         plain: true,
       });
-      rawTask.Build.url = `https://${domain.names.split(',')[0]}`;
       sinon.stub(BuildTaskQueue, 'setupTaskEnv').resolves({
         buildTask: taskWithIncludes,
         ...jobData,


### PR DESCRIPTION
## Changes proposed in this pull request:
- Implements the refactor in https://github.com/cloud-gov/pages-core/issues/4323#issuecomment-2444939054
- Closes #4323

## Notes
- [x] Needs new tests
- [x] Verification on dev
- [x] Rewrite the `url` column on the `build` table using this logic

## security considerations
None 