### PR TITLE
Release 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 0.15.0 (2025-01-15)
+
+### Added
+
+- Add db migrations for file storage service #2077
+
+### Fixed
+
+- Promote Pages better in GitHub Status Checks
+
+### Maintenance
+
+- close outstanding dependeabot vulnerabilities
+- test @shared/ButtonLink.jsx #4672
+-  test @shared/UsaIcon.jsx #4668
+- Test frontend/pages/sites/SiteListItem.jsx and refactor/remove frontend/pages/sites/PublishedState.jsx
+- Reenable sonarjs linting rules #4652
+- Test shared/GithubBuildBranchLink #4670
+- Test shared/GithubBuildShaLink #4669
+- remove SiteUser and associated concepts (#4339)
+- Test shared/GithubAuthButton #4671
+- Test shared user org select #4667
+- restore webpack bundle analyzer on dev (#4675)
+- remove jobs.js (#4677)
+- reconcile dependencies
+- upgrade to express 5 (#4611)
+- update docker uaa port to avoid zscaler conflict
+
+### Documentation
+
+- document testing strategies
+
 ## 0.14.0 (2024-11-20)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pages-core",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "",
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
## :robot: This is an automated release PR
chore: release 0.15.0
tag to create: 0.15.0
increment detected: MINOR

## 0.15.0 (2025-01-15)

### Added

- Add db migrations for file storage service #2077

### Fixed

- Promote Pages better in GitHub Status Checks

### Maintenance

- close outstanding dependeabot vulnerabilities
- test @shared/ButtonLink.jsx #4672
-  test @shared/UsaIcon.jsx #4668
- Test frontend/pages/sites/SiteListItem.jsx and refactor/remove frontend/pages/sites/PublishedState.jsx
- Reenable sonarjs linting rules #4652
- Test shared/GithubBuildBranchLink #4670
- Test shared/GithubBuildShaLink #4669
- remove SiteUser and associated concepts (#4339)
- Test shared/GithubAuthButton #4671
- Test shared user org select #4667
- restore webpack bundle analyzer on dev (#4675)
- remove jobs.js (#4677)
- reconcile dependencies
- upgrade to express 5 (#4611)
- update docker uaa port to avoid zscaler conflict

### Documentation

- document testing strategies

## security considerations
Noted in individual PRs
