### PR TITLE
restore webpack bundle analyzer on dev

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -107,7 +107,7 @@ If you are working on the front end of the application, the things you need to k
 1. It is built with `webpack`
 1. It lives in `/frontend`
 
-To analyze the contents of the front end JavaScript bundle, visit http://127.0.0.1:8888 while the application is running to see a visualization of the the bundle contents.
+To analyze the contents of the front end JavaScript bundle, visit http://localhost:8888 while the application is running to see a visualization of the the bundle contents.
 
 ### Deployment
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "build:dev": "NODE_ENV='development' --config webpack.config.js",
+    "build:dev": "NODE_ENV='development' webpack --config webpack.config.js",
     "build:test": "NODE_ENV='test' webpack --config webpack.config.js",
     "start": "node index.js",
     "start-workers": "node ./api/workers/index.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const webpack = require('webpack');
 const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const autoprefixer = require('autoprefixer');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-// const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const CopyPlugin = require('copy-webpack-plugin');
 const { getFeatureFlags } = require('./webpack-utils');
 
@@ -17,12 +17,6 @@ const resourceFilename = isDev
 const mode = isDev ? NODE_ENV : 'production';
 const devtool = isDev ? 'inline-source-map' : undefined;
 const stats = isDev ? 'minimal' : 'none';
-
-// Decide on how to use this later.
-// const bundleAnalyzer = isDev && new BundleAnalyzerPlugin({
-//   analyzerHost: '0.0.0.0',
-//   analyzerPort: '8888',
-// });
 
 const uswdsDist = './node_modules/@uswds/uswds/dist';
 
@@ -86,6 +80,15 @@ const plugins = [
     'PROXY_DOMAIN',
   ]),
 ];
+
+if (isDev) {
+  plugins.push(
+    new BundleAnalyzerPlugin({
+      analyzerHost: '0.0.0.0',
+      analyzerPort: '8888',
+    }),
+  );
+}
 
 if (!isDev) {
   plugins.push(


### PR DESCRIPTION
## Changes proposed in this pull request:
- restore webpack bundle analyzer on dev 
- close #4675

# Note
The bundle sizes shown include the sourcemaps and don't include minification so they are much larger than the resulting production bundles but should be "directionally correct" when looking to eliminate larger dependencies

## security considerations
None