### PR TITLE
Chore: test shared/GithubBuildBranchLink.jsx #4670

### DIFF
--- a/frontend/shared/GithubBuildBranchLink.jsx
+++ b/frontend/shared/GithubBuildBranchLink.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import GitHubLink from './GitHubLink';
 
-export default function GithubBuildShaLink({ build, site }) {
+export default function GithubBuildBranchLink({ build, site }) {
   const { owner, repository } = site;
   const { branch } = build;
 
@@ -18,7 +18,7 @@ export default function GithubBuildShaLink({ build, site }) {
   );
 }
 
-GithubBuildShaLink.propTypes = {
+GithubBuildBranchLink.propTypes = {
   build: PropTypes.shape({
     branch: PropTypes.string.isRequired,
   }).isRequired,

--- a/frontend/shared/GithubBuildBranchLink.test.jsx
+++ b/frontend/shared/GithubBuildBranchLink.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import GithubBuildBranchLink from './GithubBuildBranchLink';
+
+const defaultBuild = {
+  branch: 'branch_name',
+};
+const defaultSite = {
+  owner: 'repo_owner',
+  repository: 'repo_name',
+};
+const defaultProps = { build: defaultBuild, site: defaultSite };
+
+describe('<GithubBuildBranchLink/>', () => {
+  it('renders', () => {
+    render(<GithubBuildBranchLink {...defaultProps} />);
+
+    const anchor = screen.getByRole('link');
+
+    expect(anchor).toHaveClass('branch-link');
+    expect(anchor).toHaveAttribute('title', 'View branch on GitHub');
+  });
+  it('uses the build’s branch and the site’s repo and owner', () => {
+    render(<GithubBuildBranchLink {...defaultProps} />);
+
+    const anchor = screen.getByRole('link');
+
+    expect(anchor).toHaveAttribute(
+      'href',
+      'https://github.com/repo_owner/repo_name/tree/branch_name',
+    );
+    expect(anchor).toHaveTextContent('branch_name');
+  });
+});


### PR DESCRIPTION
## Changes proposed in this pull request:
- Colocate test file to @shared/GithubBuildBranchLink.test.jsx
- Test the GitHubLink renders with the proper site owner, site repository, and build branch
- Remove component defaultProps and add the to the component args

## security considerations
- N/A, just a test
