### PR TITLE
Promote Pages better in GitHub Status Checks

### DIFF
--- a/api/services/GithubBuildHelper.js
+++ b/api/services/GithubBuildHelper.js
@@ -105,18 +105,24 @@ const reportBuildStatus = async (build) => {
       config.app.hostname,
       `/sites/${site.id}/builds/${build.id}/logs`,
     );
-    options.description = 'The build is running.';
+    // eslint-disable-next-line max-len
+    options.description =
+      'The build is running. Click "Details" to see the Pages build status.';
   } else if (build.state === 'success') {
     options.state = 'success';
     options.target_url = build.url;
-    options.description = 'The build is complete!';
+    // eslint-disable-next-line max-len
+    options.description =
+      'The build is complete! Click "Details" to visit the Site Preview.';
   } else if (build.state === 'error') {
     options.state = 'error';
     options.target_url = url.resolve(
       config.app.hostname,
       `/sites/${site.id}/builds/${build.id}/logs`,
     );
-    options.description = 'The build has encountered an error.';
+    // eslint-disable-next-line max-len
+    options.description =
+      'The build has encountered an error. Click "Details" to see the Pages build logs.';
   }
   return GitHub.sendCreateGithubStatusRequest(accessToken, options);
 };


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds a little more text to help users know they can use the Details link to get directly to Pages build logs or the preview links.

## security considerations
NA