### PR TITLE
chore: refactor @shared/UsaIcon.jsx and test  #4668

### DIFF
--- a/frontend/shared/UsaIcon.jsx
+++ b/frontend/shared/UsaIcon.jsx
@@ -1,30 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-function UsaIcon({ focusable = false, role = 'img', name, size = null }) {
+function UsaIcon({ role = 'img', name, size = null }) {
   return (
     <svg
       className={size ? `usa-icon usa-icon--size-${size}` : 'usa-icon'}
-      aria-hidden="true"
-      focusable={focusable}
+      focusable={role === 'button' || role === 'link'}
       role={role}
     >
-      <use xlinkHref={`/img/sprite.svg#${name}`} />
+      <use href={`/img/sprite.svg#${name}`} />
     </svg>
   );
 }
 
 UsaIcon.propTypes = {
-  role: PropTypes.string,
-  focusable: PropTypes.bool,
+  role: PropTypes.oneOf(['img', 'presentation', 'button', 'link', 'status', 'none']),
   name: PropTypes.string.isRequired,
-  size: PropTypes.number,
-};
-
-UsaIcon.defaultProps = {
-  role: 'img',
-  focusable: false,
-  size: null,
+  size: PropTypes.oneOf([3, 4, 5, 6, 7, 8, 9]),
 };
 
 export default UsaIcon;

--- a/frontend/shared/UsaIcon.test.jsx
+++ b/frontend/shared/UsaIcon.test.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import UsaIcon from './UsaIcon';
+
+describe('<UsaIcon />', () => {
+  it('renders an SVG icon with USDWDS classes', () => {
+    render(<UsaIcon name="check" />);
+    const svgElement = screen.getByRole('img');
+    expect(svgElement).toBeInstanceOf(SVGSVGElement);
+    expect(svgElement).toHaveClass('usa-icon');
+  });
+
+  it('renders the icon as unfocusable img role', () => {
+    render(<UsaIcon name="check" />);
+    const svgElement = screen.getByRole('img');
+    expect(svgElement).toHaveAttribute('focusable', 'false');
+  });
+
+  it('renders the icon as focusable when the role is button', () => {
+    render(<UsaIcon name="check" role="button" />);
+    const svgElement = screen.getByRole('button');
+    expect(svgElement).toHaveAttribute('focusable', 'true');
+  });
+
+  it('renders the icon as focusable when the role is link', () => {
+    render(<UsaIcon name="check" role="link" />);
+    const svgElement = screen.getByRole('link');
+    expect(svgElement).toHaveAttribute('focusable', 'true');
+  });
+
+  it('renders the icon with a size class when size is set', () => {
+    render(<UsaIcon name="check" size={4} />);
+    const svgElement = screen.getByRole('img');
+    expect(svgElement).toHaveClass('usa-icon--size-4');
+  });
+
+  it('uses a role attribute when provided', () => {
+    render(<UsaIcon name="check" role="presentation" />);
+    const svgElement = screen.getByRole('presentation');
+    expect(svgElement).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Changes proposed in this pull request:
- removed `aria-hidden` because node visibility ought to be determined by the `role` https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden
- Removed unnecessary `aria-hidden` and `focusable` props, using `role` to determine visibility and focusability
- `focusable` is now `false` by default, and only set to `true` for `role="button"` and `role="link"`, per a11y guidelines
- replaced deprecated `xlinkHref` with`href` https://github.com/uswds/uswds-site/pull/2926 and https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href
- `role` must now be one of the following, suitable for icons: `img, presentation, button, link, status, none` https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles
- `size` must be one of the USWDS icon size options, 3-9 https://designsystem.digital.gov/components/icon/#component-variants-icon
- add tests per #4668

## security considerations
- None, UI changes only