### PR TITLE
Restore admin webhook functionality

### DIFF
--- a/api/admin/controllers/site.js
+++ b/api/admin/controllers/site.js
@@ -70,7 +70,7 @@ module.exports = wrapHandlers({
     } = req;
 
     const site = await Site.findOne({ where: { id } });
-    const users = site.getOrgUsers();
+    const users = await site.getOrgUsers();
     const hook = await GithubBuildHelper.createSiteWebhook(site, users);
 
     return res.json(hook || []);
@@ -82,7 +82,7 @@ module.exports = wrapHandlers({
     } = req;
 
     const site = await Site.findOne({ where: { id } });
-    const users = site.getOrgUsers();
+    const users = await site.getOrgUsers();
     const hooks = await GithubBuildHelper.listSiteWebhooks(site, users);
 
     return res.json(hooks);


### PR DESCRIPTION
## Changes proposed in this pull request:
- restore admin webhook functionality
- close #4702 
- (async `site.getOrgUsers` method called without await)

## security considerations
None