### PR TITLE
Fix site creation error

### DIFF
--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -102,7 +102,7 @@ module.exports = wrapHandlers({
       site,
     });
     await site.reload({
-      include: [Organization],
+      include: [Organization, SiteBranchConfig, SiteBuildTask],
     });
     const siteJSON = siteSerializer.serializeNew(site);
     return res.json(siteJSON);


### PR DESCRIPTION
## Changes proposed in this pull request:
- Send back fuller site object on site creation, avoid error in the site navigation pane
- Close #4704

# Note
A more robust solution to this would be swapping the "sites" internal state to use react-query instead of redux. Happy to discuss that as a better/longer-term fix 

## security considerations
None