### PR TITLE
Release 0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.15.2 (2025-02-13)
+
+### Fixed
+
+- admin auth still requires certain roles
+- Remove redundant a11y recommendation content
+- don't fetch site user model, allow admin rebuild
+
+### Maintenance
+
+- move initial uaa group checking to login/verify only
+- remove errant login logging
+
 ## 0.15.1 (2025-01-27)
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pages-core",
   "private": true,
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "",
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
## :robot: This is an automated release PR
chore: release 0.15.2
tag to create: 0.15.2
increment detected: PATCH

## 0.15.2 (2025-02-13)

### Fixed

- admin auth still requires certain roles
- Remove redundant a11y recommendation content
- don't fetch site user model, allow admin rebuild

### Maintenance

- move initial uaa group checking to login/verify only
- remove errant login logging

## security considerations
Noted in individual PRs
