### PR TITLE
fix: Remove redundant a11y recommendation content

### DIFF
--- a/frontend/pages/reports/components/ScanFinding.jsx
+++ b/frontend/pages/reports/components/ScanFinding.jsx
@@ -246,33 +246,6 @@ const FindingRecommendation = ({ anchor, solution, sbtType }) => (
           ))}
         </>
       )}
-      {sbtType === 'a11y' && (
-        <>
-          {solution.split('\n\n').map((fixList, listindex) => (
-            <div key={`${anchor}-location-${listindex}`}>
-              {fixList.split('\n').map((str, i) =>
-                i === 0 ? (
-                  <h4 key={i} className="usa-summary-box__heading">
-                    {str}
-                    <a
-                      href={`#${anchor}-recommendation`}
-                      className="usa-link target-highlight anchor-indicator"
-                    >
-                      #
-                    </a>
-                  </h4>
-                ) : (
-                  <div key={i} className="usa-summary-box__body">
-                    <ul className="usa-list margin-bottom-2">
-                      <li className="font-body-md">{str}</li>
-                    </ul>
-                  </div>
-                ),
-              )}
-            </div>
-          ))}
-        </>
-      )}
     </div>
   </div>
 );


### PR DESCRIPTION

## Changes proposed in this pull request:
- Fixes duplicate content in recommendations summary:
![Screenshot 2025-02-03 at 10 52 35 AM](https://github.com/user-attachments/assets/588cc72b-e855-455e-b47f-b4cb2e4670b2)

## security considerations
NA - deleting redundant frontend code