### PR TITLE
fix: admin auth still requires certain roles

### DIFF
--- a/api/admin/passport.js
+++ b/api/admin/passport.js
@@ -33,7 +33,7 @@ const verify = async (req, accessToken, refreshToken, profile, callback) => {
   try {
     const { user, role } = await verifyUAAUser(accessToken, refreshToken, profile);
 
-    if (user && role) {
+    if (user && ['pages.admin', 'pages.support'].includes(role)) {
       return callback(null, {
         ...user.dataValues,
         role,

--- a/test/api/admin/requests/admin-auth.test.js
+++ b/test/api/admin/requests/admin-auth.test.js
@@ -35,19 +35,20 @@ describe('Admin authentication request', () => {
       const uaaId = 'user_id_1';
       const code = 'code';
       const profile = {
-        email: 'hello@example.com',
+        email: 'justauser@example.com',
         user_id: uaaId,
       };
       const user = await userFactory();
       await createUAAIdentity({
         uaaId,
         userId: user.id,
+        email: profile.email,
       });
       const userProfile = uaaUser({
         id: uaaId,
         groups: [
           {
-            display: 'not.admin',
+            display: 'pages.user',
           },
         ],
         ...profile,


### PR DESCRIPTION
## Changes proposed in this pull request:
- fixes an access probably introduced in #4711
- fixes prior to production release

## security considerations
Stops non admin/support users from accessing the admin panel