### PR TITLE
chore: Add feature flag for file storage #4718

### DIFF
--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -52,6 +52,7 @@ applications:
       NEW_RELIC_ERROR_COLLECTOR_ENABLED: false
       QUEUES_BUILD_TASKS_CONCURRENCY: ((queues_build_tasks_concurrency))
       QUEUES_SITE_BUILDS_CONCURRENCY: ((queues_site_builds_concurrency))
+      FEATURE_FILE_STORAGE_SERVICE: ((feature_file_storage_service))
   - name: pages-admin((env_postfix))
     buildpack: staticfile_buildpack
     path: ../admin-client

--- a/.cloudgov/vars/pages-dev.yml
+++ b/.cloudgov/vars/pages-dev.yml
@@ -5,8 +5,6 @@ instances: 2
 env: dev
 env_postfix: -dev
 log_level: verbose
-feature_auth_uaa: "true"
-feature_bull_site_build_queue: "true"
 uaa_host: https://uaa.fr-stage.cloud.gov
 uaa_login_host: https://login.fr-stage.cloud.gov
 new_relic_app_name: web-pages-dev
@@ -15,3 +13,4 @@ cf_cdn_space_name: sites-dev
 node_env: development
 queues_build_tasks_concurrency: 2
 queues_site_builds_concurrency: 3
+feature_file_storage_service: "true"

--- a/.cloudgov/vars/pages-production.yml
+++ b/.cloudgov/vars/pages-production.yml
@@ -5,8 +5,6 @@ instances: 4
 env: production
 env_postfix: -production
 log_level: info
-feature_auth_uaa: "true"
-feature_bull_site_build_queue: "true"
 uaa_host: https://uaa.fr.cloud.gov
 uaa_login_host: https://login.fr.cloud.gov
 new_relic_app_name: web-pages-production
@@ -15,3 +13,4 @@ cf_cdn_space_name: sites
 node_env: production
 queues_build_tasks_concurrency: 10
 queues_site_builds_concurrency: 10
+feature_file_storage_service: "false"

--- a/.cloudgov/vars/pages-staging.yml
+++ b/.cloudgov/vars/pages-staging.yml
@@ -5,8 +5,6 @@ instances: 2
 env: staging
 env_postfix: -staging
 log_level: verbose
-feature_auth_uaa: "true"
-feature_bull_site_build_queue: "true"
 uaa_host: https://uaa.fr-stage.cloud.gov
 uaa_login_host: https://login.fr-stage.cloud.gov
 new_relic_app_name: web-pages-staging
@@ -15,3 +13,4 @@ cf_cdn_space_name: sites-staging
 node_env: production
 queues_build_tasks_concurrency: 4
 queues_site_builds_concurrency: 4
+feature_file_storage_service: "true"

--- a/api/features.js
+++ b/api/features.js
@@ -7,6 +7,7 @@ const Flags = {
     Ex.
     FEATURE_AWESOME_FEATURE: 'FEATURE_AWESOME_FEATURE',
     */
+  FEATURE_FILE_STORAGE_SERVICE: 'FEATURE_FILE_STORAGE_SERVICE',
 };
 
 const TRUTHY_VALUES = [true, 'True', 'true', 'TRUE'];

--- a/api/routers/index.js
+++ b/api/routers/index.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const Features = require('../features');
 
 const mainRouter = express.Router();
 
@@ -12,7 +13,11 @@ apiRouter.use(require('./build-log'));
 apiRouter.use(require('./build-task'));
 apiRouter.use(require('./build'));
 apiRouter.use(require('./domain'));
-apiRouter.use(require('./file-storage-service'));
+
+if (Features.enabled(Features.Flags.FEATURE_FILE_STORAGE_SERVICE)) {
+  apiRouter.use(require('./file-storage-service'));
+}
+
 apiRouter.use(require('./organization'));
 apiRouter.use(require('./organization-role'));
 apiRouter.use(require('./published-branch'));

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       CF_API_PASSWORD: deploy_pass
       PROXY_DOMAIN: localhost:1337
       CI: true
+      FEATURE_FILE_STORAGE_SERVICE: true
   db:
     image: postgres:ci
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       DOMAIN: localhost:1337
       FEATURE_BUILD_TASKS: 'active'
       FEATURE_LOCAL_BUILD_REPORTS: 'active'
+      FEATURE_FILE_STORAGE_SERVICE: 'true'
       NODE_ENV: development
       PORT: 1337
       PRODUCT: pages

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -337,7 +337,7 @@ Environment-specific feature flags are supported for both the api and frontend. 
 
 ### Current available features
 
-N/A
+- `FEATURE_FILE_STORAGE_SERVICE`: The file storage service feature flag to gate the API's accessibility in production.
 
 ### Api feature flags
 Api feature flags are evaluated at *runtime* and should be created explicitly in the code before the corresponding environment variable can be used. Example:


### PR DESCRIPTION
Closes [#4718](https://github.com/cloud-gov/pages-core/issues/4718)
## Changes proposed in this pull request:
- Adds a feature flag for the file storage API and activates it only for dev and staging.

## security considerations
Gates file storage API access to only the lower environments.
