### PR TITLE
feat: Check for duplicate file storage files

### DIFF
--- a/api/responses/siteErrors.js
+++ b/api/responses/siteErrors.js
@@ -17,4 +17,8 @@ module.exports = {
   SITE_DOES_NOT_EXIST: 'The specified site does not exist',
   DIRECTORY_MUST_BE_EMPTIED:
     'This directory cannot be deleted. Please delete file contents first.',
+  DIRECTORY_EXISTS_ALREADY:
+    'A directory with the same name already exists. Please rename your new directory.',
+  FILE_EXISTS_ALREADY:
+    'A file with the same name already exists. Please rename your new file.',
 };


### PR DESCRIPTION
Closes #4726 

## Changes proposed in this pull request:
- Checks if file with same key and file storage id exists before creating a file or directory
- Throws a 400 with the error message
- Updates the directory not empty delete to throw a 400 with error message

## security considerations
None
