### PR TITLE
fix: page titles, routes, and sidenav consistency, add file storage logs page

### DIFF
--- a/api/models/file-storage-user-action.js
+++ b/api/models/file-storage-user-action.js
@@ -1,4 +1,6 @@
 const ACTION_TYPES = [
+  // make sure to keep in sync with file storage history messages in parseAction()
+  // from /frontend/pages/sites/$siteId/storage/logs
   'CREATE_SITE_FILE_STORAGE_SERVICE',
   'CREATE_ORGANIZATION_FILE_STORAGE_SERVICE',
   'CREATE_DIRECTORY',

--- a/frontend/hooks/useFileStorage.js
+++ b/frontend/hooks/useFileStorage.js
@@ -58,7 +58,6 @@ export default function useFileStorage(
       refetchInterval: REFETCH_INTERVAL,
       refetchIntervalInBackground: false,
       enabled: !!fileStorageId,
-      keepPreviousData: true,
       staleTime: 2000,
       placeholderData: previousData.current || INITIAL_DATA,
       onError: (err) => {

--- a/frontend/hooks/useFileStorageLogs.js
+++ b/frontend/hooks/useFileStorageLogs.js
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query';
+import { useRef, useEffect } from 'react';
+
+import api from '../util/federalistApi';
+
+const INITIAL_DATA = {
+  data: [],
+  currentPage: 1,
+  totalPages: 1,
+  totalItems: 0,
+};
+
+export default function useFileStorageLogs(fileStorageServiceId, page = 1) {
+  const previousData = useRef();
+
+  const { data, error, isPending, isPlaceholderData } = useQuery({
+    queryKey: ['fileHistory', fileStorageServiceId, page],
+    queryFn: async () => {
+      const response = await api.fetchAllPublicFilesHistory(fileStorageServiceId, page);
+      return response || INITIAL_DATA;
+    },
+    enabled: !!fileStorageServiceId,
+    staleTime: 60000, // 1 minte between refetches
+    placeholderData: previousData.current || INITIAL_DATA,
+  });
+
+  useEffect(() => {
+    if (data !== undefined) {
+      previousData.current = data;
+    }
+  }, [data]);
+
+  return {
+    ...data,
+    isPending,
+    isPlaceholderData,
+    error,
+  };
+}

--- a/frontend/hooks/useFileStorageLogs.test.jsx
+++ b/frontend/hooks/useFileStorageLogs.test.jsx
@@ -1,0 +1,99 @@
+import { waitFor, renderHook } from '@testing-library/react';
+import nock from 'nock';
+import { createTestQueryClient } from '@support/queryClient';
+import useFileStorageLogs from './useFileStorageLogs';
+import { getFileStorageLogs, getFileStorageLogsError } from '@support/nocks/fileStorage';
+import { getFileStorageLogsData } from '../../test/frontend/support/data/fileStorageData';
+import federalist from '@util/federalistApi';
+
+const createWrapper = createTestQueryClient();
+
+const props = {
+  fileStorageServiceId: 123,
+  page: 1,
+};
+
+describe('useFileStorageLogs', () => {
+  beforeEach(() => nock.cleanAll());
+  afterAll(() => nock.restore());
+
+  it('should fetch file logs successfully', async () => {
+    const expectedData = getFileStorageLogsData(props.page);
+    await getFileStorageLogs({ ...props });
+
+    const { result } = renderHook(
+      () => useFileStorageLogs(props.fileStorageServiceId, props.page),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(!result.current.isPlaceholderData).toBe(true));
+    await waitFor(() => expect(!result.current.isPending).toBe(true));
+
+    expect(result.current.data).toEqual(expectedData.data);
+    expect(result.current.currentPage).toEqual(expectedData.currentPage);
+    expect(result.current.totalPages).toEqual(expectedData.totalPages);
+    expect(result.current.totalItems).toEqual(expectedData.totalItems);
+  });
+
+  it('should fetch the second page of results correctly', async () => {
+    const pageNumber = 2;
+    const expectedData = getFileStorageLogsData(pageNumber);
+    await getFileStorageLogs({ ...props, page: pageNumber });
+
+    const { result } = renderHook(
+      () => useFileStorageLogs(props.fileStorageServiceId, pageNumber),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(!result.current.isPlaceholderData).toBe(true));
+    await waitFor(() => expect(!result.current.isPending).toBe(true));
+
+    expect(result.current.data).toEqual(expectedData.data);
+    expect(result.current.data.length).toEqual(expectedData.data.length);
+    expect(result.current.currentPage).toEqual(expectedData.currentPage);
+  });
+
+  it('should return an error when fetching logs fails', async () => {
+    await getFileStorageLogsError({ ...props });
+
+    const { result } = renderHook(() => useFileStorageLogs(props.fileStorageServiceId), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.error.message).toBe('Failed to fetch storage logs');
+  });
+
+  it('should not fetch when fileStorageServiceId is not provided', async () => {
+    // Spy on the API call
+    const apiFetchSpy = jest.spyOn(federalist, 'fetchAllPublicFilesHistory');
+
+    const { result } = renderHook(() => useFileStorageLogs(), {
+      wrapper: createWrapper(),
+    });
+
+    // Check initial data
+    expect(result.current.data).toEqual([]);
+
+    // Most importantly - verify the API was never called
+    expect(apiFetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('should refetch when page changes', async () => {
+    await getFileStorageLogs({ ...props });
+    const { result, rerender } = renderHook(
+      ({ page }) => useFileStorageLogs(props.fileStorageServiceId, page),
+      {
+        wrapper: createWrapper(),
+        initialProps: { page: 1 },
+      },
+    );
+
+    await waitFor(() => expect(!result.current.isPending).toBe(true));
+
+    await getFileStorageLogs({ ...props, page: 2 });
+    rerender({ page: 2 });
+
+    await waitFor(() => expect(result.current.currentPage).toBe(2));
+  });
+});

--- a/frontend/pages/sites/$siteId/SideNav.jsx
+++ b/frontend/pages/sites/$siteId/SideNav.jsx
@@ -23,14 +23,14 @@ const SideNav = ({ config, siteId }) => (
         // eslint-disable-next-line import/namespace
         const IconComponent = icons[conf.icon];
         return (
-          <li className="margin-y-2" key={conf.route}>
+          <li className="margin-y-2" key={conf.path}>
             <Link
               className="display-flex flex-align-center"
-              to={`/sites/${siteId}/${conf.route}`}
+              to={`/sites/${siteId}/${conf.path}`}
             >
               <IconComponent />{' '}
               <span className="flex-fill margin-left-1 text-no-underline">
-                {conf.display}
+                {conf.title}
               </span>
             </Link>
           </li>
@@ -43,8 +43,8 @@ const SideNav = ({ config, siteId }) => (
 SideNav.propTypes = {
   config: PropTypes.arrayOf(
     PropTypes.shape({
-      display: PropTypes.string.isRequired,
-      route: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+      path: PropTypes.string.isRequired,
       icon: PropTypes.string.isRequired,
     }),
   ).isRequired,

--- a/frontend/pages/sites/$siteId/index.jsx
+++ b/frontend/pages/sites/$siteId/index.jsx
@@ -1,72 +1,33 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { useParams, useLocation, useSearchParams, Outlet } from 'react-router-dom';
+import {
+  matchPath,
+  useParams,
+  useLocation,
+  useSearchParams,
+  Outlet,
+} from 'react-router-dom';
 
 import { currentSite } from '@selectors/site';
 import { getOrgById } from '@selectors/organization';
 import AlertBanner from '@shared/alertBanner';
 import LoadingIndicator from '@shared/LoadingIndicator';
+import siteRoutes from './siteRoutes';
 
 import SideNav from './SideNav';
 import PagesHeader from './PagesHeader';
 
-export const SITE_NAVIGATION_CONFIG = [
-  {
-    display: 'Custom Domains',
-    route: 'custom-domains',
-    icon: 'IconLink',
-  },
-  {
-    display: 'Build history',
-    route: 'builds',
-    icon: 'IconBook',
-  },
-  {
-    display: 'Report history',
-    route: 'reports',
-    icon: 'IconReport',
-  },
-  {
-    display: 'Site settings',
-    route: 'settings',
-    icon: 'IconGear',
-  },
-  {
-    display: 'Published builds',
-    route: 'published',
-    icon: 'IconCloudUpload',
-  },
-];
+export const SITE_NAVIGATION_CONFIG = siteRoutes.filter((route) => route.showInSidebar);
 
-{
-  process.env.FEATURE_FILE_STORAGE_SERVICE === 'true' &&
-    SITE_NAVIGATION_CONFIG.push({
-      display: 'Public storage',
-      route: 'storage',
-      icon: 'IconAttachment',
-    });
-}
-
-export const SITE_TITLE_CONFIG = [
-  ...SITE_NAVIGATION_CONFIG,
-  {
-    display: 'Reports for build #',
-    route: 'reports',
-  },
-  {
-    display: 'Logs for build #',
-    route: 'logs',
-  },
-];
-
-function getPageTitle(pathname, buildId = null) {
-  const route = pathname.split('/').pop();
-  const routeConf = SITE_TITLE_CONFIG.find((conf) => conf.route === route);
-  if (routeConf) {
+function getPageTitle(location, buildId = null) {
+  const matchingRoute = siteRoutes.find((route) =>
+    matchPath('sites/:id/' + route.path, location.pathname),
+  );
+  if (matchingRoute) {
     if (buildId) {
-      return routeConf.display + buildId;
+      return matchingRoute.title + buildId;
     }
-    return routeConf.display;
+    return matchingRoute.title;
   }
   return '';
 }
@@ -120,7 +81,7 @@ export function SiteContainer() {
     return <AlertBanner status="error" header="" message={errorMessage} />;
   }
 
-  const pageTitle = getPageTitle(location.pathname, buildId);
+  const pageTitle = getPageTitle(location, buildId);
   const navConig = SITE_NAVIGATION_CONFIG.filter(
     (navItem) => !(navItem.route === 'reports' && site.SiteBuildTasks.length === 0),
   );

--- a/frontend/pages/sites/$siteId/siteRoutes.js
+++ b/frontend/pages/sites/$siteId/siteRoutes.js
@@ -1,0 +1,93 @@
+import SiteSettings from './settings';
+import SiteBuildList from './builds';
+import BuildLogs from './builds/$buildId/logs';
+import PublishedBranchesTable from './published';
+import PublishedFilesTable from './published/$name';
+import DomainList from './custom-domains';
+import NewCustomDomain from './custom-domains/new';
+import EditCustomDomain from './custom-domains/$domainId/edit';
+import Reports from './reports';
+import FileStorage from './storage';
+import { FileStorageLogs } from './storage/logs';
+export default [
+  {
+    Component: DomainList,
+    title: 'Custom Domains',
+    path: 'custom-domains',
+    icon: 'IconLink',
+    showInSidebar: true,
+  },
+  {
+    Component: NewCustomDomain,
+    title: 'New Custom Domain',
+    path: 'custom-domains/new',
+  },
+  {
+    Component: EditCustomDomain,
+    title: 'Edit custom domain',
+    path: 'custom-domains/:domainId/edit',
+  },
+  {
+    Component: SiteBuildList,
+    title: 'Build history',
+    path: 'builds',
+    icon: 'IconBook',
+    showInSidebar: true,
+  },
+  {
+    Component: BuildLogs,
+    title: 'Logs for build #',
+    path: 'builds/:buildId/logs',
+  },
+  ...(process.env.FEATURE_BUILD_TASKS === 'true'
+    ? [
+        {
+          Component: Reports,
+          title: 'Report history',
+          path: 'reports',
+          icon: 'IconReport',
+          showInSidebar: true,
+        },
+      ]
+    : []),
+  {
+    Component: SiteSettings,
+    title: 'Site settings',
+    path: 'settings',
+    icon: 'IconGear',
+    showInSidebar: true,
+  },
+
+  ...(process.env.FEATURE_FILE_STORAGE_SERVICE === 'true'
+    ? [
+        {
+          Component: FileStorage,
+          title: 'Public file storage',
+          path: 'storage',
+          icon: 'IconCloudUpload',
+          showInSidebar: true,
+        },
+      ]
+    : []),
+  ...(process.env.FEATURE_FILE_STORAGE_SERVICE === 'true'
+    ? [
+        {
+          Component: FileStorageLogs,
+          title: 'Public storage file logs',
+          path: 'storage/logs',
+        },
+      ]
+    : []),
+  {
+    Component: PublishedBranchesTable,
+    title: 'Site previews',
+    path: 'published',
+    icon: 'IconGlobe',
+    showInSidebar: true,
+  },
+  {
+    Component: PublishedFilesTable,
+    title: 'Site preview',
+    path: 'published/:name',
+  },
+];

--- a/frontend/pages/sites/$siteId/siteRoutes.test.jsx
+++ b/frontend/pages/sites/$siteId/siteRoutes.test.jsx
@@ -1,0 +1,66 @@
+import React, { isValidElement } from 'react';
+import siteRoutes from './siteRoutes';
+import '@testing-library/jest-dom';
+
+jest.mock('pretty-bytes', () => ({
+  __esModule: true,
+  default: jest.fn((bytes) => `${bytes} B`),
+}));
+
+describe('siteRoutes', () => {
+  const originalEnv = process.env;
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('feature flags', () => {
+    it('should include Reports when FEATURE_BUILD_TASKS is true', () => {
+      process.env.FEATURE_BUILD_TASKS = 'true';
+      const routes = jest.requireActual('./siteRoutes').default;
+      expect(routes.some((route) => route.path === 'reports')).toBe(true);
+    });
+
+    it('should not include Reports when FEATURE_BUILD_TASKS is false', () => {
+      process.env.FEATURE_BUILD_TASKS = 'false';
+      const routes = jest.requireActual('./siteRoutes').default;
+      expect(routes.some((route) => route.path === 'reports')).toBe(false);
+    });
+
+    it('should include storage routes when FEATURE_FILE_STORAGE_SERVICE is true', () => {
+      process.env.FEATURE_FILE_STORAGE_SERVICE = 'true';
+      const routes = jest.requireActual('./siteRoutes').default;
+      expect(routes.some((route) => route.path === 'storage')).toBe(true);
+      expect(routes.some((route) => route.path === 'storage/logs')).toBe(true);
+    });
+
+    // eslint-disable-next-line max-len
+    it('should not include storage routes when FEATURE_FILE_STORAGE_SERVICE is false', () => {
+      process.env.FEATURE_FILE_STORAGE_SERVICE = 'false';
+      const routes = jest.requireActual('./siteRoutes').default;
+      expect(routes.some((route) => route.path === 'storage')).toBe(false);
+      expect(routes.some((route) => route.path === 'storage/logs')).toBe(false);
+    });
+  });
+
+  describe('each route Component', () => {
+    it('should be a renderable React component', () => {
+      siteRoutes.forEach((route) => {
+        expect(isValidElement(<route.Component />)).toBe(true);
+      });
+    });
+
+    it('should be a valid function or memoized component', () => {
+      siteRoutes.forEach((route) => {
+        const component = route.Component;
+        expect(
+          typeof component === 'function' ||
+            component.$$typeof === Symbol.for('react.memo'),
+        ).toBe(true);
+      });
+    });
+  });
+});

--- a/frontend/pages/sites/$siteId/storage/NewFileOrFolder.jsx
+++ b/frontend/pages/sites/$siteId/storage/NewFileOrFolder.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import FileUpload from '@shared/FileUpload';
-import { IconFolder } from '@shared/icons';
-
+import { IconFolder, IconAttachment } from '@shared/icons';
+import AlertBanner from '@shared/alertBanner';
+import { Link } from 'react-router-dom';
 const NewFileOrFolder = ({ onUpload, onCreateFolder }) => {
   const [folderName, setFolderName] = useState('');
   const [creatingFolder, setCreatingFolder] = useState(false);
@@ -30,16 +31,36 @@ const NewFileOrFolder = ({ onUpload, onCreateFolder }) => {
 
     setCreatingFolder(false);
   };
-
+  const docsLink = 'https://cloud.gov/pages/documentation'; // TODO: update link
+  const message = (
+    <>
+      Before uploading, carefully review your file to ensure it does not contain any
+      Personally Identifiable Information (PII) or sensitive data. We{' '}
+      <Link to="./storage/logs"> log every file upload and deletion </Link> for security
+      tracking. For more about Public File Storage, review the{' '}
+      <a target="_blank" rel="noreferrer" className="usa-link" href={docsLink}>
+        documentation
+      </a>
+      .
+    </>
+  );
   return (
     <div className="new-file-or-folder">
       {errorMessage && <div className="usa-error-message">{errorMessage}</div>}
       {showFileDropZone && (
-        <FileUpload
-          onUpload={onUpload}
-          onCancel={() => setShowFileDropZone(false)}
-          triggerOnMount
-        />
+        <>
+          <AlertBanner
+            className="margin-top-1"
+            status="warning"
+            message={message}
+            alertRole={false}
+          />
+          <FileUpload
+            onUpload={onUpload}
+            onCancel={() => setShowFileDropZone(false)}
+            triggerOnMount
+          />
+        </>
       )}
       {showFolderNameField && (
         <div className="new-folder grid-row flex-align-center margin-y-1">
@@ -71,24 +92,30 @@ const NewFileOrFolder = ({ onUpload, onCreateFolder }) => {
       )}
       <div className="margin-y-1">
         {!showFolderNameField && !showFileDropZone && (
-          <button
-            type="button"
-            className="usa-button usa-button--outline"
-            onClick={() => setShowFileDropZone(true)}
-          >
-            <IconFolder className="usa-icon" />
-            Upload files
-          </button>
-        )}
-        {!showFileDropZone && !showFolderNameField && (
-          <button
-            type="button"
-            className="usa-button usa-button--outline"
-            onClick={() => setShowFolderNameField(true)}
-          >
-            <IconFolder className="usa-icon" />
-            New folder
-          </button>
+          <>
+            <button
+              type="button"
+              className="usa-button"
+              onClick={() => setShowFileDropZone(true)}
+            >
+              <IconAttachment className="usa-icon" />
+              Upload files
+            </button>
+            <button
+              type="button"
+              className="usa-button usa-button--outline"
+              onClick={() => setShowFolderNameField(true)}
+            >
+              <IconFolder className="usa-icon" />
+              New folder
+            </button>
+            <Link
+              className="usa-button usa-button--unstyled text-top padding-105"
+              to="./logs"
+            >
+              View file history logs
+            </Link>
+          </>
         )}
       </div>
     </div>

--- a/frontend/pages/sites/$siteId/storage/NewFileOrFolder.test.jsx
+++ b/frontend/pages/sites/$siteId/storage/NewFileOrFolder.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import NewFileOrFolder from './NewFileOrFolder';
 import prettyBytes from 'pretty-bytes';
@@ -9,13 +10,19 @@ jest.mock('pretty-bytes', () => jest.fn());
 const mockOnUpload = jest.fn();
 const mockOnCreateFolder = jest.fn();
 
+jest.mock('@shared/alertBanner', () => {
+  return jest.fn(() => null);
+});
+
 const renderComponent = (props = {}) => {
   return render(
-    <NewFileOrFolder
-      onUpload={mockOnUpload}
-      onCreateFolder={mockOnCreateFolder}
-      {...props}
-    />,
+    <MemoryRouter>
+      <NewFileOrFolder
+        onUpload={mockOnUpload}
+        onCreateFolder={mockOnCreateFolder}
+        {...props}
+      />
+    </MemoryRouter>,
   );
 };
 

--- a/frontend/pages/sites/$siteId/storage/index.js
+++ b/frontend/pages/sites/$siteId/storage/index.js
@@ -17,6 +17,22 @@ function FileStoragePage() {
   const { id } = useParams();
   const site = useSelector((state) => currentSite(state.sites, id));
   const fileStorageServiceId = site.fileStorageServiceId;
+  if (!fileStorageServiceId) {
+    const errorMessage = (
+      <span>
+        This site does not have Public File Storage enabled. Please contact{' '}
+        <a
+          title="Email support to launch a custom domain."
+          href="mailto:pages-support@cloud.gov"
+        >
+          pages-support@cloud.gov
+        </a>{' '}
+        to request access.
+      </span>
+    );
+    return <AlertBanner status="info" header="" message={errorMessage} />;
+  }
+
   const [searchParams, setSearchParams] = useSearchParams();
   let path = decodeURIComponent(searchParams.get('path') || '/').replace(/^\/+/, '/');
   // Ensure path always ends in "/" because we use it for asset url links

--- a/frontend/pages/sites/$siteId/storage/logs/index.js
+++ b/frontend/pages/sites/$siteId/storage/logs/index.js
@@ -1,20 +1,147 @@
-import React from 'react';
-// import PropTypes from 'prop-types';
+import React, { useRef } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import useFileStorageLogs from '@hooks/useFileStorageLogs';
+import PropTypes from 'prop-types';
+import QueryPage from '@shared/layouts/QueryPage';
+import Pagination from '@shared/Pagination';
+import AlertBanner from '@shared/alertBanner';
 
-import LoadingIndicator from '@shared/LoadingIndicator';
-const isLoading = false;
+import { dateAndTimeSimple, timeFrom } from '@util/datetime';
+import { currentSite } from '@selectors/site';
 
 function FileStorageLogs() {
-  if (isLoading) {
-    return <LoadingIndicator />;
+  const { id } = useParams();
+  const site = useSelector((state) => currentSite(state.sites, id));
+  const fileStorageServiceId = site.fileStorageServiceId;
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initalPage = parseInt(searchParams.get('page')) || 1;
+
+  if (!fileStorageServiceId) {
+    const errorMessage = (
+      <span>
+        This site does not have Public File Storage enabled. Please contact{' '}
+        <a
+          title="Email support to launch a custom domain."
+          href="mailto:pages-support@cloud.gov"
+        >
+          pages-support@cloud.gov
+        </a>{' '}
+        to request access.
+      </span>
+    );
+    return <AlertBanner status="info" header="" message={errorMessage} />;
   }
 
+  const { data, isPending, error, currentPage, totalPages, totalItems } =
+    useFileStorageLogs(fileStorageServiceId, initalPage);
+  const scrollTo = useRef(null);
+  function scrollToTop() {
+    return scrollTo.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+  const handlePageChange = (newPage) => {
+    if (newPage === currentPage) return;
+    setSearchParams((prev) => {
+      const newParams = new URLSearchParams(prev);
+      newParams.set('page', newPage);
+      return newParams;
+    });
+    scrollToTop();
+  };
+
   return (
-    <div className="grid-col-12">
-      <slot></slot>
-    </div>
+    <QueryPage
+      data={data}
+      showErrorIfEmpty={true}
+      error={error}
+      errorMessage={error?.message}
+      isPending={isPending}
+      isPlaceholderData={false}
+    >
+      <div id="top" ref={scrollTo} tabIndex="-1" />
+      <LogList logs={data} />
+      <Pagination
+        currentPage={currentPage || 0}
+        totalPages={totalPages || 0}
+        totalItems={totalItems || 0}
+        itemsOnCurrentPage={data?.length || 0}
+        onPageChange={handlePageChange}
+      />
+    </QueryPage>
   );
 }
+// see backend for possible messages in /api/models/file-storage-user-action.js
+function parseAction(action) {
+  switch (action) {
+    case 'UPLOAD_FILE':
+      return `uploaded`;
+    case 'CREATE_DIRECTORY':
+      return `created`;
+    case 'DELETE_FILE':
+      return `deleted`;
+    case 'RENAME_FILE':
+      return `renamed`;
+    case 'CREATE_ORGANIZATION_FILE_STORAGE_SERVICE':
+    case 'CREATE_SITE_FILE_STORAGE_SERVICE':
+      return `initialized file storage service`;
+    default:
+      return action;
+  }
+}
+
+const LogList = ({ logs = [] }) => {
+  const TABLE_CAPTION = `
+    Listing all file history
+    `;
+
+  return (
+    <table
+      className="
+        usa-table usa-table--borderless width-full margin-y-0 file-storage-logs
+      "
+    >
+      <caption className="usa-sr-only">{TABLE_CAPTION}</caption>
+      <thead>
+        <tr>
+          <th scope="col" role="columnheader">
+            Action
+          </th>
+          <th scope="col" className="width-card" role="columnheader">
+            Timestamp
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {logs?.map(({ id, fileKey, method, description, email, createdAt }) => (
+          <tr key={`${id}_${method}`}>
+            <td className="file-name-cell" data-label="Action">
+              <span className="text-bold">{email}</span> {parseAction(description)}{' '}
+              <span title={`/${fileKey}`} className="font-mono-xs text-ls-neg-1">
+                /{fileKey}
+              </span>
+            </td>
+
+            <td data-label="Timestamp">
+              <span title={dateAndTimeSimple(createdAt)}>{timeFrom(createdAt)}</span>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+LogList.propTypes = {
+  logs: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number,
+      method: PropTypes.string,
+      fileKey: PropTypes.string,
+      createdAt: PropTypes.string,
+      email: PropTypes.string,
+    }),
+  ),
+};
 
 export { FileStorageLogs };
 export default FileStorageLogs;

--- a/frontend/pages/sites/$siteId/storage/logs/index.test.jsx
+++ b/frontend/pages/sites/$siteId/storage/logs/index.test.jsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import { FileStorageLogs } from './index';
+import useFileStorageLogs from '@hooks/useFileStorageLogs';
+// eslint-disable-next-line max-len
+import { getFileStorageLogsData } from '../../../../../../test/frontend/support/data/fileStorageData';
+
+import { currentSite } from '@selectors/site';
+import { useSelector } from 'react-redux';
+
+// Mock the hooks and utilities
+jest.mock('@hooks/useFileStorageLogs');
+jest.mock('@selectors/site');
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+
+// Mock data
+const mockLogs = getFileStorageLogsData().data;
+
+const mockSite = {
+  id: '123',
+  fileStorageServiceId: 'fs-123',
+};
+
+// Setup function
+const setup = (initialEntries = ['/sites/123/storage/logs']) => {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route path="/sites/:id/storage/logs" element={<FileStorageLogs />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+};
+
+describe('storage/logs/index', () => {
+  beforeEach(() => {
+    // Reset all mocks
+    jest.clearAllMocks();
+
+    // Setup default mock implementations
+    currentSite.mockReturnValue(mockSite);
+    useSelector.mockImplementation((selector) =>
+      selector({ sites: { data: [mockSite] } }),
+    );
+    useFileStorageLogs.mockReturnValue({
+      data: mockLogs,
+      isPending: false,
+      error: null,
+      currentPage: 1,
+      totalPages: 2,
+      totalItems: 20,
+    });
+  });
+
+  it('renders the file storage logs table', () => {
+    setup();
+
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getAllByText(/user@example.com/i)).toHaveLength(mockLogs.length);
+    expect(screen.getByText(/uploaded/i)).toBeInTheDocument();
+    expect(screen.getByText(/\/test.txt/i)).toBeInTheDocument();
+  });
+
+  it('shows loading state', () => {
+    useFileStorageLogs.mockReturnValue({
+      data: [],
+      isPending: true,
+      error: null,
+    });
+
+    setup();
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('shows a message if there is no file storage service id for this site', () => {
+    const siteWithoutFileStorage = {
+      id: '123',
+    };
+
+    currentSite.mockReturnValueOnce(siteWithoutFileStorage);
+    useSelector.mockImplementationOnce((selector) =>
+      selector({ sites: { data: [siteWithoutFileStorage] } }),
+    );
+
+    setup();
+
+    expect(
+      screen.getByText(/This site does not have Public File Storage enabled/i),
+    ).toBeInTheDocument();
+    expect(useFileStorageLogs).not.toHaveBeenCalled();
+  });
+
+  it('shows error state', () => {
+    useFileStorageLogs.mockReturnValue({
+      data: [],
+      isPending: false,
+      error: new Error('Failed to load'),
+      errorMessage: 'Failed to load',
+    });
+
+    setup();
+
+    expect(screen.getByText(/Failed to load/i)).toBeInTheDocument();
+  });
+
+  it('parses different action types correctly', () => {
+    useFileStorageLogs.mockReturnValue({
+      data: mockLogs,
+      isPending: false,
+      error: null,
+    });
+
+    setup();
+
+    expect(screen.getByText(/uploaded/i)).toBeInTheDocument();
+    expect(screen.getByText(/created/i)).toBeInTheDocument();
+    expect(screen.getByText(/deleted/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/routes.js
+++ b/frontend/routes.js
@@ -8,21 +8,11 @@ import OrganizationEdit from '@pages/organizations/edit';
 import Sites from '@pages/sites';
 import AddSite from '@pages/sites/new';
 import SiteContainer from '@pages/sites/$siteId';
-import SiteSettings from '@pages/sites/$siteId/settings';
-import SiteBuildList from '@pages/sites/$siteId/builds';
-import BuildLogs from '@pages/sites/$siteId/builds/$buildId/logs';
-import PublishedBranchesTable from '@pages/sites/$siteId/published';
-import PublishedFilesTable from '@pages/sites/$siteId/published/$name';
-import DomainList from '@pages/sites/$siteId/custom-domains';
-import NewCustomDomain from '@pages/sites/$siteId/custom-domains/new';
-import EditCustomDomain from '@pages/sites/$siteId/custom-domains/$domainId/edit';
-import Reports from '@pages/sites/$siteId/reports';
-import FileStorage from '@pages/sites/$siteId/storage';
-import FileStorageLog from '@pages/sites/$siteId/storage/logs';
 import Settings from '@pages/settings';
 import NotFound from '@pages/NotFound';
 import ErrorMessage from '@pages/ErrorMessage';
 
+import siteRoutes from '@pages/sites/$siteId/siteRoutes';
 import siteActions from './actions/siteActions';
 import userActions from './actions/userActions';
 import organizationActions from './actions/organizationActions';
@@ -38,7 +28,6 @@ const fetchInitialData = () => {
   siteActions.fetchSites();
   organizationActions.fetchOrganizations();
 };
-
 export default (
   <Route
     path="/"
@@ -51,24 +40,9 @@ export default (
     <Route path="sites/new" element={<AddSite />} />
     <Route path="sites/:id" element={<SiteContainer />}>
       <Route path="" loader={() => redirect('builds')} />
-      <Route path="settings" element={<SiteSettings />} />
-      <Route path="published" element={<PublishedBranchesTable />} />
-      <Route path="published/:name" element={<PublishedFilesTable />} />
-      <Route path="builds" element={<SiteBuildList />} />
-      <Route path="custom-domains" element={<DomainList />} />
-      <Route path="custom-domains/new" element={<NewCustomDomain />} />
-      <Route path="custom-domains/:domainId/edit" element={<EditCustomDomain />} />
-      {process.env.FEATURE_FILE_STORAGE_SERVICE === 'true' && (
-        <>
-          <Route path="storage" element={<FileStorage />} />
-          <Route path="storage/logs" element={<FileStorageLog />} />
-        </>
-      )}
-      <Route path="builds/:buildId/logs" element={<BuildLogs />} />
-      <Route path="scans" loader={() => redirect('../reports')} />
-      {process.env.FEATURE_BUILD_TASKS === 'active' && (
-        <Route path="reports" element={<Reports />} />
-      )}
+      {siteRoutes.map((route) => (
+        <Route key={route.title} path={route.path} Component={route.Component} />
+      ))}
     </Route>
     <Route path="settings" element={<Settings />} />
     <Route path="*" element={<NotFound />} />

--- a/frontend/sass/_tables.scss
+++ b/frontend/sass/_tables.scss
@@ -721,3 +721,10 @@ a {
 .file-input__remove:hover + span {
   text-decoration: line-through;
 }
+
+.file-storage-logs {
+  .file-name-cell {
+    max-width: 0;
+    word-wrap: break-word;
+  }
+}

--- a/frontend/shared/Pagination.jsx
+++ b/frontend/shared/Pagination.jsx
@@ -58,7 +58,7 @@ const Pagination = ({
       pagination__label text-center margin-top-1 margin-bottom-3 margin-x-auto text-base
       "
       >
-        Showing {itemsOnCurrentPage} of {totalItems} total files in this folder
+        Showing {itemsOnCurrentPage} of {totalItems} total
       </p>
       {totalPages > 1 && (
         <nav className="usa-pagination bg-base-lightest" aria-label="Pagination">

--- a/frontend/shared/Pagination.test.jsx
+++ b/frontend/shared/Pagination.test.jsx
@@ -24,9 +24,7 @@ describe('Pagination Component', () => {
 
   test('renders pagination label correctly', () => {
     renderPagination();
-    expect(
-      screen.getByText(/Showing 10 of 111 total files in this folder/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Showing 10 of 111 total/i)).toBeInTheDocument();
   });
 
   test('displays Previous button disabled on first page', () => {

--- a/frontend/support/nocks/fileStorage.js
+++ b/frontend/support/nocks/fileStorage.js
@@ -1,5 +1,8 @@
 import nock from 'nock';
-import { getFileStorageData } from '../../../test/frontend/support/data/fileStorageData';
+import {
+  getFileStorageData,
+  getFileStorageLogsData,
+} from '../../../test/frontend/support/data/fileStorageData';
 
 const BASE_URL = 'http://localhost:80';
 
@@ -82,4 +85,22 @@ export async function createPublicDirectoryError(
   nock(BASE_URL)
     .post(`/v0/file-storage/${fileStorageId}/directory`, { parent, name })
     .reply(400, { error: true, message });
+}
+
+export async function getFileStorageLogs(
+  { fileStorageServiceId, page = 1 },
+  { times = 1 } = {},
+) {
+  nock(BASE_URL)
+    .get(`/v0/file-storage/${fileStorageServiceId}/user-actions/`)
+    .query({ page })
+    .times(times)
+    .reply(200, getFileStorageLogsData(page));
+}
+
+export async function getFileStorageLogsError({ fileStorageServiceId, page = 1 }) {
+  nock(BASE_URL)
+    .get(`/v0/file-storage/${fileStorageServiceId}/user-actions/`)
+    .query({ page })
+    .reply(400, { error: true, message: 'Failed to fetch storage logs' });
 }

--- a/frontend/util/federalistApi.js
+++ b/frontend/util/federalistApi.js
@@ -445,9 +445,15 @@ export default {
     });
   },
 
-  fetchAllPublicFilesHistory(fileStorageId) {
-    return request(`file-storage/${fileStorageId}/user-actions/`, {
-      method: 'GET',
-    });
+  fetchAllPublicFilesHistory(fileStorageId, page = 1) {
+    return request(
+      `file-storage/${fileStorageId}/user-actions/?page=${page}`,
+      {
+        method: 'GET',
+      },
+      {
+        handleHttpError: false,
+      },
+    );
   },
 };

--- a/test/frontend/support/data/fileStorageData.js
+++ b/test/frontend/support/data/fileStorageData.js
@@ -16,3 +16,33 @@ export function getFileStorageData(page = 1) {
     data: generateMockFiles(page),
   };
 }
+export function getFileStorageLogsData(page = 1) {
+  return {
+    data: [
+      {
+        id: 1,
+        fileKey: 'test.txt',
+        description: 'UPLOAD_FILE',
+        createdAt: '2024-02-14T12:00:00Z',
+        email: 'user@example.com',
+      },
+      {
+        id: 2,
+        fileKey: 'folder',
+        description: 'CREATE_DIRECTORY',
+        createdAt: '2024-02-14T13:00:00Z',
+        email: 'user@example.com',
+      },
+      {
+        id: 3,
+        fileKey: 'old.txt',
+        description: 'DELETE_FILE',
+        createdAt: '2024-02-14T14:00:00Z',
+        email: 'user@example.com',
+      },
+    ],
+    currentPage: page,
+    totalPages: 2,
+    totalItems: 10,
+  };
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Refactors sidenav and routes in order to accept multiple path patterns that end in `/logs`
    - Renames "Uploaded Files" to "Published Builds" in sidenav
- Uses a FileStorageHistory hook to fill out the content for: 
    - a new file storage logs UI component
- Adds links to this logs page from the NewFileOrFolder component
- Adds warning message (and a link to docs, TBD) about viewable logs for file actions, per Kudeha

![Screenshot 2025-03-27 at 1 33 21 PM](https://github.com/user-attachments/assets/9eaea66e-2432-49a6-a14a-c37528cb92c6)

![Screenshot 2025-03-27 at 2 30 28 PM](https://github.com/user-attachments/assets/413affe3-5c08-4f1b-92d2-fffe3e898d2b)

![Screenshot 2025-03-27 at 2 54 33 PM](https://github.com/user-attachments/assets/3bac1dbe-e08b-486b-8982-f1fd666073f8)

![Screenshot 2025-03-27 at 2 30 41 PM](https://github.com/user-attachments/assets/dd08e8bf-b8b2-4e4a-baba-8ac6c0b1c275)

![Screenshot 2025-03-27 at 2 31 01 PM](https://github.com/user-attachments/assets/4b959197-f1ed-452f-b747-d63e982b80aa)

## security considerations
- None other than what has already been noted / addressed
- 