### PR TITLE
feat: Create a file upload hook to queue uploads

### DIFF
--- a/api/services/file-storage/index.js
+++ b/api/services/file-storage/index.js
@@ -251,7 +251,7 @@ class SiteFileStorageSerivce {
 
     await this.#hasDuplicateKey(key, 'file');
 
-    await this.s3Client.putObject(fileBuffer, key);
+    await this.s3Client.putObject(fileBuffer, key, { ContentType: type });
 
     const fsf = await FileStorageFile.create({
       name,

--- a/frontend/hooks/useMultiFileUpload.js
+++ b/frontend/hooks/useMultiFileUpload.js
@@ -1,0 +1,108 @@
+import { useState, useCallback, useEffect } from 'react';
+
+// interface FileUploadItem {
+//   data: File;
+//   id: string;
+//   status: 'pending' | 'queued' | 'uploading' | 'success' | 'error';
+//   message?: string
+// }
+
+// interface UseMultiFileUploadOptions {
+//   maxConcurrentUploads?: number;
+//   onUpload: (file: File) => Promise<any>;
+// }
+
+export const useMultiFileUpload = ({ maxConcurrentUploads = 2, onUpload }) => {
+  const [isUploading, setIsUploading] = useState(false);
+  const [files, setFiles] = useState([]);
+
+  // eslint-disable-next-line sonarjs/pseudo-random
+  const generateFileId = () => Math.random().toString(36).substring(2, 15);
+
+  const addFiles = useCallback((newFiles) => {
+    const fileItems = newFiles.map((data) => ({
+      data,
+      id: generateFileId(),
+      status: 'queued',
+      message: null,
+    }));
+
+    setFiles((prevFiles) => [...prevFiles, ...fileItems]);
+  }, []);
+
+  const clearFiles = useCallback(() => setFiles(() => []));
+
+  const uploadFile = useCallback(
+    async (fileItem) => {
+      try {
+        // Update the uploading status of the files
+        setFiles((prevFiles) =>
+          prevFiles.map((f) =>
+            f.id === fileItem.id ? { ...f, status: 'uploading' } : f,
+          ),
+        );
+
+        // Perform the upload
+        await onUpload(fileItem.data);
+
+        // Update state on success
+        // Remove successful upload
+        setFiles((prevFiles) =>
+          prevFiles.map((f) =>
+            f.id === fileItem.id ? { ...f, status: 'success', message: 'Success.' } : f,
+          ),
+        );
+      } catch (error) {
+        // Update state on error
+        const message = error?.message || `Unable to upload ${fileItem.name}`;
+
+        setFiles((prevFiles) =>
+          prevFiles.map((f) =>
+            f.id === fileItem.id ? { ...f, status: 'error', message } : f,
+          ),
+        );
+      }
+    },
+    [onUpload],
+  );
+
+  const startUploads = useCallback(async () => {
+    setIsUploading(() => true);
+  }, [files]);
+
+  useEffect(() => {
+    // Manage concurrent uploads
+    function run() {
+      if (isUploading) {
+        const pendingFiles = files.filter((f) => f.status === 'queued');
+
+        if (pendingFiles.length === 0) {
+          return setIsUploading(() => false);
+        }
+
+        const filesToUpload = pendingFiles.slice(0, maxConcurrentUploads);
+
+        return Promise.allSettled(
+          filesToUpload.map((fileItem) => {
+            return uploadFile(fileItem);
+          }),
+        );
+      }
+    }
+
+    run();
+  }, [files, isUploading, maxConcurrentUploads, uploadFile]);
+
+  const removeFile = useCallback((fileId) => {
+    setFiles((prevFiles) => prevFiles.filter((f) => f.id !== fileId));
+  }, []);
+
+  return {
+    files,
+    addFiles,
+    clearFiles,
+    isUploading,
+    removeFile,
+    startUploads,
+  };
+};

--- a/frontend/hooks/useMultiFileUpload.test.js
+++ b/frontend/hooks/useMultiFileUpload.test.js
@@ -1,0 +1,165 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useMultiFileUpload } from './useMultiFileUpload';
+
+describe('useMultiFileUpload Hook', () => {
+  // Mock file creation utility
+  const createMockFile = (name = 'test.txt', size = 1000, type = 'text/plain') =>
+    new File([new ArrayBuffer(size)], name, { type });
+
+  // Mock upload function
+  const mockOnUpload = jest.fn(() => Promise.resolve());
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('addFiles', () => {
+    it('should add files to the queue', async () => {
+      const { result } = renderHook(() =>
+        useMultiFileUpload({
+          urlPath: '/upload',
+          onUpload: mockOnUpload,
+        }),
+      );
+
+      const mockFiles = [createMockFile('file1.txt'), createMockFile('file2.txt')];
+
+      await waitFor(() => result.current.addFiles(mockFiles));
+
+      expect(result.current.files).toHaveLength(2);
+      expect(result.current.files[0].status).toBe('queued');
+    });
+  });
+
+  describe('clearFiles', () => {
+    it('should clear all added files in the queue', async () => {
+      const { result } = renderHook(() =>
+        useMultiFileUpload({
+          urlPath: '/upload',
+          onUpload: mockOnUpload,
+        }),
+      );
+
+      const mockFiles = [createMockFile('file1.txt'), createMockFile('file2.txt')];
+
+      await waitFor(() => result.current.addFiles(mockFiles));
+
+      expect(result.current.files).toHaveLength(2);
+      expect(result.current.files[0].status).toBe('queued');
+
+      await waitFor(() => result.current.clearFiles());
+
+      expect(result.current.files).toHaveLength(0);
+    });
+  });
+
+  describe('removeFile', () => {
+    it('should remove a specific file from the queue', async () => {
+      const { result } = renderHook(() =>
+        useMultiFileUpload({
+          urlPath: '/upload',
+          onUpload: mockOnUpload,
+        }),
+      );
+
+      const mockFiles = [createMockFile('file1.txt'), createMockFile('file2.txt')];
+
+      await waitFor(() => {
+        result.current.addFiles(mockFiles);
+      });
+
+      const fileIdToRemove = result.current.files[0].id;
+
+      await waitFor(() => {
+        result.current.removeFile(fileIdToRemove);
+      });
+
+      expect(result.current.files).toHaveLength(1);
+      expect(result.current.files[0].data.name).toBe('file2.txt');
+    });
+  });
+
+  describe('startUploads', () => {
+    it('should start uploading queued files', async () => {
+      const mockOnUpload = jest.fn(() => Promise.resolve());
+      const { result } = renderHook(() =>
+        useMultiFileUpload({
+          onUpload: mockOnUpload,
+        }),
+      );
+
+      const mockFiles = [
+        createMockFile('file1.txt'),
+        createMockFile('file2.txt'),
+        createMockFile('file3.txt'),
+      ];
+
+      await waitFor(() => result.current.addFiles(mockFiles));
+      await waitFor(() => result.current.startUploads());
+      await waitFor(() => {
+        const successful = result.current.files.filter((f) => f.status === 'success');
+
+        if (successful.length > 0) {
+          expect(successful).toHaveLength(mockFiles.lengt);
+        }
+      });
+
+      expect(mockOnUpload).toHaveBeenCalledTimes(mockFiles.length);
+      expect(result.current.isUploading).toBeFalsy();
+      expect(result.current.files).toHaveLength(mockFiles.length);
+    });
+
+    it('should handle error uploads', async () => {
+      const errorMessage = new Error('Roro');
+      const mockOnUpload = jest.fn(() => Promise.reject(errorMessage));
+      const { result } = renderHook(() =>
+        useMultiFileUpload({
+          urlPath: '/upload',
+          onUpload: mockOnUpload,
+        }),
+      );
+
+      const mockFiles = [createMockFile('file1.txt')];
+
+      await waitFor(() => result.current.addFiles(mockFiles));
+      await waitFor(() => result.current.startUploads());
+      await waitFor(() =>
+        expect(result.current.files.filter((f) => f.status === 'error')).toHaveLength(
+          mockFiles.length,
+        ),
+      );
+
+      const errored = result.current.files.filter((f) => f.status === 'error');
+
+      expect(mockOnUpload).toHaveBeenCalledTimes(mockFiles.length);
+      expect(result.current.files).toHaveLength(mockFiles.length);
+      errored.map((file) => file.message === errorMessage);
+    });
+
+    it('should handle error with default error message', async () => {
+      const mockOnUpload = jest.fn(() => Promise.reject());
+      const { result } = renderHook(() =>
+        useMultiFileUpload({
+          urlPath: '/upload',
+          onUpload: mockOnUpload,
+        }),
+      );
+
+      const mockFiles = [createMockFile('file1.txt')];
+
+      await waitFor(() => result.current.addFiles(mockFiles));
+      await waitFor(() => result.current.startUploads());
+      await waitFor(() =>
+        expect(result.current.files.filter((f) => f.status === 'error')).toHaveLength(
+          mockFiles.length,
+        ),
+      );
+
+      const errored = result.current.files.filter((f) => f.status === 'error');
+
+      expect(mockOnUpload).toHaveBeenCalledTimes(mockFiles.length);
+      expect(result.current.files).toHaveLength(mockFiles.length);
+      errored.map((file) => file.message === `Unable to upload ${file.data.name}`);
+    });
+  });
+});

--- a/frontend/pages/sites/$siteId/storage/index.js
+++ b/frontend/pages/sites/$siteId/storage/index.js
@@ -42,8 +42,6 @@ function FileStoragePage() {
     deleteError,
     deleteSuccess,
     uploadFile,
-    uploadError,
-    uploadSuccess,
     createFolder,
     createFolderError,
     createFolderSuccess,
@@ -175,10 +173,6 @@ function FileStoragePage() {
     [deleteItem, resetModal],
   );
 
-  const handleUpload = async (files) => {
-    await Promise.all(files.map((file) => uploadFile(path, file)));
-  };
-
   const handleCreateFolder = async (folderName) => {
     await createFolder(path, folderName);
   };
@@ -191,19 +185,6 @@ function FileStoragePage() {
       isPending={false}
       isPlaceholderData={false}
     >
-      {/* TODO: make these into an array of alerts */}
-      {uploadError && (
-        <AlertBanner status="error" header="Upload Error" message={uploadError} />
-      )}
-
-      {uploadSuccess && (
-        <AlertBanner
-          status="success"
-          header="Upload Successful"
-          message={uploadSuccess}
-        />
-      )}
-
       {deleteError && (
         <AlertBanner status="error" header="Delete Error" message={deleteError} />
       )}
@@ -239,7 +220,10 @@ function FileStoragePage() {
           storageRoot={storageRoot}
           onNavigate={handleNavigate}
         />
-        <NewFileOrFolder onUpload={handleUpload} onCreateFolder={handleCreateFolder} />
+        <NewFileOrFolder
+          onUpload={(file) => uploadFile(path, file)}
+          onCreateFolder={handleCreateFolder}
+        />
         {foundFileDetails && foundFileDetails.id && (
           <FileDetails
             name={foundFileDetails?.name || ''}

--- a/frontend/shared/FileUpload.test.jsx
+++ b/frontend/shared/FileUpload.test.jsx
@@ -63,7 +63,7 @@ describe('FileUpload Component', () => {
     });
     fireEvent.change(fileInput, { target: { files: [mockFile, secondFile] } });
 
-    await screen.findByText('2 files selected');
+    await screen.findByText('3 files selected');
   });
 
   test('removes a selected file when clicking "x"', async () => {
@@ -133,7 +133,7 @@ describe('FileUpload Component', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Upload' }));
 
-    expect(mockOnUpload).toHaveBeenCalledWith([mockFile]);
+    expect(mockOnUpload).toHaveBeenCalledWith(mockFile);
   });
 
   test('triggers onCancel and clears selected files', async () => {


### PR DESCRIPTION
Closes #4746
Closes #4753 

## Changes proposed in this pull request:
- Creates a new `useMultiFileUpload` hook to manage a file upload queue
- Updates `useFileStorage` to provide a `uploadFile` function
- Adds file content-type to s3 `putObject` so the proxy reads the proper file type headers

## security considerations
None
