### PR TITLE
Release 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.18.0 (2025-04-11)
+
+### Added
+
+- Add public file storage waitlist alert
+- add file storage actions log
+- Create a file upload hook to queue uploads
+
+### Fixed
+
+- Return status 403 for invalid uaa oauth code
+- File view details alert to not flash on load
+- page titles, routes, and sidenav consistency
+
 ## 0.17.0 (2025-03-25)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pages-core",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "",
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
## :robot: This is an automated release PR

chore: release 0.18.0
tag to create: 0.18.0
increment detected: MINOR

## 0.18.0 (2025-04-11)

### Added

- Add public file storage waitlist alert
- add file storage actions log
- Create a file upload hook to queue uploads

### Fixed

- Return status 403 for invalid uaa oauth code
- File view details alert to not flash on load
- page titles, routes, and sidenav consistency
## security considerations
Noted in individual PRs
