### PR TITLE
fix: Return status 403 for invalid uaa oauth code

### DIFF
--- a/api/services/uaaStrategy.js
+++ b/api/services/uaaStrategy.js
@@ -1,4 +1,4 @@
-const { Strategy } = require('passport-oauth2');
+const { Strategy, TokenError } = require('passport-oauth2');
 const { Sequelize } = require('sequelize');
 const UAAClient = require('../utils/uaaClient');
 const { Event, UAAIdentity, User } = require('../models');
@@ -23,6 +23,14 @@ function createUAAStrategy(options, verify) {
         return callback(e);
       }
     });
+  };
+
+  strategy.parseErrorResponse = function (body) {
+    var json = JSON.parse(body);
+    if (json.error) {
+      return new TokenError(json.error_description, json.error, json.error_uri, 403);
+    }
+    return null;
   };
 
   const params = new URLSearchParams();

--- a/test/api/admin/requests/admin-auth.test.js
+++ b/test/api/admin/requests/admin-auth.test.js
@@ -62,6 +62,16 @@ describe('Admin authentication request', () => {
         .expect(401);
     });
 
+    it('returns forbidden with invalid code', () => {
+      const invalidCode = 'invlaid';
+
+      cfUAANock.mockExchangeTokenFailure();
+
+      return request(app)
+        .get(`/admin/auth/uaa/callback?code=${invalidCode}&state=abc123`)
+        .expect(403);
+    });
+
     describe('when successful', () => {
       const uaaId = 'admin_id_1';
       const code = 'code';

--- a/test/api/support/cfUAANock.js
+++ b/test/api/support/cfUAANock.js
@@ -203,6 +203,15 @@ function mockExchangeToken(code, accessToken) {
       expires_in: 10,
     });
 }
+function mockExchangeTokenFailure() {
+  const url = new URL(uaaConfig.tokenURL);
+
+  return nock(url.origin)
+    .post(url.pathname)
+    .reply(403, {
+      error: new Error('Invalid token'),
+    });
+}
 
 function mockFailedExchange(code) {
   const url = new URL(uaaConfig.tokenURL);
@@ -282,6 +291,7 @@ function mockServerErrorStatus(status, path, message, accessToken, method = 'get
 module.exports = {
   mockAddUserToGroup,
   mockUAAAuth,
+  mockExchangeTokenFailure,
   mockFailedExchange,
   mockFetchClientToken,
   mockFetchGroupId,


### PR DESCRIPTION
Closes https://github.com/cloud-gov/private/issues/2385

## Changes proposed in this pull request:

- Updates OAuth UAA strategy to return a 403 with invalid token.

## security considerations
Fixes invalid oauth toke error response to 403 from 500
