### PR TITLE
feat: Add webhook to create editor site builds

### DIFF
--- a/api/controllers/webhook.js
+++ b/api/controllers/webhook.js
@@ -44,4 +44,13 @@ module.exports = wrapHandlers({
 
     return res.ok();
   },
+
+  async siteBuild(req, res) {
+    const { body } = req;
+    const siteId = decrypt(body.siteId, encryption.key);
+
+    await Webhooks.createBuildForEditor(siteId);
+
+    return res.ok();
+  },
 });


### PR DESCRIPTION
Closes https://github.com/cloud-gov/pages-core/issues/4788

## Changes proposed in this pull request:
- Adds a webhook endpoint for Editor sites to kick off a new site build for their Pages site

## security considerations
Adds new webhook endpoint
