### PR TITLE
feat: Add bucket name to Pages Editor webhook response

### DIFF
--- a/api/controllers/site.js
+++ b/api/controllers/site.js
@@ -95,7 +95,7 @@ module.exports = wrapHandlers({
     };
 
     await authorizer.create(user, siteParams);
-    const site = await SiteCreator.createSite({
+    const { site } = await SiteCreator.createSite({
       user,
       siteParams,
     });

--- a/api/workers/jobProcessors/createEditorSite.js
+++ b/api/workers/jobProcessors/createEditorSite.js
@@ -49,7 +49,7 @@ async function createEditorSite(job) {
     );
 
     logger.log('Creating site');
-    const site = await SiteCreator.createSite({
+    const { site, s3 } = await SiteCreator.createSite({
       user,
       siteParams: {
         owner: 'cloud-gov',
@@ -85,6 +85,7 @@ async function createEditorSite(job) {
       {
         siteId: site.id,
         orgId: org.id,
+        bucket: s3.bucket,
       },
       encryption.key,
     );

--- a/test/api/unit/services/SiteCreator.test.js
+++ b/test/api/unit/services/SiteCreator.test.js
@@ -472,7 +472,7 @@ describe('SiteCreator', () => {
               siteParams,
             });
           })
-          .then((site) => {
+          .then(({ site }) => {
             expect(site).to.not.be.undefined;
             expect(site.owner).to.equal(siteParams.owner);
             expect(site.repository).to.equal(siteParams.repository);
@@ -504,7 +504,7 @@ describe('SiteCreator', () => {
               user,
             });
           })
-          .then((site) => {
+          .then(({ site }) => {
             expect(site.engine).to.equal('node.js');
             done();
           })
@@ -533,7 +533,7 @@ describe('SiteCreator', () => {
               user,
             });
           })
-          .then((site) =>
+          .then(({ site }) =>
             Site.findByPk(site.id, {
               include: [Build],
             }),

--- a/test/api/workers/jobProcessors/createEditorSite.test.js
+++ b/test/api/workers/jobProcessors/createEditorSite.test.js
@@ -76,11 +76,12 @@ describe('createEditorSite', () => {
       const siteName = 'agency-test-site';
       const apiKey = '1234abcd';
       const orgName = 'agency-org';
+      const s3 = { bucket: 'bucket', region: 'region' };
 
       sinon.stub(SiteCreator, 'createSite').callsFake(async ({ siteParams }) => {
         const site = await factory.site({ organizationId: siteParams.organizationId });
         pagesSiteId = site.id;
-        return site;
+        return { site, s3 };
       });
 
       const webhookPost = sinon.spy();
@@ -100,6 +101,7 @@ describe('createEditorSite', () => {
       expect(webhookArgs[0]).to.equal(`/${siteId}`);
       expect(webhookArgs[1]).to.have.property('siteId');
       expect(webhookArgs[1]).to.have.property('orgId');
+      expect(webhookArgs[1]).to.have.property('bucket');
       expect(webhookPost.calledOnce).to.equal(true);
 
       const siteEnvVars = await UserEnvironmentVariable.findAll({
@@ -117,13 +119,14 @@ describe('createEditorSite', () => {
       const siteName = 'agency-test-with-org';
       const orgName = 'agency-org';
       const apiKey = '1234abcd';
+      const s3 = { bucket: 'bucket', region: 'region' };
 
       await factory.organization.create({ name: `editor-${orgName}-${siteName}` });
 
       sinon.stub(SiteCreator, 'createSite').callsFake(async ({ siteParams }) => {
         const site = await factory.site({ organizationId: siteParams.organizationId });
         pagesSiteId = site.id;
-        return site;
+        return { site, s3 };
       });
 
       const webhookPost = sinon.spy();
@@ -143,6 +146,7 @@ describe('createEditorSite', () => {
       expect(webhookArgs[0]).to.equal(`/${siteId}`);
       expect(webhookArgs[1]).to.have.property('siteId');
       expect(webhookArgs[1]).to.have.property('orgId');
+      expect(webhookArgs[1]).to.have.property('bucket');
       expect(webhookPost.calledOnce).to.equal(true);
 
       const siteEnvVars = await UserEnvironmentVariable.findAll({


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds `bucket` to the Pages Editor webhook response after successful site creation

## security considerations
Adds bucket name to be saved with the corresponding Pages Editor site.
