### PR TITLE
chore: Set security considerations action to read only

### DIFF
--- a/.github/workflows/security-considerations.yml
+++ b/.github/workflows/security-considerations.yml
@@ -1,9 +1,11 @@
 name: Security Considerations
 
+permissions:
+  pull-requests: read
+
 on:
   pull_request:
     types: [opened, edited, reopened]
-    branches: [main]
 
 jobs:
   security-considerations:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Makes security considerations permissions read only.

## security considerations
Makes perms read only
