### PR TITLE
feat: Add route service cookie check for clamav file endpoints

### DIFF
--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -92,5 +92,8 @@ applications:
     memory: 1G
     routes:
       - route: route-service.((domain))
+    services:
+      - pages-((env))-env
     env:
+      APP_ENV: ((env))
       SCAN_BASEURL: pages-clamav-rest((env_postfix)).apps.internal

--- a/.profile
+++ b/.profile
@@ -1,2 +1,3 @@
 export CF_API_USERNAME="$(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == "federalist-deploy-user") | .credentials | .DEPLOY_USER_USERNAME')"
 export CF_API_PASSWORD="$(echo $VCAP_SERVICES | jq -r '."user-provided"[] | select(.name == "federalist-deploy-user") | .credentials | .DEPLOY_USER_PASSWORD')"
+export SESSION_SECRET="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "pages-$APP_ENV-env" ".[][] | select(.name == \$service_name) | .credentials.FEDERALIST_SESSION_SECRET")"


### PR DESCRIPTION
Closes #4811 

## Changes proposed in this pull request:

- Adds additional cookie check for Pages on the route service clamav
- Using the `crypto.timingSafeEqual` function to test the incoming cookie value with the session secret
- Any error occurs results in the 401 status code
- If cookie is valid, it passes the request on to the clamav scan

## security considerations
Adds additional cookie check for Pages on the route service clamav
