### PR TITLE
chore: Clean up File Details UI with fixed links and button types

### DIFF
--- a/api/models/file-storage-user-action.js
+++ b/api/models/file-storage-user-action.js
@@ -45,6 +45,7 @@ function associate({
       {
         model: FileStorageFile,
         required: true,
+        paranoid: false,
       },
     ],
   });

--- a/api/services/file-storage/index.js
+++ b/api/services/file-storage/index.js
@@ -209,6 +209,7 @@ class SiteFileStorageSerivce {
       {
         where,
         order,
+        paranoid: false,
       },
     );
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -315,11 +315,11 @@ docker compose run --rm app yarn test
 You can also just run back or front end tests via:
 
 ```sh
-docker compose --env-file ./services/local/docker.env build run --rm app yarn test:server  # for all back end tests
-docker compose --env-file ./services/local/docker.env build run --rm app yarn test:server:file ./test/api/<path/to/test.js> # to run a single back end test file
-docker compose --env-file ./services/local/docker.env build run --rm app yarn test:rtl  # for all front end tests
-docker compose --env-file ./services/local/docker.env build run --rm app yarn test:rtl:watch  # to watch and re-run front end tests
-docker compose --env-file ./services/local/docker.env build run --rm app yarn test:rtl:file ./test/frontend/<path/to/test.js> # to run a single front end test file
+docker compose --env-file ./services/local/docker.env run --rm app yarn test:server  # for all back end tests
+docker compose --env-file ./services/local/docker.env run --rm app yarn test:server:file ./test/api/<path/to/test.js> # to run a single back end test file
+docker compose --env-file ./services/local/docker.env run --rm app yarn test:rtl  # for all front end tests
+docker compose --env-file ./services/local/docker.env run --rm app yarn test:rtl:watch  # to watch and re-run front end tests
+docker compose --env-file ./services/local/docker.env run --rm app yarn test:rtl:file ./test/frontend/<path/to/test.js> # to run a single front end test file
 ```
 
 To view coverage reports as HTML:

--- a/frontend/pages/sites/$siteId/storage/CopyFileLink.jsx
+++ b/frontend/pages/sites/$siteId/storage/CopyFileLink.jsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { IconLink } from '@shared/icons';
+
+const CopyFileLink = ({ url }) => {
+  const [copySuccess, setCopySuccess] = useState(false);
+  const handleCopy = async (url) => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopySuccess(true);
+      setTimeout(() => setCopySuccess(false), 4000);
+    } catch (err) {
+      throw new Error('Failed to Copy', err);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      title="Copy full url to clipboard"
+      className="usa-button usa-button--unstyled margin-right-2 text-bold"
+      onClick={() => handleCopy(`${url}`)}
+    >
+      {copySuccess ? 'Copied!' : 'Copy link'}
+      <IconLink className="usa-icon" />
+    </button>
+  );
+};
+
+CopyFileLink.propTypes = {
+  url: PropTypes.string.isRequired,
+};
+
+export default CopyFileLink;

--- a/frontend/pages/sites/$siteId/storage/FileDetails.jsx
+++ b/frontend/pages/sites/$siteId/storage/FileDetails.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { IconAttachment } from '@shared/icons';
 import { dateAndTimeSimple } from '@util/datetime';
 import prettyBytes from 'pretty-bytes';
+import CopyFileLink from './CopyFileLink';
 
 const FileDetails = ({
   name,
@@ -79,8 +80,13 @@ const FileDetails = ({
           <tr>
             <th scope="row">Actions</th>
             <td>
-              <a href={fullPath} download className="usa-button">
-                Download
+              <a
+                href={fullPath}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="usa-button"
+              >
+                View File
               </a>
               <button
                 type="button"
@@ -94,6 +100,7 @@ const FileDetails = ({
               >
                 Delete
               </button>
+              <CopyFileLink url={fullPath} />
             </td>
           </tr>
         </tbody>

--- a/frontend/pages/sites/$siteId/storage/FileDetails.test.jsx
+++ b/frontend/pages/sites/$siteId/storage/FileDetails.test.jsx
@@ -93,9 +93,20 @@ describe('FileDetails', () => {
       </MemoryRouter>,
     );
 
-    const downloadLink = screen.getByRole('link', { name: /download/i });
+    const downloadLink = screen.getByRole('link', { name: /View File/i });
     expect(downloadLink).toHaveAttribute('href', fileProps.fullPath);
-    expect(downloadLink).toHaveAttribute('download');
+    expect(downloadLink).toHaveAttribute('target');
+  });
+
+  it('renders a working Copy Url button', () => {
+    render(
+      <MemoryRouter>
+        <FileDetails {...fileProps} />
+      </MemoryRouter>,
+    );
+
+    const copy = screen.getByRole('button', { name: /copy/i });
+    expect(copy).toBeInTheDocument();
   });
 
   it('renders nothing if given an invalid id', () => {

--- a/frontend/pages/sites/$siteId/storage/FileList.jsx
+++ b/frontend/pages/sites/$siteId/storage/FileList.jsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { dateAndTimeSimple, timeFrom } from '@util/datetime';
-import { IconAttachment, IconFolder, IconLink } from '@shared/icons';
+import { IconAttachment, IconFolder } from '@shared/icons';
+import CopyFileLink from './CopyFileLink';
 
 // constants and functions used by both components
 
@@ -22,18 +23,7 @@ const FileListRow = ({
   onViewDetails,
   highlight = false,
 }) => {
-  const copyUrl = `${baseUrl}/${item.key}`;
-  // handle copying the file's URL
-  const [copySuccess, setCopySuccess] = useState(false);
-  const handleCopy = async (url) => {
-    try {
-      await navigator.clipboard.writeText(url);
-      setCopySuccess(true);
-      setTimeout(() => setCopySuccess(false), 4000);
-    } catch (err) {
-      throw new Error('Failed to Copy', err);
-    }
-  };
+  const url = `${baseUrl}/${item.key}`;
 
   return (
     <tr key={item.name} id={item.name} className={highlight ? 'highlight' : ''}>
@@ -90,17 +80,7 @@ const FileListRow = ({
         </span>
       </td>
       <td data-label="Actions" className="width-actions">
-        {item.type !== 'directory' && (
-          <button
-            type="button"
-            title="Copy full url to clipboard"
-            className="usa-button usa-button--unstyled margin-right-2 text-bold"
-            onClick={() => handleCopy(`${copyUrl}`)}
-          >
-            {copySuccess ? 'Copied!' : 'Copy link'}
-            <IconLink className="usa-icon" />
-          </button>
-        )}
+        {item.type !== 'directory' && <CopyFileLink url={url} />}
         <button
           type="button"
           title="Remove from public storage"

--- a/frontend/pages/sites/$siteId/storage/index.jsx
+++ b/frontend/pages/sites/$siteId/storage/index.jsx
@@ -239,7 +239,7 @@ function FileStoragePage() {
           <FileDetails
             name={foundFileDetails?.name || ''}
             id={foundFileDetails?.id}
-            fullPath={`${site.liveDomain}${path}${foundFileDetails?.key}`}
+            fullPath={`${site.liveDomain}/${foundFileDetails?.key}`}
             lastModifiedBy={foundFileDetails?.lastModifiedBy || ''}
             lastModifiedAt={foundFileDetails?.lastModifiedAt || ''}
             size={foundFileDetails?.metadata.size || 0}


### PR DESCRIPTION
Closes #[4814](https://github.com/cloud-gov/pages-core/issues/4814)

## Changes proposed in this pull request:
- Fixes link url on File Details
- Fixes public file storage user actions query to include the deleted actions
- Changes  File Details `Download` link to `View File` since you cannot use download attribute for a link from a different origin.

## security considerations
None
