### PR TITLE
test for pages/organizations/OrganizationCard.jsx (#4690)

### DIFF
--- a/frontend/pages/organizations/OrganizationCard.test.jsx
+++ b/frontend/pages/organizations/OrganizationCard.test.jsx
@@ -11,14 +11,14 @@ import OrganizationCard from './OrganizationCard';
 jest.mock('react-router-dom', () => {
   const original = jest.requireActual('react-router-dom');
   return {
-    ...original, Link: ({ to, children }) => {
+    ...original,
+    Link: ({ to, children }) => {
       return `Link[to="${to}"] ${children}`;
-    }
+    },
   };
 });
 
 describe('OrganizationCard', () => {
-
   function testOrganizationCard(organizationName) {
     expect(screen.getByText(organizationName)).toBeInTheDocument();
     expect(screen.getByRole('listitem')).toHaveClass('usa-card');
@@ -59,19 +59,22 @@ describe('OrganizationCard', () => {
         name: 'Organization Name',
         isActive: isActive,
         isSandbox: isSandbox,
-        daysUntilSandboxCleaningdays: 3
-      }), role: {
-        id: randomUUID(), name: roleName
-      }
+        daysUntilSandboxCleaningdays: 3,
+      }),
+      role: {
+        id: randomUUID(),
+        name: roleName,
+      },
     };
-    render(<OrganizationCard {...(testProps)} />);
+    render(<OrganizationCard {...testProps} />);
     return testProps;
   }
 
   it('renders correctly active production organization for a non-manager role', () => {
-
     const testData = {
-      isActive: true, isSandbox: false, roleName: '!manager'
+      isActive: true,
+      isSandbox: false,
+      roleName: '!manager',
     };
     const testProps = initTest(testData);
 
@@ -82,9 +85,10 @@ describe('OrganizationCard', () => {
   });
 
   it('renders correctly active production organization for a manager role', () => {
-
     const testData = {
-      isActive: true, isSandbox: false, roleName: 'manager'
+      isActive: true,
+      isSandbox: false,
+      roleName: 'manager',
     };
     const testProps = initTest(testData);
 
@@ -94,11 +98,11 @@ describe('OrganizationCard', () => {
     testOrganizationLink(true, testProps.organization.id);
   });
 
-
   it('renders correctly active sandbox organization for a non-manager role', () => {
-
     const testData = {
-      isActive: true, isSandbox: true, roleName: '!manager'
+      isActive: true,
+      isSandbox: true,
+      roleName: '!manager',
     };
     const testProps = initTest(testData);
 
@@ -109,9 +113,10 @@ describe('OrganizationCard', () => {
   });
 
   it('renders correctly active sandbox organization for a manager role', () => {
-
     const testData = {
-      isActive: true, isSandbox: true, roleName: 'manager'
+      isActive: true,
+      isSandbox: true,
+      roleName: 'manager',
     };
     const testProps = initTest(testData);
 
@@ -122,9 +127,10 @@ describe('OrganizationCard', () => {
   });
 
   it('renders correctly inactive production organization for a non-manager role', () => {
-
     const testData = {
-      isActive: false, isSandbox: false, roleName: '!manager'
+      isActive: false,
+      isSandbox: false,
+      roleName: '!manager',
     };
     const testProps = initTest(testData);
 
@@ -135,9 +141,10 @@ describe('OrganizationCard', () => {
   });
 
   it('renders correctly inactive production organization for a manager role', () => {
-
     const testData = {
-      isActive: false, isSandbox: false, roleName: 'manager'
+      isActive: false,
+      isSandbox: false,
+      roleName: 'manager',
     };
     const testProps = initTest(testData);
 
@@ -148,9 +155,10 @@ describe('OrganizationCard', () => {
   });
 
   it('renders correctly inactive sandbox organization for a non-manager role', () => {
-
     const testData = {
-      isActive: false, isSandbox: true, roleName: '!manager'
+      isActive: false,
+      isSandbox: true,
+      roleName: '!manager',
     };
     const testProps = initTest(testData);
 
@@ -161,9 +169,10 @@ describe('OrganizationCard', () => {
   });
 
   it('renders correctly inactive sandbox organization for a manager role', () => {
-
     const testData = {
-      isActive: false, isSandbox: true, roleName: 'manager'
+      isActive: false,
+      isSandbox: true,
+      roleName: 'manager',
     };
     const testProps = initTest(testData);
 
@@ -172,6 +181,4 @@ describe('OrganizationCard', () => {
     testOrganizationActiveStatus(testData.isActive);
     testOrganizationLink(false, testProps.organization.id);
   });
-
 });
-

--- a/frontend/pages/organizations/OrganizationCard.test.jsx
+++ b/frontend/pages/organizations/OrganizationCard.test.jsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { createFixtureOrg } from '../../../test/frontend/support/data/organizations';
+import { randomUUID } from 'node:crypto';
+import OrganizationCard from './OrganizationCard';
+
+// Mocking react-router-dom's <Link> component
+// to avoid rendering actual routing elements in tests.
+// This prevents warnings  when <Link> is used outside a Router
+jest.mock('react-router-dom', () => {
+  const original = jest.requireActual('react-router-dom');
+  return {
+    ...original, Link: ({ to, children }) => {
+      return `Link[to="${to}"] ${children}`;
+    }
+  };
+});
+
+describe('OrganizationCard', () => {
+
+  function testOrganizationCard(organizationName) {
+    expect(screen.getByText(organizationName)).toBeInTheDocument();
+    expect(screen.getByRole('listitem')).toHaveClass('usa-card');
+  }
+
+  function testMessage(isSandbox, days) {
+    const m = `All data for this sandbox organization will be removed in ${days} days.`;
+    const emElement = screen.queryByText(m, { selector: 'em' });
+    if (isSandbox) {
+      expect(emElement).toBeInTheDocument();
+      expect(emElement.tagName).toBe('EM');
+    } else {
+      expect(emElement).not.toBeInTheDocument();
+    }
+  }
+
+  function testOrganizationActiveStatus(isActive) {
+    const footer = screen.queryByText('Inactive');
+    if (!isActive) {
+      expect(footer).toHaveClass('usa-card__footer');
+    } else {
+      expect(footer).not.toBeInTheDocument();
+    }
+  }
+
+  function testOrganizationLink(isLink, organizationId) {
+    const linkMock = 'Link[to="/organizations/' + organizationId.toString() + '"] Edit';
+    if (isLink) {
+      expect(screen.getByText(linkMock)).toBeInTheDocument();
+    } else {
+      expect(screen.queryByText(linkMock)).not.toBeInTheDocument();
+    }
+  }
+
+  function initTest({ isActive, isSandbox, roleName }) {
+    const testProps = {
+      organization: createFixtureOrg({
+        name: 'Organization Name',
+        isActive: isActive,
+        isSandbox: isSandbox,
+        daysUntilSandboxCleaningdays: 3
+      }), role: {
+        id: randomUUID(), name: roleName
+      }
+    };
+    render(<OrganizationCard {...(testProps)} />);
+    return testProps;
+  }
+
+  it('renders correctly active production organization for a non-manager role', () => {
+
+    const testData = {
+      isActive: true, isSandbox: false, roleName: '!manager'
+    };
+    const testProps = initTest(testData);
+
+    testOrganizationCard(testProps.organization.name);
+    testMessage(testData.isSandbox, testProps.organization.daysUntilSandboxCleaningdays);
+    testOrganizationActiveStatus(testData.isActive);
+    testOrganizationLink(false, testProps.organization.id);
+  });
+
+  it('renders correctly active production organization for a manager role', () => {
+
+    const testData = {
+      isActive: true, isSandbox: false, roleName: 'manager'
+    };
+    const testProps = initTest(testData);
+
+    testOrganizationCard(testProps.organization.name);
+    testMessage(testData.isSandbox, testProps.organization.daysUntilSandboxCleaningdays);
+    testOrganizationActiveStatus(testData.isActive);
+    testOrganizationLink(true, testProps.organization.id);
+  });
+
+
+  it('renders correctly active sandbox organization for a non-manager role', () => {
+
+    const testData = {
+      isActive: true, isSandbox: true, roleName: '!manager'
+    };
+    const testProps = initTest(testData);
+
+    testOrganizationCard(testProps.organization.name);
+    testMessage(testData.isSandbox, testProps.organization.daysUntilSandboxCleaningdays);
+    testOrganizationActiveStatus(testData.isActive);
+    testOrganizationLink(false, testProps.organization.id);
+  });
+
+  it('renders correctly active sandbox organization for a manager role', () => {
+
+    const testData = {
+      isActive: true, isSandbox: true, roleName: 'manager'
+    };
+    const testProps = initTest(testData);
+
+    testOrganizationCard(testProps.organization.name);
+    testMessage(testData.isSandbox, testProps.organization.daysUntilSandboxCleaningdays);
+    testOrganizationActiveStatus(testData.isActive);
+    testOrganizationLink(true, testProps.organization.id);
+  });
+
+  it('renders correctly inactive production organization for a non-manager role', () => {
+
+    const testData = {
+      isActive: false, isSandbox: false, roleName: '!manager'
+    };
+    const testProps = initTest(testData);
+
+    testOrganizationCard(testProps.organization.name);
+    testMessage(testData.isSandbox, testProps.organization.daysUntilSandboxCleaningdays);
+    testOrganizationActiveStatus(testData.isActive);
+    testOrganizationLink(false, testProps.organization.id);
+  });
+
+  it('renders correctly inactive production organization for a manager role', () => {
+
+    const testData = {
+      isActive: false, isSandbox: false, roleName: 'manager'
+    };
+    const testProps = initTest(testData);
+
+    testOrganizationCard(testProps.organization.name);
+    testMessage(testData.isSandbox, testProps.organization.daysUntilSandboxCleaningdays);
+    testOrganizationActiveStatus(testData.isActive);
+    testOrganizationLink(false, testProps.organization.id);
+  });
+
+  it('renders correctly inactive sandbox organization for a non-manager role', () => {
+
+    const testData = {
+      isActive: false, isSandbox: true, roleName: '!manager'
+    };
+    const testProps = initTest(testData);
+
+    testOrganizationCard(testProps.organization.name);
+    testMessage(testData.isSandbox, testProps.organization.daysUntilSandboxCleaningdays);
+    testOrganizationActiveStatus(testData.isActive);
+    testOrganizationLink(false, testProps.organization.id);
+  });
+
+  it('renders correctly inactive sandbox organization for a manager role', () => {
+
+    const testData = {
+      isActive: false, isSandbox: true, roleName: 'manager'
+    };
+    const testProps = initTest(testData);
+
+    testOrganizationCard(testProps.organization.name);
+    testMessage(testData.isSandbox, testProps.organization.daysUntilSandboxCleaningdays);
+    testOrganizationActiveStatus(testData.isActive);
+    testOrganizationLink(false, testProps.organization.id);
+  });
+
+});
+


### PR DESCRIPTION
## Changes proposed in this pull request:
- Test that the sandbox notification shows up for orgs that are in a sandbox, using daysuntil
- Link should show up if the org is active AND `role.name === 'manager'; test that the link uses the correct org id

## security considerations
[Note the any security considerations here, or make note of why there are none]
