### PR TITLE
Add admin API endpoints to improve visibility into a site's Public File Storage service #4818

### DIFF
--- a/api/admin/controllers/file-storage.js
+++ b/api/admin/controllers/file-storage.js
@@ -3,7 +3,13 @@ const { canAdminCreateSiteFileStorage } = require('../../authorizers/file-storag
 const { serializeFileStorageService } = require('../../serializers/file-storage');
 const { wrapHandlers } = require('../../utils');
 const { Event } = require('../../models');
-const { adminCreateSiteFileStorage } = require('../../services/file-storage');
+const {
+  adminCreateSiteFileStorage,
+  adminGetSiteFileStorageBySiteId,
+  adminGetSiteFileStorageById,
+  adminGetSiteFileStorageUserActions,
+} = require('../../services/file-storage');
+const siteErrors = require('../../responses/siteErrors');
 
 module.exports = wrapHandlers({
   async createSiteFileStorage(req, res) {
@@ -23,5 +29,46 @@ module.exports = wrapHandlers({
 
     const data = serializeFileStorageService(fss);
     return res.send(data);
+  },
+  async getSiteFileStorage(req, res) {
+    const { params } = req;
+
+    const siteId = parseInt(params.id, 10);
+
+    const fss = await adminGetSiteFileStorageBySiteId(siteId);
+
+    if (!fss) {
+      throw {
+        status: 404,
+        message: siteErrors.SITE_FILE_STORAGE_DOES_NOT_EXIST,
+      };
+    }
+
+    const data = serializeFileStorageService(fss);
+
+    return res.send(data);
+  },
+  async getSiteFileStorageUserActions(req, res) {
+    const { params, query } = req;
+    const { limit = 50, page = 1 } = query;
+
+    const siteFileStorageId = parseInt(params.id, 10);
+
+    const fss = await adminGetSiteFileStorageById(siteFileStorageId);
+
+    if (!fss) {
+      throw {
+        status: 404,
+        message: siteErrors.SITE_FILE_STORAGE_DOES_NOT_EXIST,
+      };
+    }
+
+    const userActions = await adminGetSiteFileStorageUserActions({
+      siteFileStorageId,
+      limit,
+      page,
+    });
+
+    return res.send(userActions);
   },
 });

--- a/api/admin/routers/api.js
+++ b/api/admin/routers/api.js
@@ -80,6 +80,11 @@ apiRouter.post(
   '/sites/:id/file-storage',
   AdminControllers.FileStorage.createSiteFileStorage,
 );
+apiRouter.get('/sites/:id/file-storage', AdminControllers.FileStorage.getSiteFileStorage);
+apiRouter.get(
+  '/site-file-storage/:id/user-actions',
+  AdminControllers.FileStorage.getSiteFileStorageUserActions,
+);
 apiRouter.get('/sites/:id/webhooks', AdminControllers.Site.listWebhooks);
 apiRouter.post('/sites/:id/webhooks', AdminControllers.Site.createWebhook);
 apiRouter.delete('/sites/:id', authorize(['pages.admin']), AdminControllers.Site.destroy);

--- a/api/responses/siteErrors.js
+++ b/api/responses/siteErrors.js
@@ -15,10 +15,12 @@ module.exports = {
   SITE_FILE_STORAGE_EXISTS:
     'The site already has an existing file storage services available.',
   SITE_DOES_NOT_EXIST: 'The specified site does not exist',
+  SITE_FILE_STORAGE_DOES_NOT_EXIST: 'The specified site file storage does not exist.',
   DIRECTORY_MUST_BE_EMPTIED:
     'This directory cannot be deleted. Please delete file contents first.',
   DIRECTORY_EXISTS_ALREADY:
     'A directory with the same name already exists. Please rename your new directory.',
   FILE_EXISTS_ALREADY:
     'A file with the same name already exists. Please rename your new file.',
+  NEW_ERRORS: '',
 };

--- a/api/services/file-storage/index.js
+++ b/api/services/file-storage/index.js
@@ -46,6 +46,46 @@ async function adminCreateSiteFileStorage(
   return fss;
 }
 
+async function adminGetSiteFileStorageBySiteId(siteId) {
+  const fss = await FileStorageService.findOne({ where: { siteId } });
+
+  return fss;
+}
+
+async function adminGetSiteFileStorageById(id) {
+  const fss = await FileStorageService.findOne({ where: { id } });
+
+  return fss;
+}
+
+async function adminGetSiteFileStorageUserActions({
+  siteFileStorageId,
+  limit = 50,
+  page = 1,
+} = {}) {
+  const order = [['createdAt', 'DESC']];
+
+  const where = {
+    fileStorageServiceId: siteFileStorageId,
+  };
+
+  const results = await paginate(
+    FileStorageUserAction.scope(['withUserIdentity']),
+    serializeFileStorageUserActions,
+    {
+      limit,
+      page,
+    },
+    {
+      where,
+      order,
+      paranoid: false,
+    },
+  );
+
+  return results;
+}
+
 class SiteFileStorageSerivce {
   constructor(fileStorageService, userId) {
     const { id, organizationId, serviceName, serviceId } = fileStorageService.dataValues;
@@ -320,5 +360,8 @@ class SiteFileStorageSerivce {
 
 module.exports = {
   adminCreateSiteFileStorage,
+  adminGetSiteFileStorageBySiteId,
+  adminGetSiteFileStorageById,
+  adminGetSiteFileStorageUserActions,
   SiteFileStorageSerivce,
 };

--- a/test/api/admin/requests/file-storage.test.js
+++ b/test/api/admin/requests/file-storage.test.js
@@ -13,6 +13,11 @@ const {
   createFileStorageServiceClient,
   stubSiteS3,
 } = require('../../support/file-storage-service');
+const fs = require('fs').promises;
+const { Validator } = require('jsonschema');
+const { FileStorageService } = require('../../../../api/models');
+
+const JSON_SCHEMA_PATH = './public/swagger/';
 
 describe('Admin File-Storage API', () => {
   beforeEach(async () => {
@@ -31,6 +36,14 @@ describe('Admin File-Storage API', () => {
         method: 'post',
         path: '/site/:id/file-storage',
       },
+      {
+        method: 'get',
+        path: '/site/:id/file-storage',
+      },
+      {
+        method: 'get',
+        path: '/site-file-storage/:id/user-actions',
+      },
     ];
 
     it('should block all unauthenticated actions', async () => {
@@ -45,7 +58,7 @@ describe('Admin File-Storage API', () => {
 
   describe('POST /admin/site/:site_id/file-storage', () => {
     it('should require admin authentication', async () => {
-      const response = await request(app)['get']('/sites/:id/file-storage').expect(401);
+      const response = await request(app)['post']('/sites/:id/file-storage').expect(401);
       expect(response.body.message).to.equal('Unauthorized');
     });
 
@@ -80,5 +93,246 @@ describe('Admin File-Storage API', () => {
 
       expect(body.message).to.be.eq(siteErrors.SITE_FILE_STORAGE_EXISTS);
     });
+  });
+
+  describe('GET /admin/site/:site_id/file-storage', () => {
+    it('should require admin authentication', async () => {
+      const response = await request(app)['get']('/sites/:id/file-storage').expect(401);
+      expect(response.body.message).to.equal('Unauthorized');
+    });
+
+    it('returns a 200 when checks for existing site file storage service', async () => {
+      const user = await factory.user();
+      const cookie = await authenticatedAdminOrSupportSession(user, sessionConfig);
+      const { site, org } = await stubSiteS3();
+
+      const sfs = await FileStorageService.create({
+        siteId: site.id,
+        organizationId: org.id,
+        name: 'site-storage',
+        serviceId: 'AAAA',
+        serviceName: 'service name',
+      });
+
+      const { body: retrievedSfs } = await request(app)
+        .get(`/sites/${site.id}/file-storage`)
+        .set('Cookie', cookie)
+        .set('Origin', config.app.adminHostname)
+        .set('x-csrf-token', csrfToken.getToken())
+        .type('json')
+        .expect(200);
+
+      expect(retrievedSfs.siteId).to.be.eq(site.id);
+      expect(retrievedSfs.id).to.be.eq(sfs.id);
+      validateFileStorageServiceAgainstJSONSchema(retrievedSfs);
+    });
+
+    it('returns a 404 when site file storage service does not exist', async () => {
+      const user = await factory.user();
+      const cookie = await authenticatedAdminOrSupportSession(user, sessionConfig);
+
+      await request(app)
+        .get(`/sites/9999/file-storage`)
+        .set('Cookie', cookie)
+        .set('Origin', config.app.adminHostname)
+        .set('x-csrf-token', csrfToken.getToken())
+        .type('json')
+        .expect(404)
+        .expect((res) => {
+          expect(res.body.message).to.be.eq(
+            'The specified site file storage does not exist.',
+          );
+        });
+    });
+
+    async function validateFileStorageServiceAgainstJSONSchema(fileStorageServiceBody) {
+      const validator = new Validator();
+      const fileStorageServiceSchema = JSON.parse(
+        await fs.readFile(JSON_SCHEMA_PATH + 'FileStorageService.json', 'utf8'),
+      );
+
+      validator.validate(fileStorageServiceBody, fileStorageServiceSchema);
+    }
+  });
+
+  describe('GET /admin/site-file-storage/:id/user-actions', () => {
+    it('should require admin authentication', async () => {
+      const response = await request(app)
+        ['get']('/site-file-storage/:id/user-actions')
+        .expect(401);
+      expect(response.body.message).to.equal('Unauthorized');
+    });
+
+    it('returns 404 when site file storage service does not exist', async () => {
+      const user = await factory.user();
+      const cookie = await authenticatedAdminOrSupportSession(user, sessionConfig);
+
+      await request(app)
+        .get(`/site-file-storage/9999/user-actions`)
+        .set('Cookie', cookie)
+        .set('Origin', config.app.adminHostname)
+        .set('x-csrf-token', csrfToken.getToken())
+        .type('json')
+        .expect(404)
+        .expect((res) => {
+          expect(res.body.message).to.be.eq(
+            'The specified site file storage does not exist.',
+          );
+        });
+    });
+
+    it('returns a 200 and an empty collection without user actions', async () => {
+      const user = await factory.user();
+      const cookie = await authenticatedAdminOrSupportSession(user, sessionConfig);
+      const { site, org } = await stubSiteS3();
+
+      const sfs = await FileStorageService.create({
+        siteId: site.id,
+        organizationId: org.id,
+        name: 'site-storage',
+        serviceId: 'AAAA',
+        serviceName: 'service name',
+      });
+
+      const { body: ua } = await request(app)
+        .get(`/site-file-storage/${sfs.id}/user-actions`)
+        .set('Cookie', cookie)
+        .set('Origin', config.app.adminHostname)
+        .set('x-csrf-token', csrfToken.getToken())
+        .type('json')
+        .expect(200);
+
+      expect(ua.data.length).to.be.eq(0);
+    });
+
+    it('returns a 200 and user actions with default pagination values', async () => {
+      const user = await factory.user();
+      const cookie = await authenticatedAdminOrSupportSession(user, sessionConfig);
+      const { site, org } = await stubSiteS3();
+
+      const sfs = await FileStorageService.create({
+        siteId: site.id,
+        organizationId: org.id,
+        name: 'site-storage',
+        serviceId: 'AAAA',
+        serviceName: 'service name',
+      });
+
+      await factory.fileStorageUserActions.createBulkRandom(
+        { fileStorageServiceId: sfs.id },
+        30,
+      );
+      await factory.fileStorageUserActions.createBulkRandom(
+        { fileStorageServiceId: sfs.id },
+        21,
+      );
+
+      const endpointUrl = `/site-file-storage/${sfs.id}/user-actions`;
+      const { body: userActions } = await request(app)
+        .get(endpointUrl)
+        .set('Cookie', cookie)
+        .set('Origin', config.app.adminHostname)
+        .set('x-csrf-token', csrfToken.getToken())
+        .type('json')
+        .expect(200);
+
+      expect(userActions.data.length).to.be.eq(50);
+      expect(userActions.currentPage).to.be.eq(1);
+      expect(userActions.totalPages).to.be.eq(2);
+      expect(userActions.totalItems).to.be.eq(51);
+
+      await validateUserActionsAgainstJSONSchema(userActions);
+    });
+
+    it('returns a 200 and user actions for specified page number and size', async () => {
+      const user = await factory.user();
+      const cookie = await authenticatedAdminOrSupportSession(user, sessionConfig);
+      const { site, org } = await stubSiteS3();
+
+      const sfs = await FileStorageService.create({
+        siteId: site.id,
+        organizationId: org.id,
+        name: 'site-storage',
+        serviceId: 'AAAA',
+        serviceName: 'service name',
+      });
+
+      await factory.fileStorageUserActions.createBulkRandom(
+        { fileStorageServiceId: sfs.id },
+        100,
+      );
+      await factory.fileStorageUserActions.createBulkRandom(
+        { fileStorageServiceId: sfs.id },
+        100,
+      );
+
+      const endpointUrl = `/site-file-storage/${sfs.id}/user-actions/?&limit=10&page=5`;
+      const { body: userActions } = await request(app)
+        .get(endpointUrl)
+        .set('Cookie', cookie)
+        .set('Origin', config.app.adminHostname)
+        .set('x-csrf-token', csrfToken.getToken())
+        .type('json')
+        .expect(200);
+
+      expect(userActions.data.length).to.be.eq(10);
+      expect(userActions.currentPage).to.be.eq(5);
+      expect(userActions.totalPages).to.be.eq(20);
+      expect(userActions.totalItems).to.be.eq(200);
+
+      await validateUserActionsAgainstJSONSchema(userActions);
+    });
+
+    it('returns a 200 and list of user actions sorted by createdAt desc', async () => {
+      const user = await factory.user();
+      const cookie = await authenticatedAdminOrSupportSession(user, sessionConfig);
+      const { site, org } = await stubSiteS3();
+
+      const sfs = await FileStorageService.create({
+        siteId: site.id,
+        organizationId: org.id,
+        name: 'site-storage',
+        serviceId: 'AAAA',
+        serviceName: 'service name',
+      });
+
+      await factory.fileStorageUserActions.createBulkRandom(
+        { fileStorageServiceId: sfs.id },
+        1,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      await factory.fileStorageUserActions.createBulkRandom(
+        { fileStorageServiceId: sfs.id },
+        1,
+      );
+
+      const endpointUrl = `/site-file-storage/${sfs.id}/user-actions`;
+      const { body: userActions } = await request(app)
+        .get(endpointUrl)
+        .set('Cookie', cookie)
+        .set('Origin', config.app.adminHostname)
+        .set('x-csrf-token', csrfToken.getToken())
+        .type('json')
+        .expect(200);
+
+      expect(
+        new Date(userActions.data[0].createdAt) > new Date(userActions.data[1].createdAt),
+      ).to.be.true;
+      await validateUserActionsAgainstJSONSchema(userActions);
+    });
+
+    async function validateUserActionsAgainstJSONSchema(userActions) {
+      const validator = new Validator();
+
+      const fileStorageUserActionSchema = JSON.parse(
+        await fs.readFile(JSON_SCHEMA_PATH + 'FileStorageUserAction.json', 'utf8'),
+      );
+      validator.addSchema(fileStorageUserActionSchema, '/FileStorageUserAction.json');
+      const fileStorageUserActionSchemas = JSON.parse(
+        await fs.readFile(JSON_SCHEMA_PATH + 'FileStorageUserActionList.json', 'utf8'),
+      );
+
+      validator.validate(userActions, fileStorageUserActionSchemas);
+    }
   });
 });


### PR DESCRIPTION
Closes https://github.com/cloud-gov/pages-core/issues/4818

## Changes proposed in this pull request:
- Add admin API endpoint to get site file storage service.
- Add admin API endpoint to get site file storage service user actions.
- User actions should be sorted in reverse chronological order.

## security considerations
- API end points require admin-level credentials;
- Unit tests verify the admin-level credential requirement.
