### PR TITLE
fix: Use the correct bound route service domain by env

### DIFF
--- a/ci/tasks/configure-clamav-route-service.sh
+++ b/ci/tasks/configure-clamav-route-service.sh
@@ -18,7 +18,7 @@ else
     PAGES_DOMAIN=pages-$APP_ENV.cloud.gov
 fi
 
-ROUTE_SERVICE_APP_DOMAIN=$ROUTE_SERVICE_APP.$PAGES_DOMAIN
+ROUTE_SERVICE_APP_DOMAIN=route-service.$PAGES_DOMAIN
 
 cf create-user-provided-service $USER_PROVIDED_SERVICE_NAME -r https://$ROUTE_SERVICE_APP_DOMAIN
 cf create-route $PAGES_DOMAIN --path /v0/file-storage


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix the bound route service domain to use the proper domain name in the staging and production envs.

## security considerations
None
