### PR TITLE
Release 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 0.21.0 (2026-04-01)
+
+### Added
+
+- create workshop site build flow 4856
+- feat: create workshop oauth flow 4855
+- Update app to Node v22 and update the dependencies
+- Add site delete webhook for publisher site
+
+### Fixed
+
+- branch with an invalid name should create an invalid build #2375
+- remove deprecated component
+- force patched version of fast-xml-parser
+- set node value in Docker
+- include screen reader text and update 404 test to expect updated login string
+- adjust slightly navigation text style
+- Audit and fix dependencies #4845
+- Publisher endpoint host environment variable
+- Use the correct bound route service domain by env
+
+### Maintenance
+
+- Remove deprecated security-considerations automation files
+- update to use new branding logos
+- update color palette
+- update styling to revise color palette
+- update admin-client node engine
+- update favicons with new pages logo
+- update styles and menus
+
 ## 0.20.1 (2025-12-01)
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pages-core",
   "private": true,
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "",
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
## :robot: This is an automated release PR
chore: release 0.21.0
tag to create: 0.21.0
increment detected: MINOR

## 0.21.0 (2026-04-01)

### Added

- create workshop site build flow 4856
- feat: create workshop oauth flow 4855
- Update app to Node v22 and update the dependencies
- Add site delete webhook for publisher site

### Fixed

- branch with an invalid name should create an invalid build #2375
- remove deprecated component
- force patched version of fast-xml-parser
- set node value in Docker
- include screen reader text and update 404 test to expect updated login string
- adjust slightly navigation text style
- Audit and fix dependencies #4845
- Publisher endpoint host environment variable
- Use the correct bound route service domain by env

### Maintenance

- Remove deprecated security-considerations automation files
- update to use new branding logos
- update color palette
- update styling to revise color palette
- update admin-client node engine
- update favicons with new pages logo
- update styles and menus
## security considerations
Noted in individual PRs
