### PR TITLE
fix: Publisher endpoint host environment variable

### DIFF
--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -47,7 +47,7 @@ applications:
       NODE_MODULES_CACHE: false
       NPM_CONFIG_PRODUCTION: true
       OPS_EMAIL: cloud-gov-pages-operations@cio.gov
-      PAGES_EDITOR_HOST: https://pages-editor((env_postfix)).app.cloud.gov
+      PAGES_PUBLISHER_HOST: ((publisher_host))
       PRODUCT: pages
       PROXY_DOMAIN: ((proxy_domain))
       QUEUES_BUILD_TASKS_CONCURRENCY: ((queues_build_tasks_concurrency))

--- a/.cloudgov/vars/pages-dev.yml
+++ b/.cloudgov/vars/pages-dev.yml
@@ -9,6 +9,7 @@ name: pages-dev
 new_relic_app_name: web-pages-dev
 node_env: development
 proxy_domain: sites.pages-dev.cloud.gov
+publisher_host: https://pages-editor-dev.app.cloud.gov
 queues_build_tasks_concurrency: 2
 queues_site_builds_concurrency: 3
 route-service-instances: 2

--- a/.cloudgov/vars/pages-production.yml
+++ b/.cloudgov/vars/pages-production.yml
@@ -9,6 +9,7 @@ name: pages-production
 new_relic_app_name: web-pages-production
 node_env: production
 proxy_domain: sites.pages.cloud.gov
+publisher_host: https://publisher.cloud.gov
 queues_build_tasks_concurrency: 10
 queues_site_builds_concurrency: 10
 route-service-instances: 6

--- a/.cloudgov/vars/pages-staging.yml
+++ b/.cloudgov/vars/pages-staging.yml
@@ -9,6 +9,7 @@ name: pages-staging
 new_relic_app_name: web-pages-staging
 node_env: production
 proxy_domain: sites.pages-staging.cloud.gov
+publisher_host: https://publisher-staging.cloud.gov
 queues_build_tasks_concurrency: 4
 queues_site_builds_concurrency: 4
 route-service-instances: 2

--- a/api/workers/jobProcessors/createEditorSite.js
+++ b/api/workers/jobProcessors/createEditorSite.js
@@ -8,7 +8,7 @@ const { UserEnvironmentVariable } = require('../../models');
 const { createJobLogger } = require('./utils');
 const { userEnvVar, encryption } = require('../../../config');
 
-const { PAGES_EDITOR_HOST } = process.env;
+const { PAGES_PUBLISHER_HOST } = process.env;
 
 /**
  * The Site Queue job processor
@@ -27,7 +27,7 @@ async function createEditorSite(job) {
   // Webhook client to send success or error request to
   // Pages Editor site endpoint
   const webhookClient = axios.create({
-    baseURL: `${PAGES_EDITOR_HOST}/api/webhook/site`,
+    baseURL: `${PAGES_PUBLISHER_HOST}/api/webhook/site`,
     headers: {
       'Content-Type': 'application/json',
     },
@@ -69,7 +69,7 @@ async function createEditorSite(job) {
       hint: apiKeyEnc.hint,
     });
 
-    const editorHostEnc = encrypt(PAGES_EDITOR_HOST, userEnvVar.key);
+    const editorHostEnc = encrypt(PAGES_PUBLISHER_HOST, userEnvVar.key);
     await UserEnvironmentVariable.create({
       siteId: site.id,
       name: 'EDITOR_APP_URL',

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       PROXY_DOMAIN: localhost:1337
       CI: true
       FEATURE_FILE_STORAGE_SERVICE: true
-      PAGES_EDITOR_HOST: https://editor.example.gov
+      PAGES_PUBLISHER_HOST: https://editor.example.gov
       OPS_EMAIL: ops@example.gov
   db:
     image: postgres:ci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       CLOUD_FOUNDRY_OAUTH_TOKEN_URL: ${CLOUD_FOUNDRY_API_HOST}/oauth/token
       CF_API_USERNAME: deploy_user
       CF_API_PASSWORD: deploy_pass
-      PAGES_EDITOR_HOST: https://editor.example.gov
+      PAGES_PUBLISHER_HOST: https://editor.example.gov
       PROXY_DOMAIN: localhost:1337
       QUEUES_BUILD_TASKS_CONCURRENCY: 1
       OPS_EMAIL: ops@example.gov


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fix the publisher endpon hostname variable for staging and production deploys
- Change the env var name to `PAGES_PUBLISHER_HOST`

## security considerations
None
