### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Cloud.gov Pages
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/cloud-gov/pages-core)
 ***Cloud.gov Pages is updated regularly. [Join our public chat room](https://chat.18f.gov/?channel=cg-pages-public) to talk to us and stay informed. You can also check out our [documentation](https://cloud.gov/pages/) to learn more.***
 
 ## About Pages


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/cloud-gov/pages-core) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.