### PR TITLE
feat: create workshop site build flow - build container env 4866

### DIFF
--- a/api/admin/controllers/build.js
+++ b/api/admin/controllers/build.js
@@ -1,6 +1,6 @@
 const buildSerializer = require('../../serializers/build');
 const BuildLogs = require('../../services/build-logs');
-const GithubBuildHelper = require('../../services/GithubBuildHelper');
+const SourceCodePlatformHelper = require('../../services/SourceCodePlatformHelper');
 
 const { Build, Domain, Event, Site, SiteBranchConfig, User } = require('../../models');
 const { fetchModelById } = require('../../utils/queryDatabase');
@@ -135,14 +135,23 @@ module.exports = wrapHandlers({
       const rebuild = await Build.create({
         branch: requestBuild.branch,
         site: requestBuild.site,
-        username: 'admin',
+        user: requestBuild.user,
+        username: requestBuild.username,
         requestedCommitSha:
           requestBuild.clonedCommitSha || requestBuild.requestedCommitSha,
       });
       await rebuild.enqueue();
       rebuild.Site = requestBuild.Site;
-      await GithubBuildHelper.reportBuildStatus(rebuild);
+      await SourceCodePlatformHelper.reportBuildStatus(rebuild);
       const rebuildJSON = await buildSerializer.serialize(rebuild);
+
+      EventCreator.audit(Event.labels.ADMIN_ACTION, req.user, 'Rebuild', {
+        build: {
+          id: rebuild.id,
+          state: rebuild.state,
+        },
+      });
+
       return res.json(rebuildJSON);
     }
     return res.ok({});

--- a/api/admin/controllers/site.js
+++ b/api/admin/controllers/site.js
@@ -8,8 +8,7 @@ const {
   SiteBuildTask,
 } = require('../../models');
 const SiteDestroyer = require('../../services/SiteDestroyer');
-const GithubBuildHelper = require('../../services/GithubBuildHelper');
-const GitLabHelper = require('../../services/GitLabHelper');
+const SourceCodePlatformHelper = require('../../services/SourceCodePlatformHelper');
 const { fetchModelById } = require('../../utils/queryDatabase');
 const { paginate, pick, wrapHandlers } = require('../../utils');
 const { serializeNew, serializeMany } = require('../../serializers/site');
@@ -71,11 +70,7 @@ module.exports = wrapHandlers({
     } = req;
 
     const site = await Site.findOne({ where: { id } });
-    const users = await site.getOrgUsers();
-    const hook =
-      site.sourceCodePlatform === Site.Platforms.Workshop
-        ? await GitLabHelper.createSiteWebhook(req.user, site)
-        : await GithubBuildHelper.createSiteWebhook(site, users);
+    const hook = await SourceCodePlatformHelper.createSiteWebhook(req.user, site);
 
     return res.json(hook || []);
   },
@@ -87,10 +82,7 @@ module.exports = wrapHandlers({
 
     const site = await Site.findOne({ where: { id } });
     const users = await site.getOrgUsers();
-    const hooks =
-      site.sourceCodePlatform === Site.Platforms.Workshop
-        ? await GitLabHelper.listSiteWebhooks(req.user, site)
-        : await GithubBuildHelper.listSiteWebhooks(site, users);
+    const hooks = await SourceCodePlatformHelper.listSiteWebhooks(req.user, site, users);
 
     return res.json(hooks);
   },

--- a/api/controllers/build.js
+++ b/api/controllers/build.js
@@ -2,7 +2,7 @@ const merge = require('lodash.merge');
 
 const { fetchModelById } = require('../utils/queryDatabase');
 const buildSerializer = require('../serializers/build');
-const GithubBuildHelper = require('../services/GithubBuildHelper');
+const SourceCodePlatformHelper = require('../services/SourceCodePlatformHelper');
 const siteAuthorizer = require('../authorizers/site');
 const SocketIOSubscriber = require('../services/SocketIOSubscriber');
 const EventCreator = require('../services/EventCreator');
@@ -123,7 +123,7 @@ module.exports = wrapHandlers({
       });
       await rebuild.enqueue();
       rebuild.Site = requestBuild.Site;
-      await GithubBuildHelper.reportBuildStatus(rebuild);
+      await SourceCodePlatformHelper.reportBuildStatus(rebuild);
       const rebuildJSON = await buildSerializer.serialize(rebuild);
       return res.json(rebuildJSON);
     }
@@ -162,7 +162,7 @@ module.exports = wrapHandlers({
     // The `requestedCommitSha` will not be present for initial builds
     // and there is no need to report status to Github
     if (build.requestedCommitSha) {
-      await GithubBuildHelper.reportBuildStatus(build);
+      await SourceCodePlatformHelper.reportBuildStatus(build);
     }
 
     return res.ok();

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -1,8 +1,7 @@
 const Ajv = require('ajv');
 const userSerializer = require('../serializers/user');
 const { revokeApplicationGrant } = require('../services/GitHub');
-const { revokeUserGitLabTokens } = require('../services/GitLab');
-const { resetGitLabTokens } = require('../services/user');
+const { revokeUserGitLabTokens } = require('../services/GitLabHelper');
 
 const ajv = new Ajv();
 
@@ -60,8 +59,6 @@ module.exports = {
     const { user } = req;
 
     await revokeUserGitLabTokens(user);
-
-    await resetGitLabTokens(user);
 
     return res.json({});
   },

--- a/api/controllers/webhook.js
+++ b/api/controllers/webhook.js
@@ -4,6 +4,8 @@ const { decrypt } = require('../services/Encryptor');
 const { encryption } = require('../../config');
 const QueueJobs = require('../queue-jobs');
 const { createQueueConnection } = require('../utils/queues');
+const SourceCodePlatformHelper = require('../services/SourceCodePlatformHelper');
+const { Site } = require('../models');
 
 const connection = createQueueConnection();
 const queueJob = new QueueJobs(connection);
@@ -12,7 +14,7 @@ module.exports = wrapHandlers({
   async github(req, res) {
     const { body: payload } = req;
 
-    await Webhooks.pushWebhookRequest(payload);
+    await Webhooks.pushWebhookRequest(payload, Site.Platforms.Github);
 
     res.ok();
   },
@@ -69,5 +71,16 @@ module.exports = wrapHandlers({
     }
 
     return res.ok();
+  },
+
+  async gitlab(req, res) {
+    const { body: payload } = req;
+
+    await Webhooks.pushWebhookRequest(
+      SourceCodePlatformHelper.getProcessedGitLabWebhookPayload(payload),
+      Site.Platforms.Workshop,
+    );
+
+    res.ok();
   },
 });

--- a/api/routers/webhook.js
+++ b/api/routers/webhook.js
@@ -60,6 +60,27 @@ function verifySiteRequest(expectedKeys) {
   };
 }
 
+function verifyToken(req, res, next) {
+  try {
+    verifyGitLabToken(req.headers);
+  } catch (err) {
+    res.badRequest();
+    next(err);
+  }
+  next();
+}
+
+function verifyGitLabToken(headers) {
+  const webhookSecret = config.webhook.gitlabSecret;
+  const headerSecret = headers['x-gitlab-token'];
+
+  if (!headerSecret) {
+    throw new Error('No X-Gitlab-Token found on request');
+  } else if (webhookSecret !== headerSecret) {
+    throw new Error('X-Gitlab-Token does not match webhook secret');
+  }
+}
+
 const verifyNewEditorSite = verifySiteRequest([
   'userEmail',
   'apiKey',
@@ -71,6 +92,7 @@ const verifyNewEditorSite = verifySiteRequest([
 const verifyEditorSiteId = verifySiteRequest(['siteId']);
 
 router.post('/webhook/github', verifySignature, WebhookController.github);
+router.post('/webhook/gitlab', verifyToken, WebhookController.gitlab);
 router.post('/webhook/organization', verifySignature, WebhookController.organization);
 router.post('/webhook/site', verifyNewEditorSite, WebhookController.site);
 router.delete('/webhook/site', verifyEditorSiteId, WebhookController.siteDelete);

--- a/api/services/GitLab.js
+++ b/api/services/GitLab.js
@@ -5,15 +5,14 @@ const CONTENT_TYPE_URL_ENCODED = 'application/x-www-form-urlencoded';
 const CONTENT_TYPE_JSON = 'application/json';
 
 const { authorizationOptions: gitlabConfig } = config.passport.gitlab;
-const getBaseUrl = (gitlabConfigBaseURL) => gitlabConfigBaseURL?.replace(/\/$/, '');
+const normalizeUrl = (gitlabConfigBaseURL) => gitlabConfigBaseURL?.replace(/\/$/, '');
+const getBaseUrl = () => normalizeUrl(gitlabConfig.baseURL);
 
-const getHeaders = (user, contentType = CONTENT_TYPE_URL_ENCODED) => {
-  return {
-    'Content-Type': contentType,
-    Authorization: `Bearer ${user.gitlabToken}`,
-    Accept: 'application/json',
-  };
-};
+const getHeaders = ({ user, contentType }) => ({
+  Authorization: `Bearer ${user.gitlabToken}`,
+  Accept: 'application/json',
+  ...(contentType && { 'Content-Type': contentType }),
+});
 
 const getClientCredentials = (_gitlabConfig) => {
   return {
@@ -24,16 +23,16 @@ const getClientCredentials = (_gitlabConfig) => {
 
 function getUrlEncodedProjectPath(sourceCodeUrl) {
   const namespacedPath = sourceCodeUrl.replace(
-    `${getBaseUrl(gitlabConfig.baseURL)}/`,
+    `${normalizeUrl(gitlabConfig.baseURL)}/`,
     '',
   );
   return encodeURIComponent(namespacedPath);
 }
 
-const fetchRefreshTokens = async (user) => {
-  return fetch(`${getBaseUrl(gitlabConfig.baseURL)}/oauth/token`, {
+const fetchRefreshUserOAuthTokens = async (user) => {
+  return fetch(`${normalizeUrl(gitlabConfig.baseURL)}/oauth/token`, {
     method: 'POST',
-    headers: getHeaders(user),
+    headers: getHeaders({ user, contentType: CONTENT_TYPE_URL_ENCODED }),
     body: new URLSearchParams({
       ...getClientCredentials(gitlabConfig),
       refresh_token: user.gitlabRefreshToken,
@@ -46,14 +45,15 @@ const fetchRefreshTokens = async (user) => {
 const fetchAddWebhook = async (user, sourceCodeUrl, webhookEndpoint) => {
   return fetch(
     // eslint-disable-next-line max-len
-    `${getBaseUrl(gitlabConfig.baseURL)}/api/v4/projects/${getUrlEncodedProjectPath(sourceCodeUrl)}/hooks`,
+    `${normalizeUrl(gitlabConfig.baseURL)}/api/v4/projects/${getUrlEncodedProjectPath(sourceCodeUrl)}/hooks`,
     {
       method: 'POST',
-      headers: getHeaders(user, CONTENT_TYPE_JSON),
+      headers: getHeaders({ user, contentType: CONTENT_TYPE_JSON }),
       body: JSON.stringify({
         url: webhookEndpoint,
         push_events: true,
         branch_filter_strategy: 'all_branches',
+        token: config.webhook.gitlabSecret,
       }),
     },
   );
@@ -62,21 +62,60 @@ const fetchAddWebhook = async (user, sourceCodeUrl, webhookEndpoint) => {
 const fetchWebhooks = async (user, sourceCodeUrl) => {
   return fetch(
     // eslint-disable-next-line max-len
-    `${getBaseUrl(gitlabConfig.baseURL)}/api/v4/projects/${getUrlEncodedProjectPath(sourceCodeUrl)}/hooks`,
+    `${normalizeUrl(gitlabConfig.baseURL)}/api/v4/projects/${getUrlEncodedProjectPath(sourceCodeUrl)}/hooks`,
     {
       method: 'GET',
-      headers: getHeaders(user),
+      headers: getHeaders({ user }),
     },
   );
 };
 
 const fetchGetProject = async (user, sourceCodeUrl) => {
   // eslint-disable-next-line max-len
-  const url = `${getBaseUrl(gitlabConfig.baseURL)}/api/v4/projects/${getUrlEncodedProjectPath(sourceCodeUrl)}`;
-  const headers = getHeaders(user);
+  const url = `${normalizeUrl(gitlabConfig.baseURL)}/api/v4/projects/${getUrlEncodedProjectPath(sourceCodeUrl)}`;
+  const headers = getHeaders({ user });
   return fetch(url, {
     method: 'GET',
     headers: headers,
+  });
+};
+
+const fetchProjectUser = async (user, sourceCodeUrl, userId) => {
+  // eslint-disable-next-line max-len
+  const url = `${normalizeUrl(gitlabConfig.baseURL)}/api/v4/projects/${getUrlEncodedProjectPath(sourceCodeUrl)}/members/all/${userId}`;
+  const headers = getHeaders({ user });
+  return fetch(url, {
+    method: 'GET',
+    headers: headers,
+  });
+};
+
+const fetchUser = async (user) => {
+  const url = `${normalizeUrl(gitlabConfig.baseURL)}/api/v4/user`;
+  const headers = getHeaders({ user });
+  return fetch(url, {
+    method: 'GET',
+    headers: headers,
+  });
+};
+
+const fetchPostCommitStatus = async (gitlabToken, sourceCodeUrl, options) => {
+  // eslint-disable-next-line max-len
+  const url = `${normalizeUrl(gitlabConfig.baseURL)}/api/v4/projects/${getUrlEncodedProjectPath(sourceCodeUrl)}/statuses/${options.sha}?state=${options.state}`;
+  const headers = getHeaders({
+    user: { gitlabToken },
+    contentType: CONTENT_TYPE_URL_ENCODED,
+  });
+
+  return fetch(url, {
+    method: 'POST',
+    headers: headers,
+    body: new URLSearchParams({
+      state: options.state, // running, success, failed, canceled, skipped
+      target_url: options.target_url,
+      description: options.description,
+      name: `${config.app.product}-${config.app.appEnv}`,
+    }),
   });
 };
 
@@ -85,10 +124,10 @@ const revokeToken = async (user, token, tokenType) => {
 
   try {
     const revokeResponse = await fetch(
-      `${getBaseUrl(gitlabConfig.baseURL)}/oauth/revoke`,
+      `${normalizeUrl(gitlabConfig.baseURL)}/oauth/revoke`,
       {
         method: 'POST',
-        headers: getHeaders(user),
+        headers: getHeaders({ user, contentType: CONTENT_TYPE_URL_ENCODED }),
         body: new URLSearchParams({
           ...getClientCredentials(gitlabConfig),
           token: `${token}`,
@@ -111,12 +150,12 @@ const revokeToken = async (user, token, tokenType) => {
   }
 };
 
-const revokeUserGitLabTokens = async (user) => {
+const revokeUserOAuthTokens = async (user, resetUserOAuthTokens) => {
   try {
     await revokeToken(user, user.gitlabToken, 'access token');
     await revokeToken(user, user.gitlabRefreshToken, 'refresh token');
 
-    const response = await fetchRefreshTokens(user);
+    const response = await fetchRefreshUserOAuthTokens(user);
     const data = await response.json();
     if (response.status !== 400 || data.error !== 'invalid_grant') {
       logger.warn(
@@ -128,21 +167,28 @@ const revokeUserGitLabTokens = async (user) => {
   } catch (error) {
     logger.error('GitLab: Error revoking GitLab tokens.', error.message, error.stack);
   }
+
+  resetUserOAuthTokens(user);
 };
 
-const getProject = async (user, sourceCodeUrl, persistTokens) => {
+const getProject = async (user, sourceCodeUrl, persistUserOAuthTokens) => {
   return await apiCallWithTokensRefresh(
     user,
     () => fetchGetProject(user, sourceCodeUrl),
-    persistTokens,
+    persistUserOAuthTokens,
   );
 };
 
-const addWebhook = async (user, sourceCodeUrl, webhookEndpoint, persistTokens) => {
+const addWebhook = async (
+  user,
+  sourceCodeUrl,
+  webhookEndpoint,
+  persistUserOAuthTokens,
+) => {
   const response = await apiCallWithTokensRefresh(
     user,
     () => fetchAddWebhook(user, sourceCodeUrl, webhookEndpoint),
-    persistTokens,
+    persistUserOAuthTokens,
   );
 
   if (!response.ok) {
@@ -156,12 +202,40 @@ const addWebhook = async (user, sourceCodeUrl, webhookEndpoint, persistTokens) =
   };
 };
 
-const getWebhooks = async (user, sourceCodeUrl, persistTokens) => {
-  return apiCallWithTokensRefresh(
+const getWebhooks = async (user, sourceCodeUrl, persistUserOAuthTokens) => {
+  return await apiCallWithTokensRefresh(
     user,
     () => fetchWebhooks(user, sourceCodeUrl),
-    persistTokens,
+    persistUserOAuthTokens,
   );
+};
+
+const getUser = async (user, persistUserOAuthTokens) => {
+  return await apiCallWithTokensRefresh(
+    user,
+    () => fetchUser(user),
+    persistUserOAuthTokens,
+  );
+};
+
+const getProjectUser = async (user, sourceCodeUrl, userId, persistUserOAuthTokens) => {
+  return await apiCallWithTokensRefresh(
+    user,
+    () => fetchProjectUser(user, sourceCodeUrl, userId),
+    persistUserOAuthTokens,
+  );
+};
+
+const sendCommitStatus = async (accessToken, sourceCodeUrl, options) => {
+  return await fetchPostCommitStatus(accessToken, sourceCodeUrl, options);
+};
+
+const getUserOAuthAccessToken = async (user, persistUserOAuthTokens) => {
+  const userOAuthAccessTokens = await refreshUserOAuthTokens(
+    user,
+    persistUserOAuthTokens,
+  );
+  return userOAuthAccessTokens.accessToken;
 };
 
 const processError = async (response, message) => {
@@ -180,35 +254,41 @@ const processError = async (response, message) => {
   );
 };
 
-const apiCallWithTokensRefresh = async (user, apiCall, persistTokens) => {
-  try {
-    const projectResponse = await apiCall();
+const refreshUserOAuthTokens = async (user, persistUserOAuthTokens) => {
+  const refreshResponse = await fetchRefreshUserOAuthTokens(user);
+  if (!refreshResponse.ok) {
+    await persistUserOAuthTokens(user, {
+      accessToken: null,
+      refreshToken: null,
+      expiresIn: null,
+      createdAt: null,
+    });
+    throw await processError(refreshResponse, 'Try reconnecting your GitLab account.');
+  }
 
-    if (projectResponse.status === 401) {
-      const refreshResponse = await fetchRefreshTokens(user);
-      if (!refreshResponse.ok) {
-        persistTokens(user, {
-          accessToken: null,
-          refreshToken: null,
-          expiresIn: null,
-          createdAt: null,
-        });
-        throw await processError(
-          refreshResponse,
-          'Try reconnecting your GitLab account.',
-        );
-      }
-      let refreshResponseData = await refreshResponse.json();
-      persistTokens(user, {
-        accessToken: refreshResponseData.access_token,
-        refreshToken: refreshResponseData.refresh_token,
-        expiresIn: refreshResponseData.expires_in,
-        createdAt: refreshResponseData.created_at,
-      });
+  let refreshResponseData = await refreshResponse.json();
+  const userOAuthTokens = {
+    accessToken: refreshResponseData.access_token,
+    refreshToken: refreshResponseData.refresh_token,
+    expiresIn: refreshResponseData.expires_in,
+    createdAt: refreshResponseData.created_at,
+  };
+
+  await persistUserOAuthTokens(user, userOAuthTokens);
+
+  return userOAuthTokens;
+};
+
+const apiCallWithTokensRefresh = async (user, apiCall, persistUserOAuthTokens) => {
+  try {
+    const response = await apiCall();
+
+    if (response.status === 401) {
+      await refreshUserOAuthTokens(user, persistUserOAuthTokens);
       return await apiCall();
     }
 
-    return projectResponse;
+    return response;
   } catch (error) {
     logger.error(
       'GitLab: Error calling API with tokens refresh.',
@@ -221,9 +301,14 @@ const apiCallWithTokensRefresh = async (user, apiCall, persistTokens) => {
 
 module.exports = {
   getBaseUrl,
-  fetchRefreshTokens,
-  revokeUserGitLabTokens,
+  normalizeUrl,
+  fetchRefreshUserOAuthTokens,
+  revokeUserOAuthTokens,
+  getUser,
   getProject,
+  getProjectUser,
   addWebhook,
   getWebhooks,
+  getUserOAuthAccessToken,
+  sendCommitStatus,
 };

--- a/api/services/GitLabHelper.js
+++ b/api/services/GitLabHelper.js
@@ -1,6 +1,23 @@
 const GitLab = require('./GitLab');
 const config = require('../../config');
-const { updateGitLabTokens } = require('./user');
+const { updateGitLabTokens, resetGitLabTokens } = require('./user');
+const { logger } = require('../../winston');
+
+const GITLAB_ACCESS_LEVEL_GUEST = 10;
+const GITLAB_ACCESS_LEVEL_REPORTER = 20;
+const GITLAB_ACCESS_LEVEL_DEVELOPER = 30;
+const GITLAB_ACCESS_LEVEL_MAINTAINER = 40;
+const GITLAB_ACCESS_LEVEL_OWNER = 50;
+
+const PAGES_ACCESS_LEVELS_CREATE_SITE = [
+  GITLAB_ACCESS_LEVEL_OWNER,
+  GITLAB_ACCESS_LEVEL_MAINTAINER,
+];
+const PAGES_ACCESS_LEVELS_DESTROY_SITE = [GITLAB_ACCESS_LEVEL_OWNER];
+
+const getProject = async (user, sourceCodeUrl) => {
+  return await GitLab.getProject(user, sourceCodeUrl, updateGitLabTokens);
+};
 
 const createSiteWebhook = async (user, site) => {
   const webhooks = await GitLab.getWebhooks(
@@ -20,12 +37,115 @@ const createSiteWebhook = async (user, site) => {
 };
 
 const listSiteWebhooks = async (user, site) => {
-  return await GitLab.getWebhooks(user, site.sourceCodeUrl, updateGitLabTokens).then(
-    (r) => r.json(),
-  );
+  const response = await GitLab.getWebhooks(user, site.sourceCodeUrl, updateGitLabTokens);
+  return await response.json();
 };
 
+const getUserOAuthAccessToken = async (user) =>
+  await GitLab.getUserOAuthAccessToken(user, updateGitLabTokens);
+
+const revokeUserGitLabTokens = async (user) =>
+  await GitLab.revokeUserOAuthTokens(user, resetGitLabTokens);
+
+const getGitLabBaseUrl = () => GitLab.getBaseUrl();
+
+const sendCommitStatus = async (accessToken, site, options) => {
+  const response = await GitLab.sendCommitStatus(
+    accessToken,
+    site.sourceCodeUrl,
+    options,
+  );
+
+  if (!response.ok) {
+    logger.error(await response.json());
+    throw new Error(
+      `Failed to send commit status (${options.state}): ${response.status}`,
+    );
+  }
+
+  return response;
+};
+
+const getProcessedWebhookPayload = (payload) => {
+  const [, owner, ...rest] = payload.project.web_url
+    .replace(`${getGitLabBaseUrl()}`, '')
+    .split('/');
+  const processedPayload = {
+    after: payload.after,
+    commits: payload.commits && payload.commits.length > 0 ? [{}] : undefined,
+    owner,
+    repository: {
+      repository_path: rest.join('/'),
+      pushed_at: Math.floor(new Date(payload.commits[0]?.timestamp).getTime() / 1000),
+    },
+    sender: { login: payload.user_username },
+    ref: payload.ref,
+  };
+
+  return processedPayload;
+};
+
+async function getProjectAccessLevel(user, sourceCodeUrl) {
+  const userResponse = await GitLab.getUser(user, updateGitLabTokens);
+  const { id: userId } = await userResponse.json();
+
+  const projectUserResponse = await GitLab.getProjectUser(
+    user,
+    sourceCodeUrl,
+    userId,
+    updateGitLabTokens,
+  );
+  const { access_level: accessLevel } = await projectUserResponse.json();
+  return accessLevel;
+}
+
+const getGitLabProjectForPermissions = async (user, sourceCodeUrl, accessLevels) => {
+  const accessLevel = await getProjectAccessLevel(user, sourceCodeUrl);
+
+  if (!accessLevels.includes(accessLevel)) {
+    throw {
+      message: 'You do not have required access level',
+      status: 403,
+    };
+  }
+
+  const projectResponse = await GitLab.getProject(
+    user,
+    sourceCodeUrl,
+    updateGitLabTokens,
+  );
+  return await projectResponse.json();
+};
+
+const getGitLabProjectToCreateSite = async (user, sourceCodeUrl) =>
+  await getGitLabProjectForPermissions(
+    user,
+    sourceCodeUrl,
+    PAGES_ACCESS_LEVELS_CREATE_SITE,
+  );
+
+const getGitLabProjectToDestroySite = async (user, sourceCodeUrl) =>
+  await getGitLabProjectForPermissions(
+    user,
+    sourceCodeUrl,
+    PAGES_ACCESS_LEVELS_DESTROY_SITE,
+  );
+
 module.exports = {
+  GITLAB_ACCESS_LEVEL_GUEST,
+  GITLAB_ACCESS_LEVEL_REPORTER,
+  GITLAB_ACCESS_LEVEL_DEVELOPER,
+  GITLAB_ACCESS_LEVEL_MAINTAINER,
+  GITLAB_ACCESS_LEVEL_OWNER,
+  revokeUserGitLabTokens,
+  getGitLabBaseUrl,
+  getProject,
+  getGitLabProjectToCreateSite,
+  getGitLabProjectToDestroySite,
   createSiteWebhook,
   listSiteWebhooks,
+  getUserOAuthAccessToken,
+  sendCommitStatus,
+  getProcessedWebhookPayload,
+  getProjectAccessLevel,
 };

--- a/api/services/GithubBuildHelper.js
+++ b/api/services/GithubBuildHelper.js
@@ -1,130 +1,25 @@
-const url = require('url');
+const { Site } = require('../models');
 const GitHub = require('./GitHub');
-const config = require('../../config');
 
-// Loops through supplied list of users, until it
-// finds a user with a valid access token
-const getAccessTokenWithCertainPermissions = async (site, users, permission) => {
-  let count = 0;
-  const filteredUsers = users
-    .filter((u) => u.githubAccessToken && u.signedInAt)
-    .sort((a, b) => b.signedInAt - a.signedInAt);
-
-  const getNextToken = async (user) => {
-    try {
-      if (!user) {
-        return null;
-      }
-
-      const permissions = await GitHub.checkPermissions(
-        user,
-        site.owner,
-        site.repository,
-      );
-
-      if (permissions[permission]) {
-        return user.githubAccessToken;
-      }
-      count += 1;
-      return getNextToken(filteredUsers[count]);
-    } catch {
-      count += 1;
-      return getNextToken(filteredUsers[count]);
-    }
-  };
-
-  return getNextToken(filteredUsers[count]);
-};
-
-const getAccessTokenWithPushPermissions = async (site, users) =>
-  getAccessTokenWithCertainPermissions(site, users, 'push');
-
-const getAccessTokenWithAdminPermissions = async (site, users) =>
-  getAccessTokenWithCertainPermissions(site, users, 'admin');
-
-const createSiteWebhook = async (site, users) => {
-  const githubAccessToken = await getAccessTokenWithAdminPermissions(site, users);
+const createSiteWebhook = async (site, users, getAccessTokenWithAdminPermissions) => {
+  const githubAccessToken = await getAccessTokenWithAdminPermissions(
+    site,
+    users,
+    Site.Platforms.Github,
+  );
   return GitHub.setWebhook(site, githubAccessToken);
 };
 
-const listSiteWebhooks = async (site, users) => {
-  const githubAccessToken = await getAccessTokenWithAdminPermissions(site, users);
+const listSiteWebhooks = async (site, users, getAccessTokenWithAdminPermissions) => {
+  const githubAccessToken = await getAccessTokenWithAdminPermissions(
+    site,
+    users,
+    Site.Platforms.Github,
+  );
   return GitHub.listSiteWebhooks(site, githubAccessToken);
 };
 
-const loadBuildUserAccessToken = async (build) => {
-  let githubAccessToken;
-  const site = build.Site;
-  const users = await build.getSiteOrgUsers();
-  const buildUser = users.find((u) => u.id === build.user);
-  if (buildUser) {
-    githubAccessToken = await getAccessTokenWithPushPermissions(site, [buildUser]);
-  }
-  if (!githubAccessToken) {
-    /**
-     * an anonymous user (i.e. not through federalist) has pushed
-     * an update, we need to find a valid GitHub access token among the
-     * site's current users with which to report the build's status
-     */
-    githubAccessToken = await getAccessTokenWithPushPermissions(site, users);
-  }
-
-  if (!githubAccessToken) {
-    throw new Error(
-      `Unable to find valid access token to report build@id=${build.id} status`,
-    );
-  }
-  return githubAccessToken;
-};
-
-const reportBuildStatus = async (build) => {
-  const sha = build.clonedCommitSha || build.requestedCommitSha;
-  if (!sha) {
-    throw new Error('Build or commit sha undefined. Unable to report build status');
-  }
-
-  const accessToken = await loadBuildUserAccessToken(build);
-
-  const context =
-    config.app.appEnv === 'production'
-      ? `${config.app.product}/build`
-      : `${config.app.product}-${config.app.appEnv}/build`;
-
-  const site = build.Site;
-
-  const options = {
-    owner: site.owner,
-    repo: site.repository,
-    sha,
-    context,
-  };
-
-  if (build.isInProgress()) {
-    options.state = 'pending';
-    options.target_url = url.resolve(
-      config.app.hostname,
-      `/sites/${site.id}/builds/${build.id}/logs`,
-    );
-    options.description =
-      'The build is running. Click "Details" to see the Pages build status.';
-  } else if (build.state === 'success') {
-    options.state = 'success';
-    options.target_url = build.url;
-    options.description =
-      'The build is complete! Click "Details" to visit the Site Preview.';
-  } else if (build.state === 'error' || build.state === 'invalid') {
-    options.state = 'error';
-    options.target_url = url.resolve(
-      config.app.hostname,
-      `/sites/${site.id}/builds/${build.id}/logs`,
-    );
-    options.description =
-      'The build has encountered an error. Click "Details" to see the Pages build logs.';
-  }
-  return GitHub.sendCreateGithubStatusRequest(accessToken, options);
-};
-
-const fetchContent = async (build, path) => {
+const fetchContent = async (build, path, loadBuildUserAccessToken) => {
   if (!build.clonedCommitSha) {
     throw new Error(
       `Build or commit sha undefined. Unable to fetch ${path} for build@id=${build.id}`,
@@ -139,7 +34,5 @@ const fetchContent = async (build, path) => {
 module.exports = {
   createSiteWebhook,
   listSiteWebhooks,
-  reportBuildStatus,
   fetchContent,
-  loadBuildUserAccessToken,
 };

--- a/api/services/SiteBuildQueue.js
+++ b/api/services/SiteBuildQueue.js
@@ -10,8 +10,8 @@ const {
 const config = require('../../config');
 const CloudFoundryAPIClient = require('../utils/cfApiClient');
 const { sitePrefix, buildUrl } = require('../utils/build');
-const GithubBuildHelper = require('./GithubBuildHelper');
 const S3Helper = require('./S3Helper');
+const SourceCodePlatformHelper = require('./SourceCodePlatformHelper');
 
 const apiClient = new CloudFoundryAPIClient();
 
@@ -45,11 +45,18 @@ const buildUEVs = (uevs) =>
     : [];
 
 const generateDefaultCredentials = async (build) => {
-  const { engine, owner, repository, UserEnvironmentVariables, SiteBranchConfigs } =
-    build.Site;
+  const {
+    engine,
+    owner,
+    repository,
+    sourceCodePlatform,
+    UserEnvironmentVariables,
+    SiteBranchConfigs,
+  } = build.Site;
 
   const baseUrl = baseURLForBuild(build);
 
+  const token = await SourceCodePlatformHelper.getTokenForSiteBuild(build);
   return {
     STATUS_CALLBACK: statusCallbackURL(build),
     BASEURL: baseUrl,
@@ -58,20 +65,19 @@ const generateDefaultCredentials = async (build) => {
     REPOSITORY: repository,
     OWNER: owner,
     SITE_PREFIX: sitePrefix(build, build.Site),
-    GITHUB_TOKEN: (build.User || {}).githubAccessToken, // temp hot-fix
+    GITHUB_TOKEN: token,
     GENERATOR: engine,
     BUILD_ID: build.id,
     USER_ENVIRONMENT_VARIABLES: JSON.stringify(buildUEVs(UserEnvironmentVariables)),
+    SOURCE_CODE_PLATFORM: sourceCodePlatform,
+    SOURCE_CODE_PLATFORM_DOMAIN:
+      SourceCodePlatformHelper.getSourceCodePlatformDomain(sourceCodePlatform),
+    SOURCE_CODE_PLATFORM_TOKEN: token,
   };
 };
 
 const buildContainerEnvironment = async (build) => {
   const defaultCredentials = await generateDefaultCredentials(build);
-
-  if (!defaultCredentials.GITHUB_TOKEN) {
-    defaultCredentials.GITHUB_TOKEN =
-      await GithubBuildHelper.loadBuildUserAccessToken(build);
-  }
 
   return apiClient
     .fetchServiceInstanceCredentials(build.Site.s3ServiceName)

--- a/api/services/SiteCreator.js
+++ b/api/services/SiteCreator.js
@@ -1,17 +1,14 @@
 const GitHub = require('./GitHub');
-const GitLab = require('./GitLab');
-const GitLabHelper = require('./GitLabHelper');
+const SourceCodePlatformHelper = require('./SourceCodePlatformHelper');
 const TemplateResolver = require('./TemplateResolver');
 const { Build, Organization, Site, User } = require('../models');
 const utils = require('../utils');
 const CloudFoundryAPIClient = require('../utils/cfApiClient');
 const config = require('../../config');
-const { updateGitLabTokens } = require('./user');
-const { logger } = require('../../winston');
 
 const apiClient = new CloudFoundryAPIClient();
 
-const defaultEngine = 'jekyll';
+const defaultEngine = 'node.js';
 
 function paramsForNewSite(params) {
   const owner = params.owner ? params.owner.toLowerCase() : null;
@@ -107,8 +104,11 @@ async function checkRepositoryAndOrg({
   sourceCodePlatform,
   sourceCodeUrl,
 }) {
-  if (sourceCodePlatform === Site.Platforms.Workshop) {
-    return await checkGitlabRepository({ user, sourceCodeUrl });
+  if (SourceCodePlatformHelper.isWorkshop(sourceCodePlatform)) {
+    return await SourceCodePlatformHelper.getGitLabProjectToCreateSite(
+      user,
+      sourceCodeUrl,
+    );
   } else {
     const repo = await checkGithubRepository({ user, owner, repository });
     await checkGithubOrg({
@@ -135,21 +135,6 @@ function checkGithubRepository({ user, owner, repository }) {
     }
     return repo;
   });
-}
-
-function checkGitlabRepository({ user, sourceCodeUrl }) {
-  return GitLab.getProject(user, sourceCodeUrl, updateGitLabTokens).then(
-    async (response) => {
-      if (!response.ok) {
-        logger.error(await response.json());
-        throw {
-          message: `The repository ${sourceCodeUrl} does not exist.`,
-          status: response.status,
-        };
-      }
-      return await response.json();
-    },
-  );
 }
 
 function buildSite(params, s3) {
@@ -203,10 +188,7 @@ function validateSite(params) {
  * returns the new site record
  */
 async function saveAndBuildSite({ site, user }) {
-  const webhook =
-    site.sourceCodePlatform === Site.Platforms.Workshop
-      ? await GitLabHelper.createSiteWebhook(user, site)
-      : await GitHub.setWebhook(site, user.githubAccessToken);
+  const webhook = await SourceCodePlatformHelper.createSiteWebhook(user, site);
 
   // This will be `undefined` if the webhook already exists
   if (webhook) {

--- a/api/services/SourceCodePlatformHelper.js
+++ b/api/services/SourceCodePlatformHelper.js
@@ -1,0 +1,243 @@
+const { Site } = require('../models');
+const GithubBuildHelper = require('./GithubBuildHelper');
+const GitLabHelper = require('./GitLabHelper');
+const GitHub = require('./GitHub');
+const { domain } = require('../utils/build');
+const config = require('../../config');
+const url = require('url');
+const Organization = require('./organization');
+
+const PULL = [
+  GitLabHelper.GITLAB_ACCESS_LEVEL_REPORTER,
+  GitLabHelper.GITLAB_ACCESS_LEVEL_DEVELOPER,
+  GitLabHelper.GITLAB_ACCESS_LEVEL_MAINTAINER,
+  GitLabHelper.GITLAB_ACCESS_LEVEL_OWNER,
+];
+
+const PUSH = [
+  GitLabHelper.GITLAB_ACCESS_LEVEL_DEVELOPER,
+  GitLabHelper.GITLAB_ACCESS_LEVEL_MAINTAINER,
+  GitLabHelper.GITLAB_ACCESS_LEVEL_OWNER,
+];
+
+const ADMIN = [
+  GitLabHelper.GITLAB_ACCESS_LEVEL_MAINTAINER,
+  GitLabHelper.GITLAB_ACCESS_LEVEL_OWNER,
+];
+
+const isWorkshop = (sourceCodePlatform) => sourceCodePlatform === Site.Platforms.Workshop;
+
+const reportBuildStatus = async (build) => {
+  const sha = build.clonedCommitSha || build.requestedCommitSha;
+  if (!sha) {
+    throw new Error('Build or commit sha undefined. Unable to report build status');
+  }
+
+  const context =
+    config.app.appEnv === 'production'
+      ? `${config.app.product}/build`
+      : `${config.app.product}-${config.app.appEnv}/build`;
+
+  const site = build.Site;
+
+  const options = {
+    owner: site.owner,
+    repo: site.repository,
+    sha,
+    context,
+  };
+
+  const workshop = isWorkshop(site.sourceCodePlatform);
+
+  if (build.isInProgress()) {
+    options.state = 'pending';
+    options.target_url = url.resolve(
+      config.app.hostname,
+      `/sites/${site.id}/builds/${build.id}/logs`,
+    );
+    options.description =
+      'The build is running. Click "Details" to see the Pages build status.';
+  } else if (build.state === 'success') {
+    options.state = 'success';
+    options.target_url = build.url;
+    options.description =
+      'The build is complete! Click "Details" to visit the Site Preview.';
+  } else if (build.state === 'error' || build.state === 'invalid') {
+    options.state = workshop ? 'failed' : 'error';
+    options.target_url = url.resolve(
+      config.app.hostname,
+      `/sites/${site.id}/builds/${build.id}/logs`,
+    );
+    options.description =
+      'The build has encountered an error. Click "Details" to see the Pages build logs.';
+  }
+
+  const accessToken = await loadBuildUserAccessToken(build);
+
+  return workshop
+    ? await GitLabHelper.sendCommitStatus(accessToken, site, options)
+    : await GitHub.sendCreateGithubStatusRequest(accessToken, options);
+};
+
+const createSiteWebhook = async (user, site) => {
+  if (isWorkshop(site.sourceCodePlatform)) {
+    return await GitLabHelper.createSiteWebhook(user, site);
+  } else {
+    const users = await Organization.getOrganizationUsers(site);
+    return await GithubBuildHelper.createSiteWebhook(
+      site,
+      users,
+      getAccessTokenWithAdminPermissions,
+    );
+  }
+};
+
+const listSiteWebhooks = async (user, site, users) =>
+  isWorkshop(site.sourceCodePlatform)
+    ? await GitLabHelper.listSiteWebhooks(user, site)
+    : await GithubBuildHelper.listSiteWebhooks(
+        site,
+        users,
+        getAccessTokenWithAdminPermissions,
+      );
+
+const getSourceCodePlatformDomain = (sourceCodePlatform) =>
+  isWorkshop(sourceCodePlatform)
+    ? domain(GitLabHelper.getGitLabBaseUrl())
+    : domain(config.app.githubBaseUrl);
+
+const getTokenForSiteBuild = async (build) => {
+  const workshop = isWorkshop(build.Site?.sourceCodePlatform);
+  let token = workshop
+    ? build.User && (await GitLabHelper.getUserOAuthAccessToken(build.User))
+    : build.User?.githubAccessToken;
+  if (!token) token = await loadBuildUserAccessToken(build);
+
+  return workshop ? `oauth2:${token}` : token;
+};
+
+const getProcessedGitLabWebhookPayload = (payload) =>
+  GitLabHelper.getProcessedWebhookPayload(payload);
+
+const getGitLabProjectToCreateSite = async (user, sourceCodeUrl) =>
+  await GitLabHelper.getGitLabProjectToCreateSite(user, sourceCodeUrl);
+
+const getUsersWithToken = (users, sourceCodePlatform) =>
+  isWorkshop(sourceCodePlatform)
+    ? getUsersWithGitLabToken(users)
+    : getUsersWithGitHubToken(users);
+
+const getUsersWithGitHubToken = (users) =>
+  users
+    .filter((u) => u.githubAccessToken && u.signedInAt)
+    .sort((a, b) => b.signedInAt - a.signedInAt);
+
+const getUsersWithGitLabToken = (users) =>
+  users
+    .filter((u) => u.gitlabToken)
+    .sort((a, b) => b.gitlabExpiresAt - a.gitlabExpiresAt);
+
+const mapGitLabAccessLevelToGitHubPermissions = (accessLevel) => ({
+  pull: PULL.includes(accessLevel),
+  push: PUSH.includes(accessLevel),
+  admin: ADMIN.includes(accessLevel),
+});
+
+const getPermissions = async (user, site, sourceCodeUrl) =>
+  isWorkshop(sourceCodeUrl)
+    ? mapGitLabAccessLevelToGitHubPermissions(
+        await GitLabHelper.getProjectAccessLevel(user, site.sourceCodeUrl),
+      )
+    : await GitHub.checkPermissions(user, site.owner, site.repository);
+
+const getToken = (user, sourceCodeUrl) =>
+  isWorkshop(sourceCodeUrl) ? user.gitlabToken : user.githubAccessToken;
+
+// Loops through supplied list of users, until it
+// finds a user with a valid access token
+const getAccessTokenWithCertainPermissions = async (
+  site,
+  users,
+  permission,
+  sourceCodePlatform,
+) => {
+  let count = 0;
+
+  if (!users) {
+    return null;
+  }
+
+  const filteredUsers = getUsersWithToken(users, sourceCodePlatform);
+
+  const getNextToken = async (user) => {
+    try {
+      if (!user) {
+        return null;
+      }
+      const permissions = await getPermissions(user, site, sourceCodePlatform);
+
+      if (permissions[permission]) {
+        return getToken(user, sourceCodePlatform);
+      }
+      count += 1;
+      return getNextToken(filteredUsers[count]);
+    } catch {
+      count += 1;
+      return getNextToken(filteredUsers[count]);
+    }
+  };
+
+  return getNextToken(filteredUsers[count]);
+};
+
+const getAccessTokenWithPushPermissions = async (site, users, sourceCodePlatform) =>
+  getAccessTokenWithCertainPermissions(site, users, 'push', sourceCodePlatform);
+
+const getAccessTokenWithAdminPermissions = async (site, users, sourceCodePlatform) =>
+  getAccessTokenWithCertainPermissions(site, users, 'admin', sourceCodePlatform);
+
+const loadBuildUserAccessToken = async (build) => {
+  let accessToken;
+  const site = build.Site;
+  const users = await build.getSiteOrgUsers();
+  const buildUser = users.find((u) => u.id === build.user);
+
+  if (buildUser) {
+    accessToken = await getAccessTokenWithPushPermissions(
+      site,
+      [buildUser],
+      site.sourceCodePlatform,
+    );
+  }
+  if (!accessToken) {
+    /**
+     * an anonymous user (i.e. not through federalist) has pushed
+     * an update, we need to find a valid GitHub access token among the
+     * site's current users with which to report the build's status
+     */
+    accessToken = await getAccessTokenWithPushPermissions(
+      site,
+      users,
+      site.sourceCodePlatform,
+    );
+  }
+
+  if (!accessToken) {
+    throw new Error(
+      `Unable to find valid access token to report build@id=${build.id} status`,
+    );
+  }
+  return accessToken;
+};
+
+module.exports = {
+  isWorkshop,
+  createSiteWebhook,
+  listSiteWebhooks,
+  reportBuildStatus,
+  getSourceCodePlatformDomain,
+  getTokenForSiteBuild,
+  getProcessedGitLabWebhookPayload,
+  getGitLabProjectToCreateSite,
+  loadBuildUserAccessToken,
+};

--- a/api/services/Webhooks.js
+++ b/api/services/Webhooks.js
@@ -1,7 +1,7 @@
 const config = require('../../config');
 const { Build, User, Site, Event, Organization } = require('../models');
 const authorizer = require('../authorizers/site');
-const GithubBuildHelper = require('./GithubBuildHelper');
+const SourceCodePlatformHelper = require('./SourceCodePlatformHelper');
 const EventCreator = require('./EventCreator');
 const SiteDestroyer = require('../services/SiteDestroyer');
 const { fetchModelById } = require('../utils/queryDatabase');
@@ -9,8 +9,17 @@ const { BuildService } = require('./build');
 
 const { OPS_EMAIL } = process.env;
 
-const findSiteForWebhookRequest = (payload) => {
-  const [owner, repository] = payload.repository.full_name.split('/');
+const getOwnerAndRepository = (payload, sourceCodePlatform) => {
+  if (SourceCodePlatformHelper.isWorkshop(sourceCodePlatform)) {
+    return { owner: payload.owner, repository: payload.repository.repository_path };
+  } else {
+    const [owner, repository] = payload.repository.full_name.split('/');
+    return { owner, repository };
+  }
+};
+
+const findSiteForWebhookRequest = (payload, sourceCodePlatform) => {
+  const { owner, repository } = getOwnerAndRepository(payload, sourceCodePlatform);
 
   return Site.findAll({
     where: {
@@ -153,16 +162,19 @@ const createBuildForWebhookRequest = async (payload, site) => {
   }).then((build) => BuildService.enqueueOrLogBuild(build));
 };
 
-const pushWebhookRequest = async (payload) => {
+const pushWebhookRequest = async (
+  payload,
+  sourceCodePlatform = Site.Platforms.Github,
+) => {
   if (payload.commits && payload.commits.length > 0) {
-    const sites = await findSiteForWebhookRequest(payload);
+    const sites = await findSiteForWebhookRequest(payload, sourceCodePlatform);
 
     await Promise.all(
       sites.map(async (site) => {
         if (shouldBuildForSite(site)) {
           const build = await createBuildForWebhookRequest(payload, site);
           await build.reload({ include: Site });
-          await GithubBuildHelper.reportBuildStatus(build);
+          await SourceCodePlatformHelper.reportBuildStatus(build);
         }
       }),
     );

--- a/api/services/organization/Organization.js
+++ b/api/services/organization/Organization.js
@@ -262,4 +262,20 @@ module.exports = {
   activateOrganization(organization) {
     return organization.update({ isActive: true });
   },
+
+  async getOrganizationUsers(site) {
+    const organization = await Organization.findOne({
+      where: {
+        id: site.organizationId,
+      },
+      include: [
+        {
+          model: OrganizationRole,
+          include: [Role, User],
+        },
+      ],
+    });
+
+    return organization?.OrganizationRoles?.map((role) => role.User);
+  },
 };

--- a/api/services/organization/index.js
+++ b/api/services/organization/index.js
@@ -11,4 +11,6 @@ module.exports = {
     OrganizationService.deactivateOrganization.bind(OrganizationService),
   activateOrganization:
     OrganizationService.activateOrganization.bind(OrganizationService),
+  getOrganizationUsers:
+    OrganizationService.getOrganizationUsers.bind(OrganizationService),
 };

--- a/api/utils/build.js
+++ b/api/utils/build.js
@@ -54,4 +54,6 @@ function sitePrefix(build, site) {
   return path.replace(/^(\/)+/, '');
 }
 
-module.exports = { buildUrl, sitePrefix };
+const domain = (url) => new URL(url).hostname;
+
+module.exports = { buildUrl, sitePrefix, domain };

--- a/api/utils/cfApiClient.js
+++ b/api/utils/cfApiClient.js
@@ -275,6 +275,7 @@ class CloudFoundryAPIClient {
       onlyEncryptKeys: [
         'STATUS_CALLBACK',
         'GITHUB_TOKEN',
+        'SOURCE_CODE_PLATFORM_TOKEN',
         'AWS_ACCESS_KEY_ID',
         'AWS_SECRET_ACCESS_KEY',
         'BUCKET',

--- a/api/utils/site.js
+++ b/api/utils/site.js
@@ -1,9 +1,7 @@
 const config = require('../../config');
-const { getBaseUrl } = require('../services/GitLab');
-const env = require('../../services/environment')();
+const GitLab = require('../services/GitLab');
 
 const { proxyDomain, githubBaseUrl } = config.app;
-const gitlabBaseUrl = getBaseUrl(env.GITLAB_BASE_URL);
 
 function path(site, deployment) {
   return `/${deployment}/${site.owner}/${site.repository}`;
@@ -19,7 +17,7 @@ function siteViewDomain(site) {
 
 function buildSourceCodeUrl(owner, repository, sourceCodePlatform, platformsWorkshop) {
   // eslint-disable-next-line max-len
-  return `${sourceCodePlatform === platformsWorkshop ? gitlabBaseUrl : githubBaseUrl}/${owner}/${repository}`;
+  return `${sourceCodePlatform === platformsWorkshop ? GitLab.getBaseUrl() : githubBaseUrl}/${owner}/${repository}`;
 }
 
 function siteViewLink(site, deployment = 'site') {

--- a/api/workers/jobProcessors/siteBuildRunner.js
+++ b/api/workers/jobProcessors/siteBuildRunner.js
@@ -83,6 +83,7 @@ async function siteBuildRunner(job, { sleepNumber = 15000, totalAttempts = 180 }
       state: Build.States.Error,
       error: err?.message,
     });
+    logger.log(err?.stack);
     throw new Error(message);
   }
 }

--- a/config/passport.js
+++ b/config/passport.js
@@ -49,7 +49,7 @@ module.exports = {
       clientID: gitlabClientID,
       clientSecret: gitlabClientSecret,
       callbackURL: `${env.APP_HOSTNAME}/auth/gitlab/callback`,
-      scope: ['read_repository api'],
+      scope: ['api'],
       state: true,
       responseType: 'code',
       passReqToCallback: true, // to extract refresh token and expires at.

--- a/config/webhook.js
+++ b/config/webhook.js
@@ -5,4 +5,5 @@ module.exports = {
   endpoint: env.GITHUB_WEBHOOK_URL || 'http://localhost:1337/webhook/github',
   secret: env.GITHUB_WEBHOOK_SECRET || 'testingSecret',
   gitlabEndpoint: env.GITLAB_WEBHOOK_URL || 'https://pages-dev.cloud.gov/webhook/gitlab',
+  gitlabSecret: env.GITLAB_WEBHOOK_SECRET || 'gitlabTestingSecret',
 };

--- a/docker-compose.workers.yml
+++ b/docker-compose.workers.yml
@@ -23,6 +23,10 @@ services:
       APP_HOSTNAME: http://localhost:1337
       NODE_ENV: development
       PRODUCT: pages
+      CLOUD_FOUNDRY_API_HOST: ${CLOUD_FOUNDRY_API_HOST}
+      CLOUD_FOUNDRY_OAUTH_TOKEN_URL: ${CLOUD_FOUNDRY_API_HOST}/oauth/token
+      CF_API_USERNAME: ${CF_API_USERNAME}
+      CF_API_PASSWORD: ${CF_API_PASSWORD}
   federalist-worker:
     build:
       dockerfile: Dockerfile-app
@@ -41,3 +45,7 @@ services:
       APP_HOSTNAME: http://localhost:1338
       NODE_ENV: development
       PRODUCT: federalist
+      CLOUD_FOUNDRY_API_HOST: ${CLOUD_FOUNDRY_API_HOST}
+      CLOUD_FOUNDRY_OAUTH_TOKEN_URL: ${CLOUD_FOUNDRY_API_HOST}/oauth/token
+      CF_API_USERNAME: ${CF_API_USERNAME}
+      CF_API_PASSWORD: ${CF_API_PASSWORD}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -142,10 +142,10 @@ Endpoints:
 Fetch service instanaces:
 - __/v3/service_instances__
 
-Fetch service instanace credentials binding name:
+Fetch service instance credentials binding name:
 - __/v3/service_credential_bindings?service_instance_names=name__
 
-Fetch service instanace credentials by binding guid
+Fetch service instance credentials by binding guid
 - __/v3/service_credential_bindings/:guid/details__
 
 #### Front end application

--- a/frontend/pages/sites/new/AddRepoSiteForm.test.jsx
+++ b/frontend/pages/sites/new/AddRepoSiteForm.test.jsx
@@ -55,6 +55,7 @@ describe('<AddRepoSiteForm />', () => {
     submitting: false,
     invalid: false,
     valid: true,
+    initialValues: {},
   };
 
   it("renders selection for site's engine", () => {

--- a/frontend/pages/sites/new/index.jsx
+++ b/frontend/pages/sites/new/index.jsx
@@ -121,7 +121,7 @@ function AddSite() {
       <div className="grid-col-8">
         <AddRepoSiteForm
           initialValues={{
-            engine: 'jekyll',
+            engine: 'node.js',
           }}
           organizations={organizations}
           showAddNewSiteFields={showAddNewSiteFields}

--- a/services/local/docker.env
+++ b/services/local/docker.env
@@ -2,4 +2,6 @@ MINIO_ROOT_USER=objectstoreaccesskey
 MINIO_ROOT_PASSWORD=objectstoreyoursecretkey
 MINIO_ENDPOINT_URL=http://minio:9000
 CLOUD_FOUNDRY_API_HOST=http://mock-cf-api:3456
+CF_API_USERNAME=deploy_user
+CF_API_PASSWORD=deploy_pass
 SITES_SERVICE_NAMES=o-user1-r-example-site,o-user1-r-example-go-site,o-user1-r-example-node-site,o-user3-r-another-example-hugo-site,o-user4-r-another-example-node-site

--- a/services/local/mock-cf-api/createResponse.js
+++ b/services/local/mock-cf-api/createResponse.js
@@ -12,7 +12,7 @@ function createResponse() {
   return factory.createCFAPIResourceList({ resources: resources });
 }
 
-function createS3ServiceInstanaces() {
+function createS3ServiceInstances() {
   const response = createResponse();
 
   return response;
@@ -50,7 +50,7 @@ function createS3ServiceBindingDetails(guid) {
 }
 
 module.exports = {
-  createS3ServiceInstanaces,
+  createS3ServiceInstances,
   createS3ServiceBindings,
   createS3ServiceBindingDetails,
 };

--- a/services/local/mock-cf-api/index.js
+++ b/services/local/mock-cf-api/index.js
@@ -3,22 +3,67 @@ const express = require('express');
 const jwt = require('jsonwebtoken');
 const app = express();
 const {
-  createS3ServiceInstanaces,
+  createS3ServiceInstances,
   createS3ServiceBindings,
   createS3ServiceBindingDetails,
 } = require('./createResponse');
 
 const PORT = 3456;
 
-// Fetch service instanaces
-app.get('/v3/service_instances', (_, res) => {
-  const response = createS3ServiceInstanaces();
+const { MINIO_ROOT_USER, MINIO_ROOT_PASSWORD } = process.env;
+const s3ServiceInstancesMap = new Map();
+
+// Fetch service instances
+app.post('/v3/service_instances', express.json(), (req, res) => {
+  const response = createS3ServiceInstances();
+
+  const newS3ServiceInstance = {
+    guid: req.body.name,
+    name: req.body.name,
+    relationships: {},
+  };
+
+  response.resources.push(newS3ServiceInstance);
+  s3ServiceInstancesMap.set(req.body.name, newS3ServiceInstance);
 
   res.json(response);
 });
 
-// Fetch service instanace credentials bindings by name
+app.get('/v3/service_instances', (_, res) => {
+  const response = createS3ServiceInstances();
+
+  response.resources.push(...s3ServiceInstancesMap.values());
+
+  res.json(response);
+});
+
+app.get('/v3/service_plans', async (req, res) => {
+  const response = createS3ServiceInstances();
+
+  res.json(response);
+});
+
+// Fetch service instance credentials bindings by name
 app.get('/v3/service_credential_bindings', (req, res) => {
+  const { query } = req;
+  const { service_instance_names, names } = query;
+
+  const response = createS3ServiceBindings(service_instance_names);
+
+  response.resources.push({
+    name: names,
+    credentials: {
+      access_key_id: MINIO_ROOT_USER,
+      secret_access_key: MINIO_ROOT_PASSWORD,
+      region: 'us-gov-west-1',
+      bucket: `${names}-key`,
+    },
+  });
+
+  res.json(response);
+});
+
+app.post('/v3/service_credential_bindings', (req, res) => {
   const { query } = req;
   const { service_instance_names } = query;
 
@@ -27,12 +72,26 @@ app.get('/v3/service_credential_bindings', (req, res) => {
   res.json(response);
 });
 
-// Fetch service instanace credentials by binding guid
+// Fetch service instance credentials by binding guid
 app.get('/v3/service_credential_bindings/:guid/details', (req, res) => {
   const { params } = req;
   const { guid } = params;
 
-  const response = createS3ServiceBindingDetails(guid);
+  let response;
+
+  try {
+    response = createS3ServiceBindingDetails(guid);
+  } catch {
+    response = {
+      name: guid,
+      credentials: {
+        access_key_id: MINIO_ROOT_USER,
+        secret_access_key: MINIO_ROOT_PASSWORD,
+        region: 'us-gov-west-1',
+        bucket: 'cg-123456789',
+      },
+    };
+  }
 
   res.json(response);
 });

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -15,6 +15,8 @@ const validateAgainstJSONSchema = require('../support/validateAgainstJSONSchema'
 const csrfToken = require('../support/csrfToken');
 const { createSiteUserOrg } = require('../support/site-user');
 const utils = require('../../../api/utils');
+// eslint-disable-next-line max-len
+const SourceCodePlatformHelper = require('../../../api/services/SourceCodePlatformHelper');
 
 const { Organization, Role, Site } = require('../../../api/models');
 const SiteDestroyer = require('../../../api/services/SiteDestroyer');
@@ -27,6 +29,9 @@ const authErrorMessage =
 describe('Site API', () => {
   beforeEach(() => {
     sinon.stub(QueueJobs.prototype, 'startSiteBuild').resolves();
+    sinon
+      .stub(SourceCodePlatformHelper, 'createSiteWebhook')
+      .resolves({ data: { id: 1 } });
     sinon.stub(EventCreator, 'error').resolves();
     sinon.stub(utils, 'generateS3ServiceName').callsFake((owner, repo) => {
       if (!owner || !repo) return undefined;
@@ -636,9 +641,31 @@ describe('Site API', () => {
     it('should respond with a 400 if a webhook cannot be created', (done) => {
       const siteOwner = crypto.randomBytes(3).toString('hex');
       const siteRepository = crypto.randomBytes(3).toString('hex');
+      SourceCodePlatformHelper.createSiteWebhook.restore();
 
       nock.cleanAll();
-      githubAPINocks.repo();
+
+      githubAPINocks.repo({
+        accessToken: 'fake-access-token',
+        owner: siteOwner,
+        repo: siteRepository,
+        response: [
+          200,
+          {
+            permissions: {
+              admin: true,
+              push: false,
+            },
+          },
+        ],
+      });
+
+      sinon.stub(Site.prototype, 'getOrgUsers').resolves([
+        {
+          githubAccessToken: 'fake-access-token',
+          signedInAt: new Date(),
+        },
+      ]);
       githubAPINocks.webhook({
         owner: siteOwner,
         repo: siteRepository,

--- a/test/api/support/gitlabAPINocks.js
+++ b/test/api/support/gitlabAPINocks.js
@@ -1,0 +1,58 @@
+const nock = require('nock');
+
+const getClientCredentials = (gitlabConfig) => ({
+  client_id: gitlabConfig.clientID,
+  client_secret: gitlabConfig.clientSecret,
+});
+
+const getHeaders = (accessToken) => {
+  return {
+    'Content-Type': 'application/x-www-form-urlencoded',
+    Authorization: `Bearer ${accessToken}`,
+  };
+};
+
+const getReqHeaders = (accessToken) => {
+  return { reqheaders: getHeaders(accessToken) };
+};
+
+const getRefreshTokenBody = (gitlabConfig, refreshToken) => {
+  return {
+    ...getClientCredentials(gitlabConfig),
+    refresh_token: refreshToken,
+    grant_type: 'refresh_token',
+    redirect_uri: gitlabConfig.callbackURL,
+  };
+};
+
+const getRefreshToken200Response = ({
+  access_token,
+  expires_in,
+  refresh_token,
+  created_at,
+} = {}) => ({
+  access_token: access_token || 'new-access-token',
+  expires_in: expires_in || 7200,
+  refresh_token: refresh_token || 'new-refresh-token',
+  created_at: created_at || 1774285431,
+});
+
+function nockRefreshTokenWithResponse(
+  gitlabConfig,
+  accessToken,
+  refreshToken,
+  responseStatusCode,
+  response,
+) {
+  return nock(gitlabConfig.baseURL, getReqHeaders(accessToken))
+    .post('/oauth/token', getRefreshTokenBody(gitlabConfig, refreshToken))
+    .reply(responseStatusCode, response);
+}
+
+module.exports = {
+  getClientCredentials,
+  getReqHeaders,
+  getRefreshTokenBody,
+  getRefreshToken200Response,
+  nockRefreshTokenWithResponse,
+};

--- a/test/api/unit/services/GitLab.test.js
+++ b/test/api/unit/services/GitLab.test.js
@@ -3,30 +3,25 @@ const nock = require('nock');
 const sinon = require('sinon');
 
 const config = require('../../../../config');
-const {
-  fetchRefreshTokens,
-  revokeUserGitLabTokens,
-  getBaseUrl,
-} = require('../../../../api/services/GitLab');
 const { logger } = require('../../../../winston');
+const {
+  getReqHeaders,
+  getRefreshTokenBody,
+  nockRefreshTokenWithResponse,
+  getClientCredentials,
+  getRefreshToken200Response,
+} = require('../../support/gitlabAPINocks');
+const {
+  fetchRefreshUserOAuthTokens,
+  normalizeUrl,
+  revokeUserOAuthTokens,
+} = require('../../../../api/services/GitLab');
 
 const { authorizationOptions: gitlabConfig } = config.passport.gitlab;
 gitlabConfig.clientID = 'mock-client-id';
 gitlabConfig.clientSecret = 'mock-client-secret';
 gitlabConfig.callbackURL = 'https://localhost:1337/auth/gitlab/callback';
-gitlabConfig.baseURL = 'http://workshop.cloud.gov/';
-
-const clientCredentials = {
-  client_id: gitlabConfig.clientID,
-  client_secret: gitlabConfig.clientSecret,
-};
-
-const refreshToken200Response = {
-  access_token: 'new-access-token',
-  expires_in: 7200,
-  refresh_token: 'new-refresh-token',
-  created_at: '2026-03-17T17:22:09.904Z',
-};
+gitlabConfig.baseURL = 'https://workshop.cloud.gov/';
 
 const refreshToken400Response = {
   error: 'invalid_grant',
@@ -43,29 +38,9 @@ function getMockUser() {
   };
 }
 
-function getHeaders(accessToken) {
-  return {
-    'Content-Type': 'application/x-www-form-urlencoded',
-    Authorization: `Bearer ${accessToken}`,
-  };
-}
-
-function getReqheaders(accessToken) {
-  return { reqheaders: getHeaders(accessToken) };
-}
-
-function getRefreshTokenBody(refreshToken) {
-  return {
-    ...clientCredentials,
-    refresh_token: refreshToken,
-    grant_type: 'refresh_token',
-    redirect_uri: gitlabConfig.callbackURL,
-  };
-}
-
 function nockRevokeToken(accessToken, tokenToRevoke) {
-  return nock(gitlabConfig.baseURL, getReqheaders(accessToken)).post('/oauth/revoke', {
-    ...clientCredentials,
+  return nock(gitlabConfig.baseURL, getReqHeaders(accessToken)).post('/oauth/revoke', {
+    ...getClientCredentials(gitlabConfig),
     token: tokenToRevoke,
   });
 }
@@ -83,54 +58,45 @@ function nockRevokeTokenWithError(tokenToRevoke, accessToken, error) {
   return nockRevokeToken(accessToken, tokenToRevoke).replyWithError(error);
 }
 
-function nockRefreshTokenWithResponse(
-  accessToken,
-  refreshToken,
-  responseStatusCode,
-  response,
-) {
-  return nock(gitlabConfig.baseURL, getReqheaders(accessToken))
-    .post('/oauth/token', getRefreshTokenBody(refreshToken))
-    .reply(responseStatusCode, response);
-}
-
 function nockRefreshTokenWithError(accessToken, refreshToken, error) {
-  return nock(gitlabConfig.baseURL, getReqheaders(accessToken))
-    .post('/oauth/token', getRefreshTokenBody(refreshToken))
+  return nock(gitlabConfig.baseURL, getReqHeaders(accessToken))
+    .post('/oauth/token', getRefreshTokenBody(gitlabConfig, refreshToken))
     .replyWithError(error);
 }
 
 describe('GitLab', () => {
-  describe('.fetchRefreshTokens(user)', () => {
+  describe('.fetchRefreshUserOAuthTokens(user)', () => {
     afterEach(() => {
       nock.cleanAll();
     });
 
-    it('should call GitLab oauth/token endpoint and return response 200', async () => {
+    it('should call  oauth/token endpoint and return response 200', async () => {
       const user = getMockUser();
       const refresh = nockRefreshTokenWithResponse(
+        gitlabConfig,
         user.gitlabToken,
         user.gitlabRefreshToken,
         200,
-        refreshToken200Response,
+        getRefreshToken200Response(),
       );
-      const response = await fetchRefreshTokens(user);
+      const response = await fetchRefreshUserOAuthTokens(user);
 
       expect(response.ok).to.equal(true);
-      expect(await response.json()).to.deep.equal(refreshToken200Response);
+      expect(await response.json()).to.deep.equal(getRefreshToken200Response());
       expect(refresh.isDone()).to.equal(true);
     });
 
-    it('should call GitLab oauth/token endpoint and return response 400', async () => {
+    it('should call  oauth/token endpoint and return response 400', async () => {
       const user = getMockUser();
       const refresh = nockRefreshTokenWithResponse(
+        gitlabConfig,
         user.gitlabToken,
         user.gitlabRefreshToken,
         400,
         refreshToken400Response,
       );
 
-      const response = await fetchRefreshTokens(user);
+      const response = await fetchRefreshUserOAuthTokens(user);
 
       expect(response.ok).to.be.false;
       expect(response.status).to.equal(400);
@@ -139,9 +105,10 @@ describe('GitLab', () => {
     });
   });
 
-  describe('.revokeUserGitLabTokens(user)', () => {
+  describe('.revokeUserOAuthTokens(user, resetUserOAuthTokens)', () => {
     let loggerWarnStub;
     let loggerErrorStub;
+    let resetUserOAuthTokensStub;
 
     beforeEach(() => {
       nock.cleanAll();
@@ -149,6 +116,7 @@ describe('GitLab', () => {
 
       loggerWarnStub = sinon.stub(logger, 'warn');
       loggerErrorStub = sinon.stub(logger, 'error');
+      resetUserOAuthTokensStub = sinon.stub();
     });
 
     afterEach(() => {
@@ -172,17 +140,19 @@ describe('GitLab', () => {
         {},
       );
       const refresh = nockRefreshTokenWithResponse(
+        gitlabConfig,
         user.gitlabToken,
         user.gitlabRefreshToken,
         400,
         refreshToken400Response,
       );
 
-      await revokeUserGitLabTokens(user);
+      await revokeUserOAuthTokens(user, resetUserOAuthTokensStub);
 
       expect(revokeAccessToken.isDone()).to.be.true;
       expect(revokeRefreshToken.isDone()).to.be.true;
       expect(refresh.isDone()).to.be.true;
+      expect(resetUserOAuthTokensStub.called).to.be.true;
 
       expect(loggerWarnStub.called).to.be.false;
       expect(loggerErrorStub.called).to.be.false;
@@ -204,22 +174,24 @@ describe('GitLab', () => {
         {},
       );
       const refresh = nockRefreshTokenWithResponse(
+        gitlabConfig,
         user.gitlabToken,
         user.gitlabRefreshToken,
         200,
-        refreshToken200Response,
+        getRefreshToken200Response(),
       );
 
-      await revokeUserGitLabTokens(user);
+      await revokeUserOAuthTokens(user, resetUserOAuthTokensStub);
 
       expect(revokeAccessToken.isDone()).to.be.true;
       expect(revokeRefreshToken.isDone()).to.be.true;
       expect(refresh.isDone()).to.be.true;
+      expect(resetUserOAuthTokensStub.called).to.be.true;
 
       expect(loggerWarnStub.called).to.be.true;
       expect(loggerWarnStub.args[0]).to.deep.equal([
         'GitLab: Unexpected token refresh response after tokens were revoked: 200',
-        refreshToken200Response,
+        getRefreshToken200Response(),
       ]);
       expect(loggerErrorStub.called).to.be.false;
     });
@@ -239,17 +211,19 @@ describe('GitLab', () => {
         {},
       );
       const refresh = nockRefreshTokenWithResponse(
+        gitlabConfig,
         user.gitlabToken,
         user.gitlabRefreshToken,
         400,
         refreshToken400Response,
       );
 
-      await revokeUserGitLabTokens(user);
+      await revokeUserOAuthTokens(user, resetUserOAuthTokensStub);
 
       expect(revokeAccessToken.isDone()).to.be.true;
       expect(revokeRefreshToken.isDone()).to.be.true;
       expect(refresh.isDone()).to.be.true;
+      expect(resetUserOAuthTokensStub.called).to.be.true;
 
       expect(loggerWarnStub.called).to.be.false;
       expect(loggerErrorStub.called).to.be.true;
@@ -276,17 +250,19 @@ describe('GitLab', () => {
         'Network error while revoking refresh token.',
       );
       const refresh = nockRefreshTokenWithResponse(
+        gitlabConfig,
         user.gitlabToken,
         user.gitlabRefreshToken,
         400,
         refreshToken400Response,
       );
 
-      await revokeUserGitLabTokens(user);
+      await revokeUserOAuthTokens(user, resetUserOAuthTokensStub);
 
       expect(revokeAccessToken.isDone()).to.be.true;
       expect(revokeRefreshToken.isDone()).to.be.true;
       expect(refresh.isDone()).to.be.true;
+      expect(resetUserOAuthTokensStub.called).to.be.true;
 
       expect(loggerWarnStub.called).to.be.false;
       expect(loggerErrorStub.called).to.be.true;
@@ -319,11 +295,12 @@ describe('GitLab', () => {
         'Network error while refreshing tokens.',
       );
 
-      await revokeUserGitLabTokens(user);
+      await revokeUserOAuthTokens(user, resetUserOAuthTokensStub);
 
       expect(revokeAccessToken.isDone()).to.be.true;
       expect(revokeRefreshToken.isDone()).to.be.true;
       expect(refresh.isDone()).to.be.true;
+      expect(resetUserOAuthTokensStub.called).to.be.true;
 
       expect(loggerWarnStub.called).to.be.false;
       expect(loggerErrorStub.called).to.be.true;
@@ -336,23 +313,23 @@ describe('GitLab', () => {
     });
   });
 
-  describe('.getBaseUrl()', () => {
+  describe('.normalizeUrl()', () => {
     it('should remove trailing slash from url', async () => {
       gitlabConfig.baseURL = 'https://workshop.cloud.gov/trailing_slash/';
-      expect(getBaseUrl(gitlabConfig.baseURL)).to.equal(
+      expect(normalizeUrl(gitlabConfig.baseURL)).to.equal(
         'https://workshop.cloud.gov/trailing_slash',
       );
     });
 
     it('should not update url if there is no trailing slash', async () => {
       gitlabConfig.baseURL = 'https://workshop.cloud.gov/no_trailing_slash';
-      expect(getBaseUrl(gitlabConfig.baseURL)).to.equal(
+      expect(normalizeUrl(gitlabConfig.baseURL)).to.equal(
         'https://workshop.cloud.gov/no_trailing_slash',
       );
     });
-  });
 
-  it('does not throw an error', async () => {
-    expect(getBaseUrl(null)).to.equal(undefined);
+    it('does not throw an error', async () => {
+      expect(normalizeUrl(null)).to.equal(undefined);
+    });
   });
 });

--- a/test/api/unit/services/GitLabHelper.test.js
+++ b/test/api/unit/services/GitLabHelper.test.js
@@ -1,0 +1,107 @@
+const { expect } = require('chai');
+
+const config = require('../../../../config');
+const { getProcessedWebhookPayload } = require('../../../../api/services/GitLabHelper');
+
+const { authorizationOptions: gitlabConfig } = config.passport.gitlab;
+gitlabConfig.clientID = 'mock-client-id';
+gitlabConfig.clientSecret = 'mock-client-secret';
+gitlabConfig.callbackURL = 'https://localhost:1337/auth/gitlab/callback';
+gitlabConfig.baseURL = 'https://workshop.cloud.gov/';
+
+describe('GitLabHelper', () => {
+  describe('.getProcessedWebhookPayload(payload)', () => {
+    const payload = {
+      object_kind: 'push',
+      event_name: 'push',
+      before: '95790bf891e76fee5e1747ab589903a6a1f80f22',
+      after: 'da1560886d4f094c3e6c9ef40349f7d38b5d27d7',
+      ref: 'refs/heads/master',
+      ref_protected: true,
+      checkout_sha: 'da1560886d4f094c3e6c9ef40349f7d38b5d27d7',
+      message: 'Hello World',
+      user_id: 4,
+      user_name: 'John Smith',
+      user_username: 'jsmith',
+      user_email: 'john@example.com',
+      user_avatar:
+        'https://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=8://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=80',
+      project_id: 15,
+      project: {
+        id: 15,
+        name: 'Diaspora',
+        description: '',
+        web_url: 'https://workshop.cloud.gov/cloud-gov/pages/project',
+        avatar_url: null,
+        git_ssh_url: 'git@example.com:mike/diaspora.git',
+        git_http_url: 'http://example.com/mike/diaspora.git',
+        namespace: 'Mike',
+        visibility_level: 0,
+        path_with_namespace: 'mike/diaspora',
+        default_branch: 'master',
+        ci_config_path: null,
+        homepage: 'http://example.com/mike/diaspora',
+        url: 'git@example.com:mike/diaspora.git',
+        ssh_url: 'git@example.com:mike/diaspora.git',
+        http_url: 'http://example.com/mike/diaspora.git',
+      },
+      commits: [
+        {
+          id: 'b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327',
+          message:
+            'Update Catalan translation to e38cb41.\n\nSee https://gitlab.com/gitlab-org/gitlab for more information',
+          title: 'Update Catalan translation to e38cb41.',
+          timestamp: '2011-12-12T14:27:31+02:00',
+          url: 'http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327',
+          author: {
+            name: 'Jordi Mallach',
+            email: 'jordi@softcatala.org',
+          },
+          added: ['CHANGELOG'],
+          modified: ['app/controller/application.rb'],
+          removed: [],
+        },
+        {
+          id: 'da1560886d4f094c3e6c9ef40349f7d38b5d27d7',
+          message: 'fixed readme',
+          title: 'fixed readme',
+          timestamp: '2012-01-03T23:36:29+02:00',
+          url: 'http://example.com/mike/diaspora/commit/da1560886d4f094c3e6c9ef40349f7d38b5d27d7',
+          author: {
+            name: 'GitLab dev user',
+            email: 'gitlabdev@dv6700.(none)',
+          },
+          added: ['CHANGELOG'],
+          modified: ['app/controller/application.rb'],
+          removed: [],
+        },
+      ],
+      total_commits_count: 4,
+      push_options: {},
+      repository: {
+        name: 'Diaspora',
+        url: 'git@example.com:mike/diaspora.git',
+        description: '',
+        homepage: 'http://example.com/mike/diaspora',
+        git_http_url: 'http://example.com/mike/diaspora.git',
+        git_ssh_url: 'git@example.com:mike/diaspora.git',
+        visibility_level: 0,
+      },
+    };
+
+    it('should return payload in GitHub format', async () => {
+      gitlabConfig.baseURL = 'https://workshop.cloud.gov/';
+      expect(getProcessedWebhookPayload(payload)).to.deep.equal({
+        after: 'da1560886d4f094c3e6c9ef40349f7d38b5d27d7',
+        commits: [{}],
+        owner: 'cloud-gov',
+        ref: 'refs/heads/master',
+        repository: {
+          pushed_at: 1323692851,
+          repository_path: 'pages/project',
+        },
+        sender: { login: 'jsmith' },
+      });
+    });
+  });
+});

--- a/test/api/unit/services/GithubBuildHelper.test.js
+++ b/test/api/unit/services/GithubBuildHelper.test.js
@@ -1,14 +1,14 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const nock = require('nock');
-const config = require('../../../../config');
-const { Site, User, Organization, OrganizationRole } = require('../../../../api/models');
+const { Site } = require('../../../../api/models');
 const factory = require('../../support/factory');
 const githubAPINocks = require('../../support/githubAPINocks');
 const { createSiteUserOrg } = require('../../support/site-user');
-const { buildUrl } = require('../../../../api/utils/build');
 const GitHub = require('../../../../api/services/GitHub');
 const GithubBuildHelper = require('../../../../api/services/GithubBuildHelper');
+// eslint-disable-next-line max-len
+const SourcecodePlatformHelper = require('../../../../api/services/SourceCodePlatformHelper');
 
 const requestedCommitSha = 'a172b66c31e19d456a448041a5b3c2a70c32d8b7';
 const clonedCommitSha = '7b8d23c07a2c3b5a140844a654d91e13c66b271a';
@@ -17,739 +17,6 @@ describe('GithubBuildHelper', () => {
   afterEach(() => {
     nock.cleanAll();
     sinon.restore();
-  });
-
-  describe('reportBuildStatus(build)', () => {
-    context('with a build in the processing state', () => {
-      let user;
-      let site;
-      let build;
-      let users;
-      let org;
-
-      beforeEach(async () => {
-        ({ site, user, org } = await createSiteUserOrg());
-        build = await factory.build({
-          state: 'processing',
-          site,
-          user,
-          requestedCommitSha,
-        });
-
-        const fullOrg = await Organization.findOne({
-          where: { id: org.id },
-          include: { model: OrganizationRole, include: User },
-        });
-        users = fullOrg.OrganizationRoles.map((role) => role.User);
-      });
-      it("should report that the status is 'pending'", async () => {
-        const repoNock = githubAPINocks.repo({
-          accessToken: user.githubAccessToken,
-          owner: site.owner,
-          repo: site.repository,
-          username: user.username,
-        });
-        const statusNock = githubAPINocks.status({
-          owner: site.owner,
-          repo: site.repository,
-          repository: site.repository,
-          sha: requestedCommitSha,
-          state: 'pending',
-        });
-        await build.reload({ include: Site });
-        await GithubBuildHelper.reportBuildStatus(build);
-
-        expect(repoNock.isDone()).to.be.true;
-        expect(statusNock.isDone()).to.be.true;
-      });
-
-      it(`should report the status if
-          the build user does not have permission'`, async () => {
-        const repoNocks = [];
-        build = await factory.build({
-          state: 'processing',
-          site,
-          requestedCommitSha,
-        });
-
-        let i;
-        let options;
-        for (i = 0; i < users.length; i += 1) {
-          options = {
-            accessToken: users[i].githubAccessToken,
-            owner: site.owner,
-            repo: site.repository,
-            username: users[i].username,
-          };
-          if (users[i].id === build.user) {
-            options.response = [
-              201,
-              {
-                permissions: {},
-              },
-            ];
-          }
-          repoNocks.push(githubAPINocks.repo(options));
-        }
-
-        const statusNock = githubAPINocks.status({
-          owner: site.owner,
-          repo: site.repository,
-          repository: site.repository,
-          sha: requestedCommitSha,
-          state: 'pending',
-        });
-
-        await build.reload({ include: Site });
-        await GithubBuildHelper.reportBuildStatus(build);
-        repoNocks.forEach((repoNock) => expect(repoNock.isDone()).to.be.true);
-        expect(statusNock.isDone()).to.be.true;
-      });
-
-      it(`should report the status if
-          the build initiated by an non-authed user`, async () => {
-        const repoNocks = [];
-        const newUser = await factory.user({
-          githubAccessToken: null,
-        });
-        await build.update({
-          user: newUser.id,
-          username: newUser.username,
-        });
-
-        let i;
-        let options;
-        for (i = 0; i < users.length; i += 1) {
-          options = {
-            accessToken: users[i].githubAccessToken,
-            owner: site.owner,
-            repo: site.repository,
-            username: users[i].username,
-          };
-          repoNocks.push(githubAPINocks.repo(options));
-        }
-
-        const statusNock = githubAPINocks.status({
-          owner: site.owner,
-          repo: site.repository,
-          repository: site.repository,
-          sha: requestedCommitSha,
-          state: 'pending',
-        });
-
-        await build.reload({ include: Site });
-        await GithubBuildHelper.reportBuildStatus(build);
-        repoNocks.forEach((repoNock) => expect(repoNock.isDone()).to.be.true);
-        expect(statusNock.isDone()).to.be.true;
-      });
-
-      it(`should report the status
-          if the build user has invalid token'`, async () => {
-        const repoNocks = [];
-        await user.update({
-          signedInAt: '1999-01-01',
-        });
-        const otherUser = await factory.user();
-        await org.addRoleUser(otherUser);
-
-        repoNocks.push(
-          githubAPINocks.repo({
-            owner: site.owner,
-            repo: site.repository,
-            username: user.username,
-            response: [
-              403,
-              {
-                permissions: {},
-              },
-            ],
-          }),
-        );
-        repoNocks.push(
-          githubAPINocks.repo({
-            owner: site.owner,
-            repo: site.repository,
-            username: otherUser.username,
-          }),
-        );
-
-        const statusNock = githubAPINocks.status({
-          owner: site.owner,
-          repo: site.repository,
-          repository: site.repository,
-          sha: requestedCommitSha,
-          state: 'pending',
-        });
-        await build.reload({ include: Site });
-        await GithubBuildHelper.reportBuildStatus(build);
-        repoNocks.forEach((repoNock) => expect(repoNock.isDone()).to.be.true);
-        expect(statusNock.isDone()).to.be.true;
-      });
-
-      it(`should report that the status if the
-          build user does not have write permissions'`, async () => {
-        const repoNocks = [];
-        await user.update({
-          signedInAt: '1999-01-01',
-        });
-        const otherUser = await factory.user();
-        await org.addRoleUser(otherUser);
-
-        repoNocks.push(
-          githubAPINocks.repo({
-            owner: site.owner,
-            repo: site.repository,
-            username: user.username,
-            response: [
-              201,
-              {
-                permissions: {},
-              },
-            ],
-          }),
-        );
-        repoNocks.push(
-          githubAPINocks.repo({
-            owner: site.owner,
-            repo: site.repository,
-            username: otherUser.username,
-          }),
-        );
-
-        const statusNock = githubAPINocks.status({
-          owner: site.owner,
-          repo: site.repository,
-          repository: site.repository,
-          sha: requestedCommitSha,
-          state: 'pending',
-        });
-        await build.reload({ include: Site });
-        await GithubBuildHelper.reportBuildStatus(build);
-        repoNocks.forEach((repoNock) => expect(repoNock.isDone()).to.be.true);
-        expect(statusNock.isDone()).to.be.true;
-      });
-
-      it(`should not report the status
-          if the build user has invalid token'`, async () => {
-        const repoNocks = [];
-        const statusSpy = sinon.spy(GitHub, 'sendCreateGithubStatusRequest');
-        const recentUser = await factory.user();
-        await org.addRoleUser(recentUser);
-
-        repoNocks.push(
-          githubAPINocks.repo({
-            owner: site.owner,
-            repo: site.repository,
-            username: user.username,
-            response: [
-              403,
-              {
-                permissions: {},
-              },
-            ],
-          }),
-        );
-        repoNocks.push(
-          githubAPINocks.repo({
-            owner: site.owner,
-            repo: site.repository,
-            username: recentUser.username,
-            response: [
-              403,
-              {
-                permissions: {},
-              },
-            ],
-          }),
-        );
-
-        await build.reload({ include: Site });
-        const err = await GithubBuildHelper.reportBuildStatus(build).catch((e) => e);
-        repoNocks.forEach((repoNock) => expect(repoNock.isDone()).to.be.true);
-        expect(statusSpy.called).to.be.false;
-        expect(err.message).to.equal(
-          `Unable to find valid access token to report build@id=${build.id} status`,
-        );
-      });
-
-      it(`should not report the status if
-          the build user does not have write permissions'`, async () => {
-        const repoNocks = [];
-        const statusSpy = sinon.spy(GitHub, 'sendCreateGithubStatusRequest');
-        const recentUser = await factory.user();
-        await org.addRoleUser(recentUser);
-
-        repoNocks.push(
-          githubAPINocks.repo({
-            owner: site.owner,
-            repo: site.repository,
-            username: user.username,
-            response: [
-              201,
-              {
-                permissions: {},
-              },
-            ],
-          }),
-        );
-        repoNocks.push(
-          githubAPINocks.repo({
-            owner: site.owner,
-            repo: site.repository,
-            username: recentUser.username,
-            response: [
-              201,
-              {
-                permissions: {},
-              },
-            ],
-          }),
-        );
-
-        await build.reload({ include: Site });
-        const err = await GithubBuildHelper.reportBuildStatus(build).catch((e) => e);
-        repoNocks.forEach((repoNock) => expect(repoNock.isDone()).to.be.true);
-        expect(statusSpy.called).to.be.false;
-        expect(err.message).to.equal(
-          `Unable to find valid access token to report build@id=${build.id} status`,
-        );
-      });
-
-      it('should set the target uri to the build logs', async () => {
-        const repoNock = githubAPINocks.repo({
-          accessToken: user.githubAccessToken,
-          owner: site.owner,
-          repo: site.repository,
-          username: user.username,
-        });
-        const statusNock = githubAPINocks.status({
-          owner: site.owner,
-          repo: site.repository,
-          sha: requestedCommitSha,
-          targetURL: `${config.app.hostname}/sites/${build.site}/builds/${build.id}/logs`,
-        });
-        await build.reload({ include: Site });
-        await GithubBuildHelper.reportBuildStatus(build);
-        expect(repoNock.isDone()).to.be.true;
-        expect(statusNock.isDone()).to.be.true;
-      });
-    });
-
-    context('with a build in the created state', () => {
-      let user;
-      let site;
-      let build;
-
-      beforeEach(async () => {
-        site = await factory.site({
-          owner: 'test-owner',
-          repository: 'test-repo',
-        });
-        ({ user } = await createSiteUserOrg({ site }));
-        build = await factory.build({
-          state: 'created',
-          site,
-          requestedCommitSha,
-          user,
-        });
-      });
-
-      it("should report that the status is 'pending'", async () => {
-        const repoNock = githubAPINocks.repo({
-          accessToken: user.githubAccessToken,
-          owner: 'test-owner',
-          repo: 'test-repo',
-          username: user.username,
-        });
-        const statusNock = githubAPINocks.status({
-          owner: 'test-owner',
-          repo: 'test-repo',
-          repository: 'test-repo',
-          sha: requestedCommitSha,
-          state: 'pending',
-        });
-
-        await build.reload({ include: Site });
-        await GithubBuildHelper.reportBuildStatus(build);
-        expect(repoNock.isDone()).to.be.true;
-        expect(statusNock.isDone()).to.be.true;
-      });
-
-      it('should set the target uri to the build logs', async () => {
-        const repoNock = githubAPINocks.repo({
-          accessToken: 'fake-access-token',
-          owner: 'test-owner',
-          repo: 'test-repo',
-          username: user.username,
-        });
-        const statusNock = githubAPINocks.status({
-          owner: 'test-owner',
-          repo: 'test-repo',
-          sha: requestedCommitSha,
-          targetURL: `${config.app.hostname}/sites/${build.site}/builds/${build.id}/logs`,
-        });
-
-        await build.reload({ include: Site });
-        await GithubBuildHelper.reportBuildStatus(build);
-        expect(repoNock.isDone()).to.be.true;
-        expect(statusNock.isDone()).to.be.true;
-      });
-    });
-
-    context('with a build in the queued state', () => {
-      let user;
-      let site;
-      let build;
-
-      beforeEach(async () => {
-        site = await factory.site({
-          owner: 'test-owner',
-          repository: 'test-repo',
-        });
-        ({ user } = await createSiteUserOrg({ site }));
-
-        build = await factory.build({
-          state: 'created',
-          site,
-          requestedCommitSha,
-          user,
-        });
-      });
-      it("should report that the status is 'pending'", async () => {
-        const repoNock = githubAPINocks.repo({
-          accessToken: user.githubAccessToken,
-          owner: 'test-owner',
-          repo: 'test-repo',
-          username: user.username,
-        });
-        const statusNock = githubAPINocks.status({
-          owner: 'test-owner',
-          repo: 'test-repo',
-          repository: 'test-repo',
-          sha: requestedCommitSha,
-          state: 'pending',
-        });
-
-        await build.reload({ include: Site });
-        await GithubBuildHelper.reportBuildStatus(build);
-        expect(repoNock.isDone()).to.be.true;
-        expect(statusNock.isDone()).to.be.true;
-      });
-
-      it('should set the target uri to the build logs', async () => {
-        const repoNock = githubAPINocks.repo({
-          accessToken: 'fake-access-token',
-          owner: 'test-owner',
-          repo: 'test-repo',
-          username: user.username,
-        });
-        const statusNock = githubAPINocks.status({
-          owner: 'test-owner',
-          repo: 'test-repo',
-          sha: requestedCommitSha,
-          targetURL: `${config.app.hostname}/sites/${build.site}/builds/${build.id}/logs`,
-        });
-
-        await build.reload({ include: Site });
-        await GithubBuildHelper.reportBuildStatus(build);
-        expect(repoNock.isDone()).to.be.true;
-        expect(statusNock.isDone()).to.be.true;
-      });
-    });
-
-    context('with every build', () => {
-      const origAppEnv = config.app.appEnv;
-      let user;
-      let site;
-      let build;
-
-      after(() => {
-        // reset config.app.appEnv to its original value
-        config.app.appEnv = origAppEnv;
-      });
-
-      beforeEach(async () => {
-        site = await factory.site({
-          owner: 'test-owner',
-          repository: 'test-repo',
-        });
-        ({ user } = await createSiteUserOrg({ site }));
-        build = await factory.build({
-          state: 'success',
-          site,
-          requestedCommitSha,
-          clonedCommitSha,
-          user,
-        });
-      });
-
-      it(`should set status context to
-          "federalist/build" when APP_ENV is "production"`, async () => {
-        config.app.appEnv = 'production';
-        const repoNock = githubAPINocks.repo({
-          accessToken: 'fake-access-token',
-          owner: 'test-owner',
-          repo: 'test-repo',
-          username: user.username,
-        });
-        const statusNock = githubAPINocks.status({
-          owner: 'test-owner',
-          repo: 'test-repo',
-          sha: clonedCommitSha,
-          state: 'success',
-        });
-
-        await build.reload({ include: Site });
-        await GithubBuildHelper.reportBuildStatus(build);
-        expect(repoNock.isDone()).to.be.true;
-        expect(statusNock.isDone()).to.be.true;
-      });
-    });
-
-    context('with a build in the success state', () => {
-      let user;
-      let site;
-      let build;
-
-      beforeEach(async () => {
-        user = await factory.user();
-        ({ site, user } = await createSiteUserOrg());
-        build = await factory.build({
-          state: 'success',
-          requestedCommitSha,
-          clonedCommitSha,
-          user,
-          site,
-        });
-      });
-      it("should report that the status is 'success'", async () => {
-        const repoNock = githubAPINocks.repo({
-          accessToken: user.githubAccessToken,
-          owner: site.owner,
-          repo: site.repository,
-          username: user.username,
-        });
-        const statusNock = githubAPINocks.status({
-          owner: site.owner,
-          repo: site.repository,
-          sha: clonedCommitSha,
-          state: 'success',
-        });
-
-        await build.reload({ include: Site });
-        await GithubBuildHelper.reportBuildStatus(build);
-        expect(repoNock.isDone()).to.be.true;
-        expect(statusNock.isDone()).to.be.true;
-      });
-
-      it('should set the target uri to the preview link', async () => {
-        await build.update({
-          branch: 'preview-branch',
-        });
-
-        await build.reload();
-
-        // this depends on branch so we update twice
-        await build.update({
-          url: buildUrl(build, site),
-        });
-
-        const repoNock = githubAPINocks.repo({
-          accessToken: user.githubAccessToken,
-          owner: site.owner,
-          repo: site.repository,
-          username: user.username,
-        });
-        const statusNock = githubAPINocks.status({
-          owner: site.owner,
-          repo: site.repository,
-          sha: clonedCommitSha,
-          targetURL: buildUrl(build, site),
-        });
-
-        await build.reload({ include: Site });
-
-        await GithubBuildHelper.reportBuildStatus(build);
-        expect(repoNock.isDone()).to.be.true;
-        expect(statusNock.isDone()).to.be.true;
-      });
-    });
-
-    context('with a build in the error state', () => {
-      let user;
-      let site;
-      let build;
-
-      beforeEach(async () => {
-        ({ site, user } = await createSiteUserOrg());
-        build = await factory.build({
-          state: 'error',
-          requestedCommitSha,
-          user,
-          site,
-        });
-      });
-      it("should report that the status is 'error' with requestedCommitSha", async () => {
-        const repoNock = githubAPINocks.repo({
-          accessToken: user.githubAccessToken,
-          owner: site.owner,
-          repo: site.repository,
-          username: user.username,
-        });
-        const statusNock = githubAPINocks.status({
-          owner: site.owner,
-          repo: site.repository,
-          sha: requestedCommitSha,
-          state: 'error',
-        });
-
-        await build.reload({ include: Site });
-        await GithubBuildHelper.reportBuildStatus(build);
-        expect(statusNock.isDone()).to.be.true;
-        expect(repoNock.isDone()).to.be.true;
-      });
-
-      it("should report that the status is 'error' with clonedCommitSha", async () => {
-        await build.update({
-          clonedCommitSha,
-        });
-
-        const repoNock = githubAPINocks.repo({
-          accessToken: user.githubAccessToken,
-          owner: site.owner,
-          repo: site.repository,
-          username: user.username,
-        });
-        const statusNock = githubAPINocks.status({
-          owner: site.owner,
-          repo: site.repository,
-          sha: clonedCommitSha,
-          state: 'error',
-          targetURL: `${config.app.hostname}/sites/${build.site}/builds/${build.id}/logs`,
-        });
-
-        await build.reload({ include: Site });
-        await GithubBuildHelper.reportBuildStatus(build);
-        expect(statusNock.isDone()).to.be.true;
-        expect(repoNock.isDone()).to.be.true;
-      });
-
-      it(`should use the GitHub
-          access token of the build's user not a site user`, async () => {
-        const nonSiteUser = await factory.user();
-        await build.update({
-          user: nonSiteUser.id,
-        });
-
-        const repoNock = githubAPINocks.repo({
-          accessToken: nonSiteUser.githubAccessToken,
-          owner: site.owner,
-          repo: site.repository,
-          username: user.username,
-        });
-        const statusNock = githubAPINocks.status({
-          owner: site.owner,
-          repo: site.repository,
-          sha: requestedCommitSha,
-          state: 'error',
-          targetURL: `${config.app.hostname}/sites/${build.site}/builds/${build.id}/logs`,
-        });
-
-        await build.reload({ include: Site });
-        await GithubBuildHelper.reportBuildStatus(build);
-
-        expect(statusNock.isDone()).to.be.true;
-        expect(repoNock.isDone()).to.be.true;
-      });
-    });
-
-    context('with a build in the invalid state', () => {
-      let user;
-      let site;
-      let build;
-
-      beforeEach(async () => {
-        ({ site, user } = await createSiteUserOrg());
-        build = await factory.build({
-          state: 'invalid',
-          requestedCommitSha,
-          user,
-          site,
-        });
-      });
-      it("should report that the status is 'error' with requestedCommitSha", async () => {
-        const repoNock = githubAPINocks.repo({
-          accessToken: user.githubAccessToken,
-          owner: site.owner,
-          repo: site.repository,
-          username: user.username,
-        });
-        const statusNock = githubAPINocks.status({
-          owner: site.owner,
-          repo: site.repository,
-          sha: requestedCommitSha,
-          state: 'error',
-        });
-
-        await build.reload({ include: Site });
-        await GithubBuildHelper.reportBuildStatus(build);
-        expect(statusNock.isDone()).to.be.true;
-        expect(repoNock.isDone()).to.be.true;
-      });
-
-      it("should report that the status is 'error' with clonedCommitSha", async () => {
-        await build.update({
-          clonedCommitSha,
-        });
-
-        const repoNock = githubAPINocks.repo({
-          accessToken: user.githubAccessToken,
-          owner: site.owner,
-          repo: site.repository,
-          username: user.username,
-        });
-        const statusNock = githubAPINocks.status({
-          owner: site.owner,
-          repo: site.repository,
-          sha: clonedCommitSha,
-          state: 'error',
-          targetURL: `${config.app.hostname}/sites/${build.site}/builds/${build.id}/logs`,
-        });
-
-        await build.reload({ include: Site });
-        await GithubBuildHelper.reportBuildStatus(build);
-        expect(statusNock.isDone()).to.be.true;
-        expect(repoNock.isDone()).to.be.true;
-      });
-
-      it(`should use the GitHub
-          access token of the build's user not a site user`, async () => {
-        const nonSiteUser = await factory.user();
-        await build.update({
-          user: nonSiteUser.id,
-        });
-
-        const repoNock = githubAPINocks.repo({
-          accessToken: nonSiteUser.githubAccessToken,
-          owner: site.owner,
-          repo: site.repository,
-          username: user.username,
-        });
-        const statusNock = githubAPINocks.status({
-          owner: site.owner,
-          repo: site.repository,
-          sha: requestedCommitSha,
-          state: 'error',
-          targetURL: `${config.app.hostname}/sites/${build.site}/builds/${build.id}/logs`,
-        });
-
-        await build.reload({ include: Site });
-        await GithubBuildHelper.reportBuildStatus(build);
-
-        expect(statusNock.isDone()).to.be.true;
-        expect(repoNock.isDone()).to.be.true;
-      });
-    });
   });
 
   describe('fetchContent(build, site, users, path)', () => {
@@ -775,7 +42,11 @@ describe('GithubBuildHelper', () => {
         push: true,
       });
       await build.reload({ include: Site });
-      const content = await GithubBuildHelper.fetchContent(build, path);
+      const content = await GithubBuildHelper.fetchContent(
+        build,
+        path,
+        SourcecodePlatformHelper.loadBuildUserAccessToken,
+      );
       expect(content).to.equal('testContent');
     });
 
@@ -785,7 +56,11 @@ describe('GithubBuildHelper', () => {
         clonedCommitSha: null,
       });
       await build.reload({ include: Site });
-      const err = await GithubBuildHelper.fetchContent(build, path).catch((e) => e);
+      const err = await GithubBuildHelper.fetchContent(
+        build,
+        path,
+        SourcecodePlatformHelper.loadBuildUserAccessToken,
+      ).catch((e) => e);
       expect(err.message).to.equal(
         `Build or commit sha undefined. Unable to fetch ${path} for build@id=${build.id}`,
       );
@@ -814,7 +89,8 @@ describe('GithubBuildHelper', () => {
         username: user.username,
       });
       await build.reload({ include: Site });
-      const githubAccessToken = await GithubBuildHelper.loadBuildUserAccessToken(build);
+      const githubAccessToken =
+        await SourcecodePlatformHelper.loadBuildUserAccessToken(build);
       expect(githubAccessToken).to.equal(user.githubAccessToken);
       expect(repoNock.isDone()).to.be.true;
     });
@@ -847,7 +123,8 @@ describe('GithubBuildHelper', () => {
         }),
       );
       await build.reload({ include: Site });
-      const githubAccessToken = await GithubBuildHelper.loadBuildUserAccessToken(build);
+      const githubAccessToken =
+        await SourcecodePlatformHelper.loadBuildUserAccessToken(build);
       expect(githubAccessToken).to.equal(orgUser.githubAccessToken);
       repoNocks.forEach((repoNock) => expect(repoNock.isDone()).to.be.true);
     });
@@ -879,7 +156,8 @@ describe('GithubBuildHelper', () => {
         }),
       );
       await build.reload({ include: Site });
-      const githubAccessToken = await GithubBuildHelper.loadBuildUserAccessToken(build);
+      const githubAccessToken =
+        await SourcecodePlatformHelper.loadBuildUserAccessToken(build);
       expect(githubAccessToken).to.equal(orgUser.githubAccessToken);
       repoNocks.forEach((repoNock) => expect(repoNock.isDone()).to.be.true);
     });
@@ -917,7 +195,9 @@ describe('GithubBuildHelper', () => {
         }),
       );
       await build.reload({ include: Site });
-      const err = await GithubBuildHelper.loadBuildUserAccessToken(build).catch((e) => e);
+      const err = await SourcecodePlatformHelper.loadBuildUserAccessToken(build).catch(
+        (e) => e,
+      );
       repoNocks.forEach((repoNock) => expect(repoNock.isDone()).to.be.true);
       expect(err.message).to.equal(
         `Unable to find valid access token to report build@id=${build.id} status`,
@@ -957,7 +237,9 @@ describe('GithubBuildHelper', () => {
         }),
       );
       await build.reload({ include: Site });
-      const err = await GithubBuildHelper.loadBuildUserAccessToken(build).catch((e) => e);
+      const err = await SourcecodePlatformHelper.loadBuildUserAccessToken(build).catch(
+        (e) => e,
+      );
       repoNocks.forEach((repoNock) => expect(repoNock.isDone()).to.be.true);
       expect(err.message).to.equal(
         `Unable to find valid access token to report build@id=${build.id} status`,

--- a/test/api/unit/services/SiteBuildQueue.test.js
+++ b/test/api/unit/services/SiteBuildQueue.test.js
@@ -6,7 +6,6 @@ const apiNocks = require('../../support/cfAPINocks');
 const config = require('../../../../config');
 const factory = require('../../support/factory');
 const { createSiteUserOrg } = require('../../support/site-user');
-const GithubBuildHelper = require('../../../../api/services/GithubBuildHelper');
 const SiteBuildQueue = require('../../../../api/services/SiteBuildQueue');
 const {
   Build,
@@ -18,6 +17,14 @@ const {
 } = require('../../../../api/models');
 const CFApiClient = require('../../../../api/utils/cfApiClient');
 const S3Helper = require('../../../../api/services/S3Helper');
+const {
+  nockRefreshTokenWithResponse,
+  getRefreshToken200Response,
+} = require('../../support/gitlabAPINocks');
+const GitHub = require('../../../../api/services/GitHub');
+
+const { authorizationOptions: gitlabConfig } = config.passport.gitlab;
+gitlabConfig.baseURL = 'http://workshop.cloud.gov/';
 
 describe('SiteBuildQueue', () => {
   afterEach(() => {
@@ -693,7 +700,7 @@ describe('SiteBuildQueue', () => {
         .catch(done);
     });
 
-    it(`should set GITHUB_TOKEN in the
+    it(`should set GITHUB_TOKEN and SOURCE_CODE_PLATFORM_TOKEN in the
         message to the user's GitHub access token`, async () => {
       const user = await factory.user({
         githubAccessToken: 'fake-github-token-123',
@@ -716,6 +723,9 @@ describe('SiteBuildQueue', () => {
       });
 
       const message = await SiteBuildQueue.messageBodyForBuild(fullBuild);
+      expect(messageEnv(message, 'SOURCE_CODE_PLATFORM_TOKEN')).to.equal(
+        'fake-github-token-123',
+      );
       expect(messageEnv(message, 'GITHUB_TOKEN')).to.equal('fake-github-token-123');
     });
 
@@ -743,12 +753,102 @@ describe('SiteBuildQueue', () => {
       });
 
       sinon
-        .stub(GithubBuildHelper, 'loadBuildUserAccessToken')
-        .resolves(user2.githubAccessToken);
+        .stub(GitHub, 'checkPermissions')
+        .withArgs(sinon.match.any, sinon.match.any, sinon.match.any)
+        .resolves({ push: {} });
+
+      sinon.stub(build, 'getSiteOrgUsers').resolves([user1, user2]);
 
       const message = await SiteBuildQueue.messageBodyForBuild(build);
 
-      expect(messageEnv(message, 'GITHUB_TOKEN')).to.equal(user2.githubAccessToken);
+      expect(messageEnv(message, 'SOURCE_CODE_PLATFORM_TOKEN')).to.equal(
+        user2.githubAccessToken,
+      );
+    });
+
+    it(`should set 
+        SOURCE_CODE_PLATFORM, SOURCE_CODE_PLATFORM_DOMAIN, SOURCE_CODE_PLATFORM_TOKEN 
+        in the message for GitHub repository`, async () => {
+      const user = await factory.user({
+        githubAccessToken: 'fake-github-token-123',
+        gitlabToken: 'fake-gitlab-token-123',
+      });
+      const site = await factory.site({
+        sourceCodePlatform: Site.Platforms.Github,
+      });
+      const { org } = await createSiteUserOrg(site);
+      await org.addRoleUser(user);
+      const build = await factory.build({
+        user,
+        site,
+      });
+
+      const fullBuild = await Build.findByPk(build.id, {
+        include: [
+          {
+            model: Site,
+            required: true,
+            include: [SiteBranchConfig],
+          },
+          User,
+        ],
+      });
+
+      const message = await SiteBuildQueue.messageBodyForBuild(fullBuild);
+      expect(messageEnv(message, 'SOURCE_CODE_PLATFORM')).to.equal('github');
+      expect(messageEnv(message, 'SOURCE_CODE_PLATFORM_DOMAIN')).to.equal('github.com');
+      expect(messageEnv(message, 'SOURCE_CODE_PLATFORM_TOKEN')).to.equal(
+        'fake-github-token-123',
+      );
+      expect(messageEnv(message, 'GITHUB_TOKEN')).to.equal('fake-github-token-123');
+    });
+
+    it(`should set 
+        SOURCE_CODE_PLATFORM, SOURCE_CODE_PLATFORM_DOMAIN, SOURCE_CODE_PLATFORM_TOKEN 
+        in the message for GitLab project`, async () => {
+      const user = await factory.user({
+        githubAccessToken: 'fake-github-token-123',
+        gitlabToken: 'fake-gitlab-token-123',
+      });
+      const site = await factory.site({
+        sourceCodePlatform: Site.Platforms.Workshop,
+      });
+      const { org } = await createSiteUserOrg(site);
+      await org.addRoleUser(user);
+      const build = await factory.build({
+        user,
+        site,
+      });
+
+      const fullBuild = await Build.findByPk(build.id, {
+        include: [
+          {
+            model: Site,
+            required: true,
+            include: [SiteBranchConfig],
+          },
+          User,
+        ],
+      });
+
+      const refresh = nockRefreshTokenWithResponse(
+        gitlabConfig,
+        user.gitlabToken,
+        user.gitlabRefreshToken,
+        200,
+        getRefreshToken200Response({ access_token: 'fake-gitlab-token-123-refreshed' }),
+      );
+
+      const message = await SiteBuildQueue.messageBodyForBuild(fullBuild);
+
+      expect(refresh.isDone()).to.equal(true);
+      expect(messageEnv(message, 'SOURCE_CODE_PLATFORM')).to.equal('workshop');
+      expect(messageEnv(message, 'SOURCE_CODE_PLATFORM_DOMAIN')).to.equal(
+        'workshop.cloud.gov',
+      );
+      expect(messageEnv(message, 'SOURCE_CODE_PLATFORM_TOKEN')).to.equal(
+        'oauth2:fake-gitlab-token-123-refreshed',
+      );
     });
 
     it(`should set GENERATOR in the message

--- a/test/api/unit/services/SiteCreator.test.js
+++ b/test/api/unit/services/SiteCreator.test.js
@@ -12,6 +12,7 @@ const TemplateResolver = require('../../../../api/services/TemplateResolver');
 const { Build, Site, SiteBranchConfig } = require('../../../../api/models');
 const QueueJobs = require('../../../../api/queue-jobs');
 const utils = require('../../../../api/utils');
+const Organization = require('../../../../api/services/organization');
 
 describe('SiteCreator', () => {
   beforeEach(() => {
@@ -58,6 +59,20 @@ describe('SiteCreator', () => {
         },
         include: [Build, SiteBranchConfig],
       });
+
+    const setupWebhook = (accessToken, owner, repo) => {
+      sinon.stub(Organization, 'getOrganizationUsers').resolves([
+        {
+          githubAccessToken: accessToken,
+          signedInAt: new Date(),
+        },
+      ]);
+      return githubAPINocks.webhook({
+        accessToken,
+        owner,
+        repo,
+      });
+    };
 
     context('from a GitHub repo', () => {
       let siteParams, name;
@@ -146,13 +161,6 @@ describe('SiteCreator', () => {
       let user;
       let webhookNock;
 
-      const setupWebhook = (accessToken, owner, repo) =>
-        githubAPINocks.webhook({
-          accessToken,
-          owner,
-          repo,
-        });
-
       context('when the owner of the repo is an authorized federalist org', () => {
         it(`creates new site record for the given repository,
             adds the webhook and build`, (done) => {
@@ -162,6 +170,7 @@ describe('SiteCreator', () => {
             .user()
             .then((model) => {
               user = model;
+              user.signedInAt = new Date();
               githubAPINocks.repo({
                 defaultBranch,
               });
@@ -171,6 +180,21 @@ describe('SiteCreator', () => {
                 organizations: [
                   {
                     login: siteParams.owner,
+                  },
+                ],
+              });
+
+              githubAPINocks.repo({
+                accessToken: user.accessToken,
+                owner: siteParams.owner,
+                repo: siteParams.repository,
+                response: [
+                  200,
+                  {
+                    permissions: {
+                      admin: true,
+                      push: false,
+                    },
                   },
                 ],
               });
@@ -214,7 +238,27 @@ describe('SiteCreator', () => {
               githubAPINocks.repo({
                 defaultBranch,
               });
-              githubAPINocks.webhook();
+
+              githubAPINocks.repo({
+                accessToken: user.accessToken,
+                owner: siteParams.owner,
+                repo: siteParams.repository,
+                response: [
+                  200,
+                  {
+                    permissions: {
+                      admin: true,
+                      push: false,
+                    },
+                  },
+                ],
+              });
+
+              webhookNock = setupWebhook(
+                user.githubAccessToken,
+                siteParams.owner,
+                siteParams.repository,
+              );
 
               githubAPINocks.userOrganizations({
                 accessToken: user.githubAccessToken,
@@ -466,7 +510,24 @@ describe('SiteCreator', () => {
           .then((model) => {
             user = model;
             githubAPINocks.createRepoUsingTemplate();
-            githubAPINocks.webhook();
+
+            githubAPINocks.repo({
+              accessToken: user.accessToken,
+              owner: siteParams.owner,
+              repo: siteParams.repository,
+              response: [
+                200,
+                {
+                  permissions: {
+                    admin: true,
+                    push: false,
+                  },
+                },
+              ],
+            });
+
+            setupWebhook(user.githubAccessToken, siteParams.owner, siteParams.repository);
+
             return SiteCreator.createSite({
               user,
               siteParams,
@@ -498,7 +559,24 @@ describe('SiteCreator', () => {
           .then((model) => {
             user = model;
             githubAPINocks.createRepoUsingTemplate();
-            githubAPINocks.webhook();
+
+            githubAPINocks.repo({
+              accessToken: user.accessToken,
+              owner: siteParams.owner,
+              repo: siteParams.repository,
+              response: [
+                200,
+                {
+                  permissions: {
+                    admin: true,
+                    push: false,
+                  },
+                },
+              ],
+            });
+
+            setupWebhook(user.githubAccessToken, siteParams.owner, siteParams.repository);
+
             return SiteCreator.createSite({
               siteParams,
               user,
@@ -527,7 +605,24 @@ describe('SiteCreator', () => {
           .then((model) => {
             user = model;
             githubAPINocks.createRepoUsingTemplate();
-            githubAPINocks.webhook();
+
+            githubAPINocks.repo({
+              accessToken: user.accessToken,
+              owner: siteParams.owner,
+              repo: siteParams.repository,
+              response: [
+                200,
+                {
+                  permissions: {
+                    admin: true,
+                    push: false,
+                  },
+                },
+              ],
+            });
+
+            setupWebhook(user.githubAccessToken, siteParams.owner, siteParams.repository);
+
             return SiteCreator.createSite({
               siteParams,
               user,
@@ -558,11 +653,28 @@ describe('SiteCreator', () => {
           .then((model) => {
             user = model;
             githubAPINocks.createRepoUsingTemplate();
-            webhookNock = githubAPINocks.webhook({
-              accessToken: user.githubAccessToken,
+
+            githubAPINocks.repo({
+              accessToken: user.accessToken,
               owner: siteParams.owner,
               repo: siteParams.repository,
+              response: [
+                200,
+                {
+                  permissions: {
+                    admin: true,
+                    push: false,
+                  },
+                },
+              ],
             });
+
+            webhookNock = setupWebhook(
+              user.githubAccessToken,
+              siteParams.owner,
+              siteParams.repository,
+            );
+
             return SiteCreator.createSite({
               user,
               siteParams,
@@ -638,13 +750,6 @@ describe('SiteCreator', () => {
     context('with a private S3 bucket', () => {
       let user;
       let webhookNock;
-
-      const setupWebhook = (accessToken, owner, repo) =>
-        githubAPINocks.webhook({
-          accessToken,
-          owner,
-          repo,
-        });
 
       describe('for the Pages product', () => {
         it(`creates new bucket and site record for the given repository,
@@ -739,6 +844,21 @@ describe('SiteCreator', () => {
                 organizations: [
                   {
                     login: siteParams.owner,
+                  },
+                ],
+              });
+
+              githubAPINocks.repo({
+                accessToken: user.accessToken,
+                owner: siteParams.owner,
+                repo: siteParams.repository,
+                response: [
+                  200,
+                  {
+                    permissions: {
+                      admin: true,
+                      push: false,
+                    },
                   },
                 ],
               });

--- a/test/api/unit/services/SourceCodePlatformHelper.test.js
+++ b/test/api/unit/services/SourceCodePlatformHelper.test.js
@@ -1,0 +1,754 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const nock = require('nock');
+const config = require('../../../../config');
+const { Site, User, Organization, OrganizationRole } = require('../../../../api/models');
+const factory = require('../../support/factory');
+const githubAPINocks = require('../../support/githubAPINocks');
+const { createSiteUserOrg } = require('../../support/site-user');
+const { buildUrl } = require('../../../../api/utils/build');
+const GitHub = require('../../../../api/services/GitHub');
+const SourceCodePlatform = require('../../../../api/services/SourceCodePlatformHelper');
+
+const requestedCommitSha = 'a172b66c31e19d456a448041a5b3c2a70c32d8b7';
+const clonedCommitSha = '7b8d23c07a2c3b5a140844a654d91e13c66b271a';
+
+describe('GithubBuildHelper', () => {
+  afterEach(() => {
+    nock.cleanAll();
+    sinon.restore();
+  });
+
+  describe('reportBuildStatus(build)', () => {
+    context('with a build in the processing state', () => {
+      let user;
+      let site;
+      let build;
+      let users;
+      let org;
+
+      beforeEach(async () => {
+        ({ site, user, org } = await createSiteUserOrg());
+        build = await factory.build({
+          state: 'processing',
+          site,
+          user,
+          requestedCommitSha,
+        });
+
+        const fullOrg = await Organization.findOne({
+          where: { id: org.id },
+          include: { model: OrganizationRole, include: User },
+        });
+        users = fullOrg.OrganizationRoles.map((role) => role.User);
+      });
+      it("should report that the status is 'pending'", async () => {
+        const repoNock = githubAPINocks.repo({
+          accessToken: user.githubAccessToken,
+          owner: site.owner,
+          repo: site.repository,
+          username: user.username,
+        });
+        const statusNock = githubAPINocks.status({
+          owner: site.owner,
+          repo: site.repository,
+          repository: site.repository,
+          sha: requestedCommitSha,
+          state: 'pending',
+        });
+        await build.reload({ include: Site });
+        await SourceCodePlatform.reportBuildStatus(build);
+
+        expect(repoNock.isDone()).to.be.true;
+        expect(statusNock.isDone()).to.be.true;
+      });
+
+      it(`should report the status if
+          the build user does not have permission'`, async () => {
+        const repoNocks = [];
+        build = await factory.build({
+          state: 'processing',
+          site,
+          requestedCommitSha,
+        });
+
+        let i;
+        let options;
+        for (i = 0; i < users.length; i += 1) {
+          options = {
+            accessToken: users[i].githubAccessToken,
+            owner: site.owner,
+            repo: site.repository,
+            username: users[i].username,
+          };
+          if (users[i].id === build.user) {
+            options.response = [
+              201,
+              {
+                permissions: {},
+              },
+            ];
+          }
+          repoNocks.push(githubAPINocks.repo(options));
+        }
+
+        const statusNock = githubAPINocks.status({
+          owner: site.owner,
+          repo: site.repository,
+          repository: site.repository,
+          sha: requestedCommitSha,
+          state: 'pending',
+        });
+
+        await build.reload({ include: Site });
+        await SourceCodePlatform.reportBuildStatus(build);
+        repoNocks.forEach((repoNock) => expect(repoNock.isDone()).to.be.true);
+        expect(statusNock.isDone()).to.be.true;
+      });
+
+      it(`should report the status if
+          the build initiated by an non-authed user`, async () => {
+        const repoNocks = [];
+        const newUser = await factory.user({
+          githubAccessToken: null,
+        });
+        await build.update({
+          user: newUser.id,
+          username: newUser.username,
+        });
+
+        let i;
+        let options;
+        for (i = 0; i < users.length; i += 1) {
+          options = {
+            accessToken: users[i].githubAccessToken,
+            owner: site.owner,
+            repo: site.repository,
+            username: users[i].username,
+          };
+          repoNocks.push(githubAPINocks.repo(options));
+        }
+
+        const statusNock = githubAPINocks.status({
+          owner: site.owner,
+          repo: site.repository,
+          repository: site.repository,
+          sha: requestedCommitSha,
+          state: 'pending',
+        });
+
+        await build.reload({ include: Site });
+        await SourceCodePlatform.reportBuildStatus(build);
+        repoNocks.forEach((repoNock) => expect(repoNock.isDone()).to.be.true);
+        expect(statusNock.isDone()).to.be.true;
+      });
+
+      it(`should report the status
+          if the build user has invalid token'`, async () => {
+        const repoNocks = [];
+        await user.update({
+          signedInAt: '1999-01-01',
+        });
+        const otherUser = await factory.user();
+        await org.addRoleUser(otherUser);
+
+        repoNocks.push(
+          githubAPINocks.repo({
+            owner: site.owner,
+            repo: site.repository,
+            username: user.username,
+            response: [
+              403,
+              {
+                permissions: {},
+              },
+            ],
+          }),
+        );
+        repoNocks.push(
+          githubAPINocks.repo({
+            owner: site.owner,
+            repo: site.repository,
+            username: otherUser.username,
+          }),
+        );
+
+        const statusNock = githubAPINocks.status({
+          owner: site.owner,
+          repo: site.repository,
+          repository: site.repository,
+          sha: requestedCommitSha,
+          state: 'pending',
+        });
+        await build.reload({ include: Site });
+        await SourceCodePlatform.reportBuildStatus(build);
+        repoNocks.forEach((repoNock) => expect(repoNock.isDone()).to.be.true);
+        expect(statusNock.isDone()).to.be.true;
+      });
+
+      it(`should report that the status if the
+          build user does not have write permissions'`, async () => {
+        const repoNocks = [];
+        await user.update({
+          signedInAt: '1999-01-01',
+        });
+        const otherUser = await factory.user();
+        await org.addRoleUser(otherUser);
+
+        repoNocks.push(
+          githubAPINocks.repo({
+            owner: site.owner,
+            repo: site.repository,
+            username: user.username,
+            response: [
+              201,
+              {
+                permissions: {},
+              },
+            ],
+          }),
+        );
+        repoNocks.push(
+          githubAPINocks.repo({
+            owner: site.owner,
+            repo: site.repository,
+            username: otherUser.username,
+          }),
+        );
+
+        const statusNock = githubAPINocks.status({
+          owner: site.owner,
+          repo: site.repository,
+          repository: site.repository,
+          sha: requestedCommitSha,
+          state: 'pending',
+        });
+        await build.reload({ include: Site });
+        await SourceCodePlatform.reportBuildStatus(build);
+        repoNocks.forEach((repoNock) => expect(repoNock.isDone()).to.be.true);
+        expect(statusNock.isDone()).to.be.true;
+      });
+
+      it(`should not report the status
+          if the build user has invalid token'`, async () => {
+        const repoNocks = [];
+        const statusSpy = sinon.spy(GitHub, 'sendCreateGithubStatusRequest');
+        const recentUser = await factory.user();
+        await org.addRoleUser(recentUser);
+
+        repoNocks.push(
+          githubAPINocks.repo({
+            owner: site.owner,
+            repo: site.repository,
+            username: user.username,
+            response: [
+              403,
+              {
+                permissions: {},
+              },
+            ],
+          }),
+        );
+        repoNocks.push(
+          githubAPINocks.repo({
+            owner: site.owner,
+            repo: site.repository,
+            username: recentUser.username,
+            response: [
+              403,
+              {
+                permissions: {},
+              },
+            ],
+          }),
+        );
+
+        await build.reload({ include: Site });
+        const err = await SourceCodePlatform.reportBuildStatus(build).catch((e) => e);
+        repoNocks.forEach((repoNock) => expect(repoNock.isDone()).to.be.true);
+        expect(statusSpy.called).to.be.false;
+        expect(err.message).to.equal(
+          `Unable to find valid access token to report build@id=${build.id} status`,
+        );
+      });
+
+      it(`should not report the status if
+          the build user does not have write permissions'`, async () => {
+        const repoNocks = [];
+        const statusSpy = sinon.spy(GitHub, 'sendCreateGithubStatusRequest');
+        const recentUser = await factory.user();
+        await org.addRoleUser(recentUser);
+
+        repoNocks.push(
+          githubAPINocks.repo({
+            owner: site.owner,
+            repo: site.repository,
+            username: user.username,
+            response: [
+              201,
+              {
+                permissions: {},
+              },
+            ],
+          }),
+        );
+        repoNocks.push(
+          githubAPINocks.repo({
+            owner: site.owner,
+            repo: site.repository,
+            username: recentUser.username,
+            response: [
+              201,
+              {
+                permissions: {},
+              },
+            ],
+          }),
+        );
+
+        await build.reload({ include: Site });
+        const err = await SourceCodePlatform.reportBuildStatus(build).catch((e) => e);
+        repoNocks.forEach((repoNock) => expect(repoNock.isDone()).to.be.true);
+        expect(statusSpy.called).to.be.false;
+        expect(err.message).to.equal(
+          `Unable to find valid access token to report build@id=${build.id} status`,
+        );
+      });
+
+      it('should set the target uri to the build logs', async () => {
+        const repoNock = githubAPINocks.repo({
+          accessToken: user.githubAccessToken,
+          owner: site.owner,
+          repo: site.repository,
+          username: user.username,
+        });
+        const statusNock = githubAPINocks.status({
+          owner: site.owner,
+          repo: site.repository,
+          sha: requestedCommitSha,
+          targetURL: `${config.app.hostname}/sites/${build.site}/builds/${build.id}/logs`,
+        });
+        await build.reload({ include: Site });
+        await SourceCodePlatform.reportBuildStatus(build);
+        expect(repoNock.isDone()).to.be.true;
+        expect(statusNock.isDone()).to.be.true;
+      });
+    });
+
+    context('with a build in the created state', () => {
+      let user;
+      let site;
+      let build;
+
+      beforeEach(async () => {
+        site = await factory.site({
+          owner: 'test-owner',
+          repository: 'test-repo',
+        });
+        ({ user } = await createSiteUserOrg({ site }));
+        build = await factory.build({
+          state: 'created',
+          site,
+          requestedCommitSha,
+          user,
+        });
+      });
+
+      it("should report that the status is 'pending'", async () => {
+        const repoNock = githubAPINocks.repo({
+          accessToken: user.githubAccessToken,
+          owner: 'test-owner',
+          repo: 'test-repo',
+          username: user.username,
+        });
+        const statusNock = githubAPINocks.status({
+          owner: 'test-owner',
+          repo: 'test-repo',
+          repository: 'test-repo',
+          sha: requestedCommitSha,
+          state: 'pending',
+        });
+
+        await build.reload({ include: Site });
+        await SourceCodePlatform.reportBuildStatus(build);
+        expect(repoNock.isDone()).to.be.true;
+        expect(statusNock.isDone()).to.be.true;
+      });
+
+      it('should set the target uri to the build logs', async () => {
+        const repoNock = githubAPINocks.repo({
+          accessToken: 'fake-access-token',
+          owner: 'test-owner',
+          repo: 'test-repo',
+          username: user.username,
+        });
+        const statusNock = githubAPINocks.status({
+          owner: 'test-owner',
+          repo: 'test-repo',
+          sha: requestedCommitSha,
+          targetURL: `${config.app.hostname}/sites/${build.site}/builds/${build.id}/logs`,
+        });
+
+        await build.reload({ include: Site });
+        await SourceCodePlatform.reportBuildStatus(build);
+        expect(repoNock.isDone()).to.be.true;
+        expect(statusNock.isDone()).to.be.true;
+      });
+    });
+
+    context('with a build in the queued state', () => {
+      let user;
+      let site;
+      let build;
+
+      beforeEach(async () => {
+        site = await factory.site({
+          owner: 'test-owner',
+          repository: 'test-repo',
+        });
+        ({ user } = await createSiteUserOrg({ site }));
+
+        build = await factory.build({
+          state: 'created',
+          site,
+          requestedCommitSha,
+          user,
+        });
+      });
+      it("should report that the status is 'pending'", async () => {
+        const repoNock = githubAPINocks.repo({
+          accessToken: user.githubAccessToken,
+          owner: 'test-owner',
+          repo: 'test-repo',
+          username: user.username,
+        });
+        const statusNock = githubAPINocks.status({
+          owner: 'test-owner',
+          repo: 'test-repo',
+          repository: 'test-repo',
+          sha: requestedCommitSha,
+          state: 'pending',
+        });
+
+        await build.reload({ include: Site });
+        await SourceCodePlatform.reportBuildStatus(build);
+        expect(repoNock.isDone()).to.be.true;
+        expect(statusNock.isDone()).to.be.true;
+      });
+
+      it('should set the target uri to the build logs', async () => {
+        const repoNock = githubAPINocks.repo({
+          accessToken: 'fake-access-token',
+          owner: 'test-owner',
+          repo: 'test-repo',
+          username: user.username,
+        });
+        const statusNock = githubAPINocks.status({
+          owner: 'test-owner',
+          repo: 'test-repo',
+          sha: requestedCommitSha,
+          targetURL: `${config.app.hostname}/sites/${build.site}/builds/${build.id}/logs`,
+        });
+
+        await build.reload({ include: Site });
+        await SourceCodePlatform.reportBuildStatus(build);
+        expect(repoNock.isDone()).to.be.true;
+        expect(statusNock.isDone()).to.be.true;
+      });
+    });
+
+    context('with every build', () => {
+      const origAppEnv = config.app.appEnv;
+      let user;
+      let site;
+      let build;
+
+      after(() => {
+        // reset config.app.appEnv to its original value
+        config.app.appEnv = origAppEnv;
+      });
+
+      beforeEach(async () => {
+        site = await factory.site({
+          owner: 'test-owner',
+          repository: 'test-repo',
+        });
+        ({ user } = await createSiteUserOrg({ site }));
+        build = await factory.build({
+          state: 'success',
+          site,
+          requestedCommitSha,
+          clonedCommitSha,
+          user,
+        });
+      });
+
+      it(`should set status context to
+          "federalist/build" when APP_ENV is "production"`, async () => {
+        config.app.appEnv = 'production';
+        const repoNock = githubAPINocks.repo({
+          accessToken: 'fake-access-token',
+          owner: 'test-owner',
+          repo: 'test-repo',
+          username: user.username,
+        });
+        const statusNock = githubAPINocks.status({
+          owner: 'test-owner',
+          repo: 'test-repo',
+          sha: clonedCommitSha,
+          state: 'success',
+        });
+
+        await build.reload({ include: Site });
+        await SourceCodePlatform.reportBuildStatus(build);
+        expect(repoNock.isDone()).to.be.true;
+        expect(statusNock.isDone()).to.be.true;
+      });
+    });
+
+    context('with a build in the success state', () => {
+      let user;
+      let site;
+      let build;
+
+      beforeEach(async () => {
+        user = await factory.user();
+        ({ site, user } = await createSiteUserOrg());
+        build = await factory.build({
+          state: 'success',
+          requestedCommitSha,
+          clonedCommitSha,
+          user,
+          site,
+        });
+      });
+      it("should report that the status is 'success'", async () => {
+        const repoNock = githubAPINocks.repo({
+          accessToken: user.githubAccessToken,
+          owner: site.owner,
+          repo: site.repository,
+          username: user.username,
+        });
+        const statusNock = githubAPINocks.status({
+          owner: site.owner,
+          repo: site.repository,
+          sha: clonedCommitSha,
+          state: 'success',
+        });
+
+        await build.reload({ include: Site });
+        await SourceCodePlatform.reportBuildStatus(build);
+        expect(repoNock.isDone()).to.be.true;
+        expect(statusNock.isDone()).to.be.true;
+      });
+
+      it('should set the target uri to the preview link', async () => {
+        await build.update({
+          branch: 'preview-branch',
+        });
+
+        await build.reload();
+
+        // this depends on branch so we update twice
+        await build.update({
+          url: buildUrl(build, site),
+        });
+
+        const repoNock = githubAPINocks.repo({
+          accessToken: user.githubAccessToken,
+          owner: site.owner,
+          repo: site.repository,
+          username: user.username,
+        });
+        const statusNock = githubAPINocks.status({
+          owner: site.owner,
+          repo: site.repository,
+          sha: clonedCommitSha,
+          targetURL: buildUrl(build, site),
+        });
+
+        await build.reload({ include: Site });
+
+        await SourceCodePlatform.reportBuildStatus(build);
+        expect(repoNock.isDone()).to.be.true;
+        expect(statusNock.isDone()).to.be.true;
+      });
+    });
+
+    context('with a build in the error state', () => {
+      let user;
+      let site;
+      let build;
+
+      beforeEach(async () => {
+        ({ site, user } = await createSiteUserOrg());
+        build = await factory.build({
+          state: 'error',
+          requestedCommitSha,
+          user,
+          site,
+        });
+      });
+      it("should report that the status is 'error' with requestedCommitSha", async () => {
+        const repoNock = githubAPINocks.repo({
+          accessToken: user.githubAccessToken,
+          owner: site.owner,
+          repo: site.repository,
+          username: user.username,
+        });
+        const statusNock = githubAPINocks.status({
+          owner: site.owner,
+          repo: site.repository,
+          sha: requestedCommitSha,
+          state: 'error',
+        });
+
+        await build.reload({ include: Site });
+        await SourceCodePlatform.reportBuildStatus(build);
+        expect(statusNock.isDone()).to.be.true;
+        expect(repoNock.isDone()).to.be.true;
+      });
+
+      it("should report that the status is 'error' with clonedCommitSha", async () => {
+        await build.update({
+          clonedCommitSha,
+        });
+
+        const repoNock = githubAPINocks.repo({
+          accessToken: user.githubAccessToken,
+          owner: site.owner,
+          repo: site.repository,
+          username: user.username,
+        });
+        const statusNock = githubAPINocks.status({
+          owner: site.owner,
+          repo: site.repository,
+          sha: clonedCommitSha,
+          state: 'error',
+          targetURL: `${config.app.hostname}/sites/${build.site}/builds/${build.id}/logs`,
+        });
+
+        await build.reload({ include: Site });
+        await SourceCodePlatform.reportBuildStatus(build);
+        expect(statusNock.isDone()).to.be.true;
+        expect(repoNock.isDone()).to.be.true;
+      });
+
+      it(`should use the GitHub
+          access token of the build's user not a site user`, async () => {
+        const nonSiteUser = await factory.user();
+        await build.update({
+          user: nonSiteUser.id,
+        });
+
+        const repoNock = githubAPINocks.repo({
+          accessToken: nonSiteUser.githubAccessToken,
+          owner: site.owner,
+          repo: site.repository,
+          username: user.username,
+        });
+        const statusNock = githubAPINocks.status({
+          owner: site.owner,
+          repo: site.repository,
+          sha: requestedCommitSha,
+          state: 'error',
+          targetURL: `${config.app.hostname}/sites/${build.site}/builds/${build.id}/logs`,
+        });
+
+        await build.reload({ include: Site });
+        await SourceCodePlatform.reportBuildStatus(build);
+
+        expect(statusNock.isDone()).to.be.true;
+        expect(repoNock.isDone()).to.be.true;
+      });
+    });
+
+    context('with a build in the invalid state', () => {
+      let user;
+      let site;
+      let build;
+
+      beforeEach(async () => {
+        ({ site, user } = await createSiteUserOrg());
+        build = await factory.build({
+          state: 'invalid',
+          requestedCommitSha,
+          user,
+          site,
+        });
+      });
+      it("should report that the status is 'error' with requestedCommitSha", async () => {
+        const repoNock = githubAPINocks.repo({
+          accessToken: user.githubAccessToken,
+          owner: site.owner,
+          repo: site.repository,
+          username: user.username,
+        });
+        const statusNock = githubAPINocks.status({
+          owner: site.owner,
+          repo: site.repository,
+          sha: requestedCommitSha,
+          state: 'error',
+        });
+
+        await build.reload({ include: Site });
+        await SourceCodePlatform.reportBuildStatus(build);
+        expect(statusNock.isDone()).to.be.true;
+        expect(repoNock.isDone()).to.be.true;
+      });
+
+      it("should report that the status is 'error' with clonedCommitSha", async () => {
+        await build.update({
+          clonedCommitSha,
+        });
+
+        const repoNock = githubAPINocks.repo({
+          accessToken: user.githubAccessToken,
+          owner: site.owner,
+          repo: site.repository,
+          username: user.username,
+        });
+        const statusNock = githubAPINocks.status({
+          owner: site.owner,
+          repo: site.repository,
+          sha: clonedCommitSha,
+          state: 'error',
+          targetURL: `${config.app.hostname}/sites/${build.site}/builds/${build.id}/logs`,
+        });
+
+        await build.reload({ include: Site });
+        await SourceCodePlatform.reportBuildStatus(build);
+        expect(statusNock.isDone()).to.be.true;
+        expect(repoNock.isDone()).to.be.true;
+      });
+
+      it(`should use the GitHub
+          access token of the build's user not a site user`, async () => {
+        const nonSiteUser = await factory.user();
+        await build.update({
+          user: nonSiteUser.id,
+        });
+
+        const repoNock = githubAPINocks.repo({
+          accessToken: nonSiteUser.githubAccessToken,
+          owner: site.owner,
+          repo: site.repository,
+          username: user.username,
+        });
+        const statusNock = githubAPINocks.status({
+          owner: site.owner,
+          repo: site.repository,
+          sha: requestedCommitSha,
+          state: 'error',
+          targetURL: `${config.app.hostname}/sites/${build.site}/builds/${build.id}/logs`,
+        });
+
+        await build.reload({ include: Site });
+        await SourceCodePlatform.reportBuildStatus(build);
+
+        expect(statusNock.isDone()).to.be.true;
+        expect(repoNock.isDone()).to.be.true;
+      });
+    });
+  });
+});

--- a/test/api/unit/services/Webhooks.test.js
+++ b/test/api/unit/services/Webhooks.test.js
@@ -5,7 +5,8 @@ const sinon = require('sinon');
 const { Build, User, Event } = require('../../../../api/models');
 const QueueJobs = require('../../../../api/queue-jobs');
 const EventCreator = require('../../../../api/services/EventCreator');
-const GithubBuildHelper = require('../../../../api/services/GithubBuildHelper');
+// eslint-disable-next-line max-len
+const SourceCodePlatformHelper = require('../../../../api/services/SourceCodePlatformHelper');
 
 const factory = require('../../support/factory');
 const githubAPINocks = require('../../support/githubAPINocks');
@@ -182,7 +183,9 @@ describe('Webhooks Service', () => {
 
     it(`should find the site by the lowercased
         owner and repository and upper cased github user`, async () => {
-      const reporterSpy = sinon.stub(GithubBuildHelper, 'reportBuildStatus').resolves();
+      const reporterSpy = sinon
+        .stub(SourceCodePlatformHelper, 'reportBuildStatus')
+        .resolves();
       const { site, user } = await createSiteUserOrg();
 
       user.username = user.username.toUpperCase();


### PR DESCRIPTION
## Changes proposed in this pull request:
- Refactored GitLab integration to encapsulate details behind GitLabHelper
- Added SourceCodePlatformHelper to handle GitHub and GitLab platform-specific logic
- Added SOURCE_CODE_PLATFORM, SOURCE_CODE_PLATFORM_DOMAIN, and SOURCE_CODE_PLATFORM_TOKEN to site build message
- Updated default site engine selection from jekyll to node.js (https://github.com/cloud-gov/pages-core/issues/4758)
- Updated mock CF API to support site creation
- added endpoint to process GitLab webhook posts
- new env variable: GITLAB_WEBHOOK_SECRET
