### PR TITLE
Release 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.22.0 (2026-04-16)
+
+### Added
+
+- normalization on the file extension when uploading a public file 4859
+- create workshop project from template 4874
+- create workshop site build flow - build container env 4866
+
+### Fixed
+
+- getOwnerAndRepo to return workshop site designation when feature flag is on and off
+- Public File details modal buttons
+- **ci**: Ouptut config for e2e tests
+- Button colors and contrast on the public file storage views
+- **ci**: ClamAV REST image source
+
 ## 0.21.0 (2026-04-01)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pages-core",
   "private": true,
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "",
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
## :robot: This is an automated release PR
chore: release 0.22.0
tag to create: 0.22.0
increment detected: MINOR

## 0.22.0 (2026-04-16)

### Added

- normalization on the file extension when uploading a public file 4859
- create workshop project from template 4874
- create workshop site build flow - build container env 4866

### Fixed

- getOwnerAndRepo to return workshop site designation when feature flag is on and off
- Public File details modal buttons
- **ci**: Ouptut config for e2e tests
- Button colors and contrast on the public file storage views
- **ci**: ClamAV REST image source
## security considerations
Noted in individual PRs
