### PR TITLE
feat: normalization on the file extension when uploading a public fil…

### DIFF
--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -335,7 +335,7 @@ function slugify(text, len = 200) {
     // eslint-disable-next-line sonarjs/slow-regex
     .replace(/-+$/, ''); // Trim hyphens from the end
 
-  return extension ? `${slugifiedBase}.${extension}` : slugifiedBase;
+  return extension ? `${slugifiedBase}.${extension?.toLowerCase()}` : slugifiedBase;
 }
 
 function normalizeDirectoryPath(dir) {

--- a/test/api/unit/utils/utils.test.js
+++ b/test/api/unit/utils/utils.test.js
@@ -416,6 +416,14 @@ describe('utils', () => {
       expect(result).to.be.eq(expected);
     });
 
+    it('should convert file name and extension to low case', () => {
+      const input = 'TEST.PDF';
+      const expected = 'test.pdf';
+
+      const result = utils.slugify(input);
+      expect(result).to.be.eq(expected);
+    });
+
     it('should slugify a number', () => {
       const input = 25624;
       const expected = '25624';


### PR DESCRIPTION
…e 4859

## Changes proposed in this pull request:
- file extension converted to lower case.


From slack message:
... found a little Pages File Storage bug, while the slugifying of the filename itself seems to be working as expected, the normalization is not being applied to the file extension itself, so we are winding up with files like /~assets/cases/osc-di-14-3637south-tx-vhcs.PDF but we're referencing them as /~assets/cases/osc-di-14-3637south-tx-vhcs.pdf and they are 404ing. 