### PR TITLE
Release 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 0.23.0 (2026-05-04)
+
+### Added
+
+- clean build params 4893
+- delete workshop pages site 4887
+
+### Fixed
+
+- remove unecessary AGR in dockerfile
+- remove unecessary steps since this Dockerfile-uaa only runs locally
+- Add zscaler workaround steps for local development (https://github.com/cloud-gov/pages-editor/pull/95)
+
+### Maintenance
+
+- Add webhook rotation script
+
 ## 0.22.0 (2026-04-16)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pages-core",
   "private": true,
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "",
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
## :robot: This is an automated release PR
chore: release 0.23.0
tag to create: 0.23.0
increment detected: MINOR

## 0.23.0 (2026-05-04)

### Added

- clean build params 4893
- delete workshop pages site 4887

### Fixed

- remove unecessary AGR in dockerfile
- remove unecessary steps since this Dockerfile-uaa only runs locally
- Add zscaler workaround steps for local development (https://github.com/cloud-gov/pages-editor/pull/95)

### Maintenance

- Add webhook rotation script
## security considerations
Noted in individual PRs
