### PR TITLE
Release 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+## 0.24.0 (2026-06-08)
+
+### Added
+
+- Call editor webhook when a editor build is running
+- add editor site id field
+- Update pages Admin project repository links for Workshop GitLab sites 4877
+- Site defaults to large container with new 10GB disk space
+- Increase file size limit on the public file storage 4885 - add audit event
+- Increase file size limit on the public file storage 4885
+
+### Fixed
+
+- fix linting
+- fix lint
+- add log
+- fix date check
+
+### Maintenance
+
+- **admin**: Vendor page router to allow for dependency updates
+- Upgrade admin client to svelte v5
+- **ci**: Update .prettierignore to ignore package-lock.json
+- add tests
+- remove empty space
+- add logs
+- stringify json
+- stringify json
+- stringify json
+- remove console logs
+- Update Pages ci pipelines to use the same creds value for Github. #2839
+- Remove underscore dependency from pages-core #2946
+- Update core to use NPM install with improved security config 2949
+- Remove archived gatsby template from site choices
+- Update core to use NPM install with improved security config 2949
+- Update core to use NPM install with improved security config 2949
+- Update core to use NPM install with improved security config 2949
+
 ## 0.23.1 (2026-05-14)
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pages-core",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pages-core",
-      "version": "0.23.1",
+      "version": "0.24.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1011.0",
@@ -2548,7 +2548,7 @@
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
       "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-      "deprecated": "🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.",
+      "deprecated": "\ud83d\udea8 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18360,7 +18360,7 @@
         "prop-types": "^15.5.6"
       },
       "peerDependencies": {
-        "react": "0.14.x || ^15.0.0 || ^16.0.0",
+        "react": "0.14.x || ^15.0.0 ||\u00a0^16.0.0",
         "react-dom": "0.14.x || ^15.0.0 || ^16.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pages-core",
   "private": true,
-  "version": "0.23.1",
+  "version": "0.24.0",
   "description": "",
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
## :robot: This is an automated release PR
chore: release 0.24.0
tag to create: 0.24.0
increment detected: MINOR

## 0.24.0 (2026-06-08)

### Added

- Call editor webhook when a editor build is running
- add editor site id field
- Update pages Admin project repository links for Workshop GitLab sites 4877
- Site defaults to large container with new 10GB disk space
- Increase file size limit on the public file storage 4885 - add audit event
- Increase file size limit on the public file storage 4885

### Fixed

- fix linting
- fix lint
- add log
- fix date check

### Maintenance

- **admin**: Vendor page router to allow for dependency updates
- Upgrade admin client to svelte v5
- **ci**: Update .prettierignore to ignore package-lock.json
- add tests
- remove empty space
- add logs
- stringify json
- stringify json
- stringify json
- remove console logs
- Update Pages ci pipelines to use the same creds value for Github. #2839
- Remove underscore dependency from pages-core #2946
- Update core to use NPM install with improved security config 2949
- Remove archived gatsby template from site choices
- Update core to use NPM install with improved security config 2949
- Update core to use NPM install with improved security config 2949
- Update core to use NPM install with improved security config 2949
## security considerations
Noted in individual PRs
