### PR TITLE
chore: Remove archived gatsby template from site choices

### DIFF
--- a/config/templates.js
+++ b/config/templates.js
@@ -12,19 +12,6 @@ module.exports = {
     thumb: '/images/pages-uswds-v3-11ty-thumbnail.png',
     templateSourceCodeUrl: 'https://github.com/cloud-gov/pages-uswds-11ty',
   },
-  'uswds-gatsby': {
-    owner: 'cloud-gov',
-    repo: 'pages-uswds-gatsby',
-    branch: 'main',
-    engine: 'node.js',
-    example: 'https://uswds-gatsby.pages.cloud.gov',
-    title: 'Gatsby - U.S. Web Design System v2.0',
-    description:
-      // eslint-disable-next-line max-len
-      'A flexible multi-page setup intended to introduce an agency or program using Gatsby.js. It offers an engaging Hero section for a current priority and a landing page layout designed to provide clarity and context for first time visitors. This template also offers navigation options for internal pages.',
-    thumb: '/images/pages-uswds-v2-gatsby-thumbnail.png',
-    templateSourceCodeUrl: 'https://github.com/cloud-gov/pages-uswds-gatsby',
-  },
   'workshop-uswds-11ty': {
     owner: 'n/a',
     repo: 'n/a',

--- a/test/api/requests/site.test.js
+++ b/test/api/requests/site.test.js
@@ -535,7 +535,7 @@ describe('Site API', () => {
             .send({
               defaultBranch: 'main',
               engine: 'node.js',
-              template: 'uswds-gatsby',
+              template: 'uswds-11ty',
             })
             .set('Cookie', cookie)
             .expect(403),

--- a/test/api/unit/services/SiteCreator.test.js
+++ b/test/api/unit/services/SiteCreator.test.js
@@ -518,7 +518,7 @@ describe('SiteCreator', () => {
           SiteCreator.getProcessedSiteParams(
             { owner: ' owner ', repository: ' repository ' },
             {
-              templateSourceCodeUrl: 'https://github.com/cloud-gov/pages-uswds-gatsby',
+              templateSourceCodeUrl: 'https://github.com/cloud-gov/pages-uswds-11ty',
               branch: 'main',
               engine: 'engine',
             },
@@ -537,7 +537,7 @@ describe('SiteCreator', () => {
           SiteCreator.getProcessedSiteParams(
             { owner: ' /cloud-gov/ ', repository: ' /repository/ ' },
             {
-              templateSourceCodeUrl: 'https://github.com/cloud-gov/pages-uswds-gatsby',
+              templateSourceCodeUrl: 'https://github.com/cloud-gov/pages-uswds-11ty',
               branch: 'main',
               engine: 'engine',
             },


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove Gatsby template from site options since the source code template is archived

