### PR TITLE
Update Pages ci pipelines to use the same creds value for Github. #2839

### DIFF
--- a/ci/partials/code-coverage-diff.yml
+++ b/ci/partials/code-coverage-diff.yml
@@ -9,7 +9,7 @@ params:
   GH_BOT_GPG_KEY: ((pages-operations-github-user-gpg.private_key))
   GH_BOT_SSH_KEY: ((pages-gpg-operations-github-sshkey.private_key))
   GH_BOT_GPG_TRUST: ((pages-operations-github-user-gpg-trust))
-  GH_TOKEN: ((pages-operations-ci-github-token))
+  GH_TOKEN: ((gh-access-token))
 run:
   dir: src
   path: ci/tasks/code-coverage-diff.sh

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -573,7 +573,7 @@ resources:
     check_every: 1m
     source:
       repository: ((pages-repository-path))
-      access_token: ((pages-operations-ci-github-token))
+      access_token: ((gh-access-token))
       base_branch: main
       disable_forks: true
       ignore_drafts: false
@@ -653,7 +653,7 @@ resources:
     source:
       owner: cloud-gov
       repository: pages-core
-      access_token: ((pages-operations-ci-github-token))
+      access_token: ((gh-access-token))
   #@ end
 
   - name: redis

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -263,7 +263,7 @@ Some credentials in this pipeline are "compound" credentials that use the pipeli
 |**`((support-email))`**| Our support email address | :x:|
 |**`((git-base-url))`**|The base url to the git server's HTTP endpoint|:x:|
 |**`((pages-repository-path))`**|The url path to the repository|:x:|
-|**`((pages-operations-ci-github-token))`**| The Github access token|:x:|
+|**`((gh-access-token))`**| The Github access token|:x:|
 
 ##### Setting up the pipeline for Core
 The pipeline and each of it's instances will only needed to be set once per instance to create the initial pipeline. After the pipelines are set, updates to the default branch will automatically set the pipeline. See the [`set_pipeline` step](https://concourse-ci.org/set-pipeline-step.html) for more information. First, a compiled pipeline file needs to be created with [`ytt`](https://carvel.dev/ytt/):


### PR DESCRIPTION
## Changes proposed in this pull request:
- related to https://github.com/cloud-gov/private/issues/2839

