### PR TITLE
feat: Don't allow folder names to have ../ in the public file storage…

### DIFF
--- a/api/controllers/file-storage-service.js
+++ b/api/controllers/file-storage-service.js
@@ -1,4 +1,4 @@
-const { isEmpty } = require('../utils');
+const { isEmpty, validateInputPath } = require('../utils');
 const EventCreator = require('../services/EventCreator');
 const {
   canCreateSiteStorage,
@@ -41,6 +41,9 @@ module.exports = wrapHandlers({
       params,
       user,
     } = req;
+
+    validateInputPath(parent);
+    validateInputPath(name);
 
     const fssId = parseInt(params.file_storage_id, 10);
     const { fileStorageService } = await isFileStorageUser(user.id, fssId);
@@ -151,6 +154,9 @@ module.exports = wrapHandlers({
       const err = new Error('No file name or parent directory defined.');
       return badRequest(err, { res });
     }
+
+    validateInputPath(parent);
+    validateInputPath(name);
 
     const { buffer: fileBuffer, originalname, encoding, mimetype, size } = file;
 

--- a/api/responses/siteErrors.js
+++ b/api/responses/siteErrors.js
@@ -26,6 +26,7 @@ module.exports = {
   SITE_FILE_STORAGE_DOES_NOT_EXIST: 'The specified site file storage does not exist.',
   DIRECTORY_MUST_BE_EMPTIED:
     'This directory cannot be deleted. Please delete file contents first.',
+  PATH_TRAVERSAL_DETECTED: 'Path traversal detected.',
   DIRECTORY_EXISTS_ALREADY:
     'A directory with the same name already exists. Please rename your new directory.',
   FILE_EXISTS_ALREADY:

--- a/api/services/file-storage/index.js
+++ b/api/services/file-storage/index.js
@@ -7,7 +7,12 @@ const {
 } = require('../../models');
 const S3Helper = require('../S3Helper');
 const CloudFoundryAPIClient = require('../../utils/cfApiClient');
-const { normalizeDirectoryPath, paginate, slugify } = require('../../utils');
+const {
+  normalizeDirectoryPath,
+  paginate,
+  slugify,
+  validatePath,
+} = require('../../utils');
 const {
   serializeFileStorageFile,
   serializeFileStorageFiles,
@@ -315,6 +320,8 @@ class SiteFileStorageSerivce {
 
   #buildKeyPath(keyPath) {
     const normalized = normalizeDirectoryPath(keyPath);
+    validatePath(this.S3_BASE_PATH, normalized);
+
     const root = normalized.split('/').filter((x) => x)[0];
 
     if (`${root}/` !== this.S3_BASE_PATH) {

--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -5,6 +5,7 @@ const moment = require('moment');
 
 const config = require('../../config');
 const { logger } = require('../../winston');
+const siteErrors = require('../responses/siteErrors');
 
 /**
  * @param {string[]} values The enum values
@@ -339,8 +340,20 @@ function slugify(text, len = 200) {
   return extension ? `${slugifiedBase}.${extension?.toLowerCase()}` : slugifiedBase;
 }
 
+function throwPathTraversalError() {
+  const error = new Error(siteErrors.PATH_TRAVERSAL_DETECTED);
+  error.status = 400;
+  throw error;
+}
+
 function normalizeDirectoryPath(dir) {
-  let normalized = path.normalize(dir);
+  const sanitized = sanitizePathInput(dir);
+  let normalized = path.normalize(sanitized);
+
+  // Verify no traversal after normalization
+  if (normalized.includes('..')) {
+    throwPathTraversalError();
+  }
 
   if (normalized.startsWith('/') && normalized.endsWith('/')) {
     normalized = normalized.slice(1);
@@ -351,6 +364,36 @@ function normalizeDirectoryPath(dir) {
   }
 
   return normalized;
+}
+
+function validateInputPath(inputPath) {
+  const decoded = decodeURIComponent(inputPath);
+  if (decoded.includes('..') || decoded.includes('\0')) {
+    throwPathTraversalError();
+  }
+}
+
+function sanitizePathInput(inputPath) {
+  if (!inputPath) {
+    return inputPath;
+  }
+
+  // Decode and check for traversal sequences
+  validateInputPath(inputPath);
+
+  // Remove dangerous characters
+  // eslint-disable-next-line no-control-regex
+  return inputPath.replace(/[<>:"|?*\x00-\x1f]/g, '');
+}
+
+function validatePath(basePath, keyPath) {
+  const fullPath = path.join(basePath, keyPath);
+  const resolved = path.resolve('/', fullPath);
+  const baseResolved = path.resolve('/', basePath);
+
+  if (!resolved.startsWith(baseResolved)) {
+    throwPathTraversalError();
+  }
 }
 
 const omitByPredicate = (obj, predicate) =>
@@ -412,6 +455,9 @@ module.exports = {
   loadProductionManifest,
   mapValues,
   normalizeDirectoryPath,
+  sanitizePathInput,
+  validatePath,
+  validateInputPath,
   omitBy,
   omit,
   paginate,

--- a/test/api/requests/file-storage-service.test.js
+++ b/test/api/requests/file-storage-service.test.js
@@ -248,7 +248,7 @@ describe('File Storgage API', () => {
         validateAgainstJSONSchema('GET', endpoint, 404, body);
       });
 
-      it('returns a 404 when file exists in differnt file service', async () => {
+      it('returns a 404 when file exists in different file service', async () => {
         const { site, org, user } = await stubSiteS3();
         const fss = await factory.fileStorageService.create({
           siteId: site.id,
@@ -874,6 +874,52 @@ describe('File Storgage API', () => {
         validateAgainstJSONSchema('POST', endpoint, 400, body);
       });
     });
+
+    describe('when a user creates a directory with path traversal', () => {
+      async function tester(parent, name) {
+        const { site, org, user } = await stubSiteS3({
+          roleName: 'manager',
+        });
+        const fss = await factory.fileStorageService.create({
+          siteId: site.id,
+          serviceName: site.s3ServiceName,
+          org,
+        });
+
+        const cookie = await authenticatedSession(user);
+        const payload = { parent: parent, name: name };
+
+        const { body } = await request(app)
+          .post(`/v0/file-storage/${fss.id}/directory`)
+          .set('Cookie', cookie)
+          .set('x-csrf-token', csrfToken.getToken())
+          .type('json')
+          .send(payload)
+          .expect(400);
+
+        validateAgainstJSONSchema('POST', endpoint, 400, body);
+      }
+
+      const parentsNames = [
+        ['../../../etc/passwd', 'name'],
+        ['~assets/../../../etc/passwd', 'name'],
+        ['~assets/legit/../../etc/passwd', 'name'],
+        ['%2E%2E%2F%2E%2E%2Ftest', 'name'],
+        ['../../../', 'name'],
+        ['parent', '../../../etc/passwd'],
+        ['parent', '~assets/../../../etc/passwd'],
+        ['parent', '~assets/legit/../../etc/passwd'],
+        ['parent', '%2E%2E%2F%2E%2E%2Ftest'],
+        ['parent', '../../../'],
+      ];
+
+      parentsNames.forEach((parentName) => {
+        // eslint-disable-next-line max-len
+        it(`returns a 400 for parent: '${parentName[0]}' and name: '${parentName[1]}'`, async () => {
+          await tester(parentName[0], parentName[1]);
+        });
+      });
+    });
   });
 
   describe('POST /v0/file-storage/:file_storage_id/upload', () => {
@@ -980,6 +1026,45 @@ describe('File Storgage API', () => {
           .expect(400);
 
         validateAgainstJSONSchema('POST', endpoint, 400, body);
+      });
+    });
+
+    describe('when a user uploads a file with path traversal in parent field', () => {
+      async function tester(parent) {
+        const { site, org, user } = await stubSiteS3({
+          roleName: 'manager',
+        });
+        const fss = await factory.fileStorageService.create({
+          siteId: site.id,
+          serviceName: site.s3ServiceName,
+          org,
+        });
+        const cookie = await authenticatedSession(user);
+        const name = 'test.txt';
+
+        const { body } = await request(app)
+          .post(`/v0/file-storage/${fss.id}/upload`)
+          .set('Cookie', cookie)
+          .set('x-csrf-token', csrfToken.getToken())
+          .field('name', name)
+          .field('parent', parent)
+          .attach('file', path.join(__dirname, '../support/fixtures/lorem.txt'))
+          .expect(400);
+
+        validateAgainstJSONSchema('POST', endpoint, 400, body);
+      }
+
+      const parents = [
+        '../../../etc/passwd',
+        '~assets/../../../etc/passwd',
+        '~assets/legit/../../etc/passwd',
+        '%2E%2E%2F%2E%2E%2Ftest',
+      ];
+
+      parents.forEach((path) => {
+        it(`returns a 400 for ${path}`, async () => {
+          await tester(path);
+        });
       });
     });
 

--- a/test/api/unit/services/FileStorage.test.js
+++ b/test/api/unit/services/FileStorage.test.js
@@ -774,4 +774,26 @@ describe('FileStorage services', () => {
       expect(error.status).to.be.eq(400);
     });
   });
+
+  describe('buildKeyPath', async () => {
+    const testCases = [
+      '../../../etc/passwd',
+      '%2e%2e/secret',
+      '/uploads/%2e%2e%2fsecret',
+      '../../../etc/passwd',
+      '~assets/../../../etc/passwd',
+      '~assets/legit/../../etc/passwd',
+    ];
+
+    testCases.forEach((testCase) => {
+      it(`throws "Path traversal detected" for input: ${testCase}`, async () => {
+        const { fss, user } = await stubFileStorageClient();
+        const siteStorageService = new SiteFileStorageSerivce(fss, user.id);
+
+        await expect(siteStorageService.listDirectoryFiles(testCase)).to.be.rejectedWith(
+          'Path traversal detected',
+        );
+      });
+    });
+  });
 });

--- a/test/api/unit/utils/utils.test.js
+++ b/test/api/unit/utils/utils.test.js
@@ -8,6 +8,7 @@ const fsMock = require('mock-fs');
 const proxyquire = require('proxyquire').noCallThru();
 
 const config = require('../../../../config');
+const { sanitizePathInput, validatePath } = require('../../../../api/utils');
 
 const publicPath = '/publicPath/';
 const filename = 'bundle';
@@ -506,6 +507,123 @@ describe('utils', () => {
       const result = utils.normalizeDirectoryPath(dir);
 
       expect(result).to.be.eq(expected);
+    });
+  });
+
+  describe('sanitizePathInput', () => {
+    describe('path traversal detection', () => {
+      it('throws on plain ".." traversal', () => {
+        expect(() => sanitizePathInput('../etc/passwd')).to.throw(
+          'Path traversal detected',
+        );
+      });
+
+      it('throws on nested ".." traversal', () => {
+        expect(() => sanitizePathInput('/uploads/../../etc/passwd')).to.throw(
+          'Path traversal detected',
+        );
+      });
+
+      it('throws on URI-encoded ".." (%2e%2e)', () => {
+        expect(() => sanitizePathInput('%2e%2e/etc/passwd')).to.throw(
+          'Path traversal detected',
+        );
+      });
+
+      it('throws on mixed-encoding traversal (%2e%2e/)', () => {
+        expect(() => sanitizePathInput('/uploads/%2e%2e/secret')).to.throw(
+          'Path traversal detected',
+        );
+      });
+
+      it('throws on null byte injection', () => {
+        expect(() => sanitizePathInput('/uploads/image.png\0.jpg')).to.throw(
+          'Path traversal detected',
+        );
+      });
+
+      it('throws on URI-encoded null byte (%00)', () => {
+        expect(() => sanitizePathInput('/uploads/image.png%00.jpg')).to.throw(
+          'Path traversal detected',
+        );
+      });
+
+      it('throws if decodeURIComponent reveals ".." only after decoding', () => {
+        // %2e%2e decodes to ".." — not visible before decoding
+        const input = '/uploads/%2e%2e%2fsecret';
+        expect(() => sanitizePathInput(input)).to.throw('Path traversal detected');
+      });
+    });
+
+    describe('malformed URI handling', () => {
+      it('throws (or handles gracefully) on invalid percent-encoding', () => {
+        // decodeURIComponent throws URIError on malformed sequences like '%'
+        expect(() => sanitizePathInput('/uploads/%')).to.throw();
+      });
+    });
+
+    describe('dangerous character stripping', () => {
+      it('removes angle brackets', () => {
+        expect(sanitizePathInput('/uploads/<script>.png')).to.equal(
+          '/uploads/script.png',
+        );
+      });
+
+      it('removes colons', () => {
+        expect(sanitizePathInput('C:/uploads/image.png')).to.equal('C/uploads/image.png');
+      });
+
+      it('removes double quotes', () => {
+        expect(sanitizePathInput('/uploads/"image".png')).to.equal('/uploads/image.png');
+      });
+
+      it('removes pipe characters', () => {
+        expect(sanitizePathInput('/uploads/image|rm -rf.png')).to.equal(
+          '/uploads/imagerm -rf.png',
+        );
+      });
+
+      it('removes question marks', () => {
+        expect(sanitizePathInput('/uploads/image.png?query=1')).to.equal(
+          '/uploads/image.pngquery=1',
+        );
+      });
+
+      it('removes asterisks', () => {
+        expect(sanitizePathInput('/uploads/*.png')).to.equal('/uploads/.png');
+      });
+
+      it('removes control characters (0x00-0x1f)', () => {
+        const input = '/uploads/image\x01\x02.png';
+        expect(sanitizePathInput(input)).to.equal('/uploads/image.png');
+      });
+
+      it('removes multiple dangerous characters at once', () => {
+        const input = '/uploads/<foo>:"bar"|*?.png';
+        expect(sanitizePathInput(input)).to.equal('/uploads/foobar.png');
+      });
+    });
+
+    describe('valid input passthrough', () => {
+      it('returns a normal path unchanged', () => {
+        expect(sanitizePathInput('/uploads/image.png')).to.equal('/uploads/image.png');
+      });
+
+      it('returns a relative-but-safe filename unchanged', () => {
+        expect(sanitizePathInput('photo123.jpg')).to.equal('photo123.jpg');
+      });
+    });
+  });
+
+  describe('validatePath', () => {
+    it('resolves successfully when keyPath is within basePath', () => {
+      validatePath('/uploads', 'image');
+    });
+
+    it('throws when keyPath attempts to traverse outside basePath', async () => {
+      expect(() => validatePath('/uploads', '../../../etc/passwd')).to.throw(
+        'Path traversal detected',
+      );
     });
   });
 


### PR DESCRIPTION
… #2906

## Changes proposed in this pull request:
- Throw an error when a user attempts to name a folder with a ../ ie ../../etc/
- Escapes the folder name to not allow other possible nefarious naming conventions


